### PR TITLE
feat: add GitHub issue templates (closes #7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/auto_build_task.yml
+++ b/.github/ISSUE_TEMPLATE/auto_build_task.yml
@@ -1,0 +1,39 @@
+name: 🏗️ Auto-Build Task
+description: Task for the automated sailing-yachts-builder cron
+labels: ["auto-build"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Task Description
+      description: What needs to be implemented.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - critical
+        - high
+        - medium
+        - low
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this task to be considered complete.
+      placeholder: |
+        - [ ] Feature works as described
+        - [ ] Tests pass
+        - [ ] Build succeeds
+        - [ ] Deployed to production
+      render: markdown
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation Notes
+      description: Any technical notes or pointers for the implementer.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is.
+      placeholder: "When I visit /yachts, the page loads slowly and shows..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Go to '/yachts'
+        2. Click on 'Beneteau Oceanis 30.1'
+        3. See error
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the issue.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, device, OS info
+      placeholder: |
+        - Browser: Chrome 120
+        - Device: Desktop
+        - URL: https://sailing-yachts.vercel.app/yachts
+      render: markdown
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://github.com/pgedeon/sailing-yachts#readme
+    about: Check the README and ROADMAP for project details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: "I'm frustrated when I can't compare more than 2 yachts..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature?
+      options:
+        - Low — Nice to have
+        - Medium — Would improve experience
+        - High — Significant impact
+        - Critical — Blocking current work
+      default: 1
+    validations:
+      required: true
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Roadmap Phase
+      description: Which phase does this belong to? (see ROADMAP.md)
+      options:
+        - Phase 0 — Fix Build & CI
+        - Phase 1 — Data & Content
+        - Phase 2 — Core Features
+        - Phase 3 — User Features
+        - Phase 4 — sailboats.fr Integration
+        - Phase 5 — Advanced Features
+      default: 2
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references.


### PR DESCRIPTION
## Changes

Adds GitHub issue templates for structured issue creation:

### Templates
- **🐛 Bug Report** — Steps to reproduce, expected behavior, environment
- **✨ Feature Request** — Problem/motivation, proposed solution, priority, roadmap phase
- **🏗️ Auto-Build Task** — For cron-driven development with acceptance criteria

### Config
- Blank issues disabled (encourages structured submissions)
- Link to README documentation

Completes the last unchecked Phase 0 item in ROADMAP.md.

Closes #7