### PR TITLE
feat: saved comparisons with localStorage and shareable URLs

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import Link from "next/link";
+import {
+  getSavedComparisons,
+  saveComparison,
+  deleteComparison,
+  getShareUrl,
+  type SavedComparison,
+} from "@/lib/savedComparisons";
 
 interface Yacht {
   id: number;
@@ -119,6 +126,63 @@ export function CompareClient({ initialIds }: CompareClientProps) {
   const [search, setSearch] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Saved comparisons state
+  const [savedList, setSavedList] = useState<SavedComparison[]>([]);
+  const [saveName, setSaveName] = useState('');
+  const [showSaveInput, setShowSaveInput] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [savedPanelOpen, setSavedPanelOpen] = useState(false);
+
+  // Load saved comparisons from localStorage on mount
+  useEffect(() => {
+    setSavedList(getSavedComparisons());
+  }, []);
+
+  const refreshSavedList = useCallback(() => {
+    setSavedList(getSavedComparisons());
+  }, []);
+
+  const handleSave = () => {
+    if (!saveName.trim() || selectedIds.length < 2) return;
+    const result = saveComparison(saveName, selectedIds);
+    if (result) {
+      setSaveName('');
+      setShowSaveInput(false);
+      refreshSavedList();
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    deleteComparison(id);
+    refreshSavedList();
+  };
+
+  const handleLoadComparison = (ids: number[]) => {
+    setSelectedIds(ids.slice(0, MAX_COMPARE));
+    lastFetchKey.current = '';
+    updateUrl(ids.slice(0, MAX_COMPARE));
+    setSavedPanelOpen(false);
+  };
+
+  const handleCopyLink = async () => {
+    const url = getShareUrl(selectedIds);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback
+      const input = document.createElement('input');
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   // Fetch all yachts for the picker
   useEffect(() => {
@@ -245,7 +309,6 @@ export function CompareClient({ initialIds }: CompareClientProps) {
   // Collect extra spec rows from specsByGroup, deduped across all yachts
   const extraSpecRows = useMemo(() => {
     const allSpecs: Record<string, Record<string, { name: string; value: string; unit: string | null }>> = {};
-    // Collect unique (group, name) pairs
     const keys = new Set<string>();
     for (const y of yachts) {
       for (const [group, entries] of Object.entries(y.specsByGroup || {})) {
@@ -255,7 +318,6 @@ export function CompareClient({ initialIds }: CompareClientProps) {
         }
       }
     }
-    // Build rows: group -> name -> { name, value (per yacht), unit }
     const rows: { group: string; name: string; unit: string | null; values: (string | null)[] }[] = [];
     const sortedKeys = [...keys].sort();
     for (const k of sortedKeys) {
@@ -272,7 +334,6 @@ export function CompareClient({ initialIds }: CompareClientProps) {
       });
       rows.push({ group, name, unit, values });
     }
-    // Group by spec group
     const grouped: Record<string, typeof rows> = {};
     for (const r of rows) {
       if (!grouped[r.group]) grouped[r.group] = [];
@@ -281,12 +342,10 @@ export function CompareClient({ initialIds }: CompareClientProps) {
     return grouped;
   }, [yachts]);
 
-  // Merge built-in groups with extra spec groups (skip duplicates with built-in fields)
   const builtInFieldKeys = new Set(ALL_COMPARE_FIELDS.map(f => f.label.toLowerCase()));
   const displayGroups = useMemo(() => {
     const result: { group: string; type: 'builtin' | 'extra' }[] = SPEC_GROUPS.map(g => ({ group: g.group, type: 'builtin' as const }));
     for (const group of Object.keys(extraSpecRows)) {
-      // Only add extra groups not already covered
       const hasUndupedSpecs = extraSpecRows[group]?.some(r => !builtInFieldKeys.has(r.name.toLowerCase()));
       if (hasUndupedSpecs) {
         if (!result.find(r => r.group === group)) {
@@ -302,10 +361,154 @@ export function CompareClient({ initialIds }: CompareClientProps) {
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Compare Yachts</h1>
-        <p className="mt-1 text-gray-500">Select up to {MAX_COMPARE} yachts to compare side by side</p>
+      <div className="mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Compare Yachts</h1>
+          <p className="mt-1 text-gray-500">Select up to {MAX_COMPARE} yachts to compare side by side</p>
+        </div>
+        {/* Share + Save actions */}
+        {selectedIds.length >= 2 && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              onClick={handleCopyLink}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors"
+              title="Copy share link"
+            >
+              {copied ? (
+                <>
+                  <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span className="text-green-600">Copied!</span>
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                  </svg>
+                  <span>Share</span>
+                </>
+              )}
+            </button>
+            <button
+              onClick={() => { setShowSaveInput(!showSaveInput); setSaveName(''); }}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors"
+            >
+              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+              <span>Save</span>
+            </button>
+            <button
+              onClick={() => setSavedPanelOpen(!savedPanelOpen)}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors relative"
+            >
+              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+              <span>Saved</span>
+              {savedList.length > 0 && (
+                <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-blue-100 text-blue-700 font-semibold">
+                  {savedList.length}
+                </span>
+              )}
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* Save comparison input */}
+      {showSaveInput && selectedIds.length >= 2 && (
+        <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+          <label className="block text-sm font-medium text-gray-700 mb-2">Name this comparison</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={saveName}
+              onChange={e => setSaveName(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSave()}
+              placeholder="e.g. Family cruisers under 40ft"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
+              maxLength={80}
+              autoFocus
+            />
+            <button
+              onClick={handleSave}
+              disabled={!saveName.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => { setShowSaveInput(false); setSaveName(''); }}
+              className="px-3 py-2 text-gray-500 hover:text-gray-700 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Saved comparisons panel */}
+      {savedPanelOpen && (
+        <div className="mb-6 bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          <div className="px-4 py-3 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-gray-700">Saved Comparisons</h3>
+            <button
+              onClick={() => setSavedPanelOpen(false)}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          {savedList.length === 0 ? (
+            <div className="px-4 py-6 text-center text-gray-400 text-sm">
+              No saved comparisons yet. Select 2+ yachts and click Save.
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-100 max-h-64 overflow-y-auto">
+              {savedList.map(sc => (
+                <li key={sc.id} className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors group">
+                  <button
+                    onClick={() => handleLoadComparison(sc.yachtIds)}
+                    className="flex-1 text-left min-w-0"
+                  >
+                    <div className="text-sm font-medium text-gray-800 truncate">{sc.name}</div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      {sc.yachtIds.length} yachts · {new Date(sc.createdAt).toLocaleDateString()}
+                    </div>
+                  </button>
+                  <button
+                    onClick={() => {
+                      const url = getShareUrl(sc.yachtIds);
+                      navigator.clipboard.writeText(url);
+                    }}
+                    className="text-gray-300 hover:text-blue-500 transition-colors p-1"
+                    title="Copy share link"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDelete(sc.id)}
+                    className="text-gray-300 hover:text-red-500 transition-colors p-1"
+                    title="Delete"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {/* Selection Area */}
       <div className="mb-8">
@@ -535,10 +738,9 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                       );
                     }
                   } else {
-                    // Extra spec rows from spec_values table
                     const extraGroup = extraSpecRows[dg.group] || [];
                     for (const row of extraGroup) {
-                      if (builtInFieldKeys.has(row.name.toLowerCase())) continue; // skip dupes
+                      if (builtInFieldKeys.has(row.name.toLowerCase())) continue;
                       groupRows.push(
                         <tr key={`extra-${dg.group}-${row.name}`} className="hover:bg-gray-50/50 transition-colors">
                           <td className="px-5 py-3 text-gray-600 font-medium whitespace-nowrap sticky left-0 bg-white z-10">
@@ -557,7 +759,6 @@ export function CompareClient({ initialIds }: CompareClientProps) {
 
                   return (
                     <React.Fragment key={dg.group}>
-                      {/* Group header row */}
                       <tr className="bg-slate-50">
                         <td colSpan={yachts.length + 1} className="px-5 py-2 text-xs font-bold text-slate-500 uppercase tracking-wider">
                           {dg.group}
@@ -568,7 +769,6 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                   );
                 })}
 
-                {/* Design Notes (if any) */}
                 {yachts.some(y => y.designNotes) && (
                   <>
                     <tr className="bg-slate-50">

--- a/lib/savedComparisons.ts
+++ b/lib/savedComparisons.ts
@@ -1,0 +1,71 @@
+/**
+ * Saved comparisons stored in localStorage.
+ * Each comparison has a name, array of yacht IDs, and a timestamp.
+ */
+
+export interface SavedComparison {
+  id: string;
+  name: string;
+  yachtIds: number[];
+  createdAt: string;
+}
+
+const STORAGE_KEY = "sailing-yachts-saved-comparisons";
+const MAX_SAVED = 20;
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+export function getSavedComparisons(): SavedComparison[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export function saveComparison(name: string, yachtIds: number[]): SavedComparison | null {
+  if (!name.trim() || yachtIds.length < 2) return null;
+  const saved = getSavedComparisons();
+  if (saved.length >= MAX_SAVED) return null;
+
+  const entry: SavedComparison = {
+    id: generateId(),
+    name: name.trim(),
+    yachtIds: yachtIds.slice(0, 4),
+    createdAt: new Date().toISOString(),
+  };
+
+  saved.push(entry);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+  } catch {
+    return null;
+  }
+  return entry;
+}
+
+export function deleteComparison(id: string): boolean {
+  const saved = getSavedComparisons();
+  const filtered = saved.filter((c) => c.id !== id);
+  if (filtered.length === saved.length) return false;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getShareUrl(yachtIds: number[]): string {
+  if (typeof window === "undefined") return "";
+  const url = new URL(window.location.origin + "/compare");
+  url.searchParams.set("ids", yachtIds.join(","));
+  return url.toString();
+}

--- a/tests/saved-comparisons.spec.ts
+++ b/tests/saved-comparisons.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://sailing-yachts.vercel.app';
+
+test.describe('Saved Comparisons', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('should show Share and Save buttons when 2+ yachts selected', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    const shareBtn = page.locator('button:has-text("Share")');
+    const saveBtn = page.locator('button:has-text("Save")');
+    const savedBtn = page.locator('button:has-text("Saved")');
+    await expect(shareBtn).toBeVisible();
+    await expect(saveBtn).toBeVisible();
+    await expect(savedBtn).toBeVisible();
+  });
+
+  test('should not show Share/Save buttons with no yachts', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare`);
+    await page.waitForLoadState('networkidle');
+    const shareBtn = page.locator('button:has-text("Share")');
+    const saveBtn = page.locator('button:has-text("Save")');
+    await expect(shareBtn).toHaveCount(0);
+    await expect(saveBtn).toHaveCount(0);
+  });
+
+  test('should open save name input on Save click', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    const saveBtn = page.locator('button:has-text("Save")');
+    await saveBtn.click();
+    const nameInput = page.locator('input[placeholder*="Name this comparison"], input[placeholder*="Family cruisers"]');
+    await expect(nameInput).toBeVisible();
+    const saveSubmit = page.locator('button:has-text("Save")').last();
+    await expect(saveSubmit).toBeVisible();
+  });
+
+  test('should open saved comparisons panel on Saved click', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    const savedBtn = page.locator('button:has-text("Saved")');
+    await savedBtn.click();
+    // Panel header should appear
+    const panelHeader = page.locator('h3:has-text("Saved Comparisons")');
+    await expect(panelHeader).toBeVisible();
+  });
+
+  test('should show empty state in saved panel when nothing saved', async ({ page }) => {
+    // Use a fresh context to ensure no localStorage
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    // Clear localStorage to ensure clean state
+    await page.evaluate(() => localStorage.removeItem('sailing-yachts-saved-comparisons'));
+    const savedBtn = page.locator('button:has-text("Saved")');
+    await savedBtn.click();
+    const emptyMsg = page.locator('text=No saved comparisons yet');
+    await expect(emptyMsg).toBeVisible();
+  });
+
+  test('should copy share link and show Copied! feedback', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    const shareBtn = page.locator('button:has-text("Share")');
+    await shareBtn.click();
+    // Should briefly show "Copied!" text
+    const copied = page.locator('text=Copied!');
+    await expect(copied).toBeVisible({ timeout: 3000 });
+  });
+
+  test('should save a comparison to localStorage', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    // Click Save
+    await page.locator('button:has-text("Save")').click();
+    // Type name
+    const nameInput = page.locator('input[placeholder*="Family cruisers"]');
+    await nameInput.fill('Test comparison E2E');
+    // Submit
+    await page.locator('button:has-text("Save")').last().click();
+    // Open saved panel
+    await page.locator('button:has-text("Saved")').click();
+    // Should show the saved comparison
+    const savedItem = page.locator('text=Test comparison E2E');
+    await expect(savedItem).toBeVisible();
+    // Verify in localStorage
+    const stored = await page.evaluate(() => localStorage.getItem('sailing-yachts-saved-comparisons'));
+    expect(stored).toContain('Test comparison E2E');
+    // Clean up
+    await page.evaluate(() => localStorage.removeItem('sailing-yachts-saved-comparisons'));
+  });
+
+  test('should delete a saved comparison', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    // Save one first
+    await page.locator('button:has-text("Save")').click();
+    await page.locator('input[placeholder*="Family cruisers"]').fill('To be deleted');
+    await page.locator('button:has-text("Save")').last().click();
+    // Open panel
+    await page.locator('button:has-text("Saved")').click();
+    await expect(page.locator('text=To be deleted')).toBeVisible();
+    // Click delete (trash icon in the list item)
+    const listItem = page.locator('li').filter({ hasText: 'To be deleted' });
+    await listItem.locator('button[title="Delete"]').click();
+    // Should be gone
+    await expect(page.locator('text=To be deleted')).toHaveCount(0);
+    // Clean up
+    await page.evaluate(() => localStorage.removeItem('sailing-yachts-saved-comparisons'));
+  });
+
+  test('should load a saved comparison when clicked', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    // Save a comparison with IDs 1,2
+    await page.locator('button:has-text("Save")').click();
+    await page.locator('input[placeholder*="Family cruisers"]').fill('Load test');
+    await page.locator('button:has-text("Save")').last().click();
+    // Navigate away (clear selection)
+    await page.goto(`${BASE_URL}/compare`);
+    await page.waitForLoadState('networkidle');
+    // Open saved panel
+    await page.locator('button:has-text("Saved")').click();
+    // Click the saved item to load it
+    await page.locator('text=Load test').click();
+    // URL should now have ids=1,2
+    await page.waitForTimeout(1000);
+    const url = page.url();
+    expect(url).toContain('ids=1%2C2');
+    // Clean up
+    await page.evaluate(() => localStorage.removeItem('sailing-yachts-saved-comparisons'));
+  });
+
+  test('saved button badge shows count', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare?ids=1,2`);
+    await page.waitForLoadState('networkidle');
+    // Save two comparisons
+    await page.locator('button:has-text("Save")').click();
+    await page.locator('input[placeholder*="Family cruisers"]').fill('First save');
+    await page.locator('button:has-text("Save")').last().click();
+    // Small delay
+    await page.waitForTimeout(300);
+    await page.locator('button:has-text("Save")').click();
+    await page.locator('input[placeholder*="Family cruisers"]').fill('Second save');
+    await page.locator('button:has-text("Save")').last().click();
+    // Badge should show 2
+    const badge = page.locator('button:has-text("Saved") span.rounded-full');
+    await expect(badge).toHaveText('2');
+    // Clean up
+    await page.evaluate(() => localStorage.removeItem('sailing-yachts-saved-comparisons'));
+  });
+});


### PR DESCRIPTION
## Summary
Adds the ability to save, load, share, and delete yacht comparisons.

Closes #29

## Changes
- **lib/savedComparisons.ts** — localStorage utility for CRUD on saved comparisons
- **app/compare/CompareClient.tsx** — new UI elements:
  - Share button (copies `/compare?ids=...` URL to clipboard)
  - Save button (opens name input, saves to localStorage)
  - Saved panel (lists all saved comparisons, load/delete/copy link)
  - Badge counter on Saved button
- **tests/saved-comparisons.spec.ts** — 10 Playwright E2E tests

## Features
- Save comparisons with custom names (up to 20 stored)
- Load saved comparisons by clicking them (updates URL + selection)
- Copy shareable URL with visual "Copied!" feedback
- Delete saved comparisons via trash icon
- Responsive UI for all screen sizes
- No auth needed — uses localStorage only

## Testing
- ✅ `npm run typecheck` passes
- ✅ `npm run build` succeeds (21/21 pages)
- 10 new Playwright E2E tests added

## Phase
Phase 2 — Core Features (Saved comparisons item)