### PR TITLE
feat: add print-friendly yacht spec sheets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Sailing Yachts — Improvement Roadmap
 
 Created: 2026-03-27
-Updated: 2026-03-31
+Updated: 2026-04-02
 Status: Active
 Repo: https://github.com/pgedeon/sailing-yachts
 Vercel: sailing-yachts (peter-gedeons-projects)
@@ -42,7 +42,7 @@ Cron: sailing-yachts-builder (every 6h)
 
 ## Phase 3 — User Features (Priority: Medium)
 - [x] User favorites / shortlist (localStorage, no auth needed) — Issue #33, PR #34
-- [ ] Find similar yachts feature (spec-based similarity scoring)
+- [x] Find similar yachts feature (spec-based similarity scoring) — API + UI with match scores
 - [x] Price range indicator (where data available) — Issue #41, PR #42
 - [x] Filter presets (Bluewater cruisers, Racing yachts, Budget friendly) — Issue #43, PR #44
 - [ ] Print-friendly yacht spec sheets

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,132 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── Print styles for yacht spec sheets ── */
+@media print {
+  /* Hide non-essential UI */
+  header,
+  footer,
+  nav,
+  .no-print,
+  [data-no-print],
+  #mobile-menu-btn,
+  #mobile-menu-panel,
+  .favorite-button,
+  .admin-links {
+    display: none !important;
+  }
+
+  /* Reset backgrounds */
+  body {
+    background: white !important;
+    color: black !important;
+    font-size: 11pt;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Remove sticky header offset */
+  main {
+    padding-top: 0 !important;
+  }
+
+  /* Yacht detail page */
+  .yacht-detail-page {
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+
+  /* Hero section: two columns */
+  .yacht-hero {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 20px !important;
+    margin-bottom: 20px !important;
+  }
+
+  .yacht-hero img {
+    max-height: 250px !important;
+    object-fit: contain !important;
+    border-radius: 4px !important;
+  }
+
+  /* Spec groups */
+  .spec-group {
+    page-break-inside: avoid;
+    margin-bottom: 12px !important;
+  }
+
+  .spec-group h2 {
+    font-size: 14pt !important;
+    border-bottom: 1px solid #333 !important;
+    padding-bottom: 4px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .spec-grid {
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 6px !important;
+  }
+
+  .spec-item {
+    border: 1px solid #ddd !important;
+    border-radius: 4px !important;
+    padding: 6px 8px !important;
+    page-break-inside: avoid;
+  }
+
+  /* Similar yachts and compare button hidden */
+  .similar-yachts-section,
+  .compare-button-section {
+    display: none !important;
+  }
+
+  /* Print spec sheet button hidden */
+  .print-spec-sheet-btn {
+    display: none !important;
+  }
+
+  /* Show print header with branding */
+  .print-header {
+    display: block !important;
+    border-bottom: 2px solid #333 !important;
+    padding-bottom: 8px !important;
+    margin-bottom: 16px !important;
+    text-align: center;
+  }
+
+  .print-header h1 {
+    font-size: 10pt !important;
+    color: #666 !important;
+    margin: 0 !important;
+  }
+
+  /* Print footer */
+  .print-footer {
+    display: block !important;
+    border-top: 1px solid #ccc !important;
+    padding-top: 8px !important;
+    margin-top: 20px !important;
+    font-size: 8pt !important;
+    color: #999 !important;
+    text-align: center;
+  }
+
+  /* Page margins */
+  @page {
+    margin: 1.5cm 2cm;
+  }
+
+  /* Prevent orphaned headings */
+  h2 {
+    page-break-after: avoid;
+  }
+
+  /* Prevent breaking inside cards */
+  .bg-card,
+  .border-border {
+    page-break-inside: avoid;
+  }
+}

--- a/app/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/yachts/[slug]/YachtDetailClient.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, Ruler, Wind, Home, Wrench, Star } from "lucide-react";
+import { ChevronLeft, Ruler, Wind, Home, Wrench, Star, Printer } from "lucide-react";
 import { FavoriteButton } from "@/app/components/FavoriteButton";
 import { PriceTierDetail } from "@/app/components/PriceTierBadge";
 import { calculatePriceTier } from "@/lib/price-tier";
@@ -103,6 +103,10 @@ export default function YachtDetailClient() {
       .finally(() => setLoading(false));
   }, [slug]);
 
+  const handlePrint = () => {
+    window.print();
+  };
+
   if (loading)
     return (
       <div className="max-w-7xl mx-auto px-4 py-12 text-center">
@@ -138,19 +142,33 @@ export default function YachtDetailClient() {
     yacht.images.find((img) => img.isPrimary) || yacht.images[0];
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-      {/* Back link */}
-      <div className="mb-4 sm:mb-6">
-        <Button asChild variant="ghost" size="sm">
+    <div className="yacht-detail-page max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+      {/* Print-only header */}
+      <div className="print-header hidden" data-testid="print-header">
+        <h1>Sailing Yachts Database — Spec Sheet</h1>
+      </div>
+
+      {/* Back link + Print button */}
+      <div className="mb-4 sm:mb-6 flex items-center justify-between">
+        <Button asChild variant="ghost" size="sm" className="no-print">
           <Link href="/yachts">
             <ChevronLeft className="h-4 w-4 mr-1" />
             Back to Browse
           </Link>
         </Button>
+        <button
+          onClick={handlePrint}
+          className="print-spec-sheet-btn no-print inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
+          data-testid="print-spec-sheet-btn"
+          type="button"
+        >
+          <Printer className="h-4 w-4" />
+          Print Spec Sheet
+        </button>
       </div>
 
       {/* Hero */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8 mb-10 sm:mb-12">
+      <div className="yacht-hero grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8 mb-10 sm:mb-12">
         <div>
           {primaryImage ? (
             <img
@@ -172,7 +190,9 @@ export default function YachtDetailClient() {
             <h1 className="text-2xl sm:text-3xl font-bold mb-2">
               {yacht.manufacturer} {yacht.modelName} ({yacht.year})
             </h1>
-            <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel />
+            <div className="no-print">
+              <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel />
+            </div>
           </div>
           <p className="text-base sm:text-lg text-muted-foreground mb-4">
             A sailing yacht built by {yacht.manufacturer}.
@@ -186,7 +206,7 @@ export default function YachtDetailClient() {
           {/* Core specs quick view */}
           <div className="grid grid-cols-2 gap-3 sm:gap-4 my-4 sm:my-6">
             {yacht.lengthOverall && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4">
+              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
                 <div className="text-xs sm:text-sm text-muted-foreground">
                   Length Overall
                 </div>
@@ -196,7 +216,7 @@ export default function YachtDetailClient() {
               </div>
             )}
             {yacht.beam && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4">
+              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
                 <div className="text-xs sm:text-sm text-muted-foreground">Beam</div>
                 <div className="text-xl sm:text-2xl font-semibold">
                   {formatNumber(yacht.beam)} m
@@ -204,7 +224,7 @@ export default function YachtDetailClient() {
               </div>
             )}
             {yacht.draft && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4">
+              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
                 <div className="text-xs sm:text-sm text-muted-foreground">Draft</div>
                 <div className="text-xl sm:text-2xl font-semibold">
                   {formatNumber(yacht.draft)} m
@@ -212,7 +232,7 @@ export default function YachtDetailClient() {
               </div>
             )}
             {yacht.displacement && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4">
+              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
                 <div className="text-xs sm:text-sm text-muted-foreground">
                   Displacement
                 </div>
@@ -236,7 +256,7 @@ export default function YachtDetailClient() {
 
           {/* Admin links */}
           {yacht.adminLinks && yacht.adminLinks.length > 0 && (
-            <div className="flex flex-wrap gap-2 sm:gap-3 mt-4">
+            <div className="admin-links flex flex-wrap gap-2 sm:gap-3 mt-4 no-print">
               {yacht.adminLinks.map((link, idx) => (
                 <Button key={idx} asChild variant="outline" size="sm">
                   <a href={link.url} target="_blank" rel="noopener noreferrer">
@@ -269,16 +289,16 @@ export default function YachtDetailClient() {
           const label = GROUP_LABELS[group] || group;
           const icon = GROUP_ICONS[group];
           return (
-            <section key={group}>
+            <section key={group} className="spec-group">
               <div className="flex items-center gap-2 mb-3 sm:mb-4">
                 {icon}
                 <h2 className="text-lg sm:text-xl font-bold">{label}</h2>
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
+              <div className="spec-grid grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
                 {specs.map((spec, idx) => (
                   <div
                     key={idx}
-                    className="bg-card border border-border rounded-lg p-3 sm:p-4"
+                    className="spec-item bg-card border border-border rounded-lg p-3 sm:p-4"
                   >
                     <div className="text-xs sm:text-sm text-muted-foreground">
                       {spec.category}
@@ -330,13 +350,20 @@ export default function YachtDetailClient() {
       )}
 
       {/* Similar Yachts */}
-      <SimilarYachts slug={slug} />
+      <div className="similar-yachts-section no-print">
+        <SimilarYachts slug={slug} />
+      </div>
 
       {/* Compare Button */}
-      <div className="mt-10 sm:mt-12 text-center">
+      <div className="compare-button-section mt-10 sm:mt-12 text-center no-print">
         <Button asChild size="lg">
           <Link href={`/compare?ids=${yacht.id}`}>Compare This Yacht</Link>
         </Button>
+      </div>
+
+      {/* Print-only footer */}
+      <div className="print-footer hidden" data-testid="print-footer">
+        Printed from sailing-yachts.vercel.app — {yacht.manufacturer} {yacht.modelName} ({yacht.year}) — {new Date().toLocaleDateString()}
       </div>
     </div>
   );

--- a/tests/print-spec-sheet.spec.ts
+++ b/tests/print-spec-sheet.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Print Spec Sheet Feature", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the yachts listing and pick the first yacht
+    await page.goto("/yachts");
+    await page.waitForLoadState("networkidle");
+
+    const firstYacht = page.locator('a[href^="/yachts/"]').first();
+    await firstYacht.click();
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("print spec sheet button is visible on yacht detail page", async ({
+    page,
+  }) => {
+    const printBtn = page.getByTestId("print-spec-sheet-btn");
+    await expect(printBtn).toBeVisible();
+    await expect(printBtn).toContainText("Print Spec Sheet");
+  });
+
+  test("print button has printer icon", async ({ page }) => {
+    const printBtn = page.getByTestId("print-spec-sheet-btn");
+    await expect(printBtn).toBeVisible();
+    // Check for the lucide printer SVG icon
+    const icon = printBtn.locator("svg");
+    await expect(icon).toBeVisible();
+  });
+
+  test("print header and footer exist in DOM but are hidden on screen", async ({
+    page,
+  }) => {
+    const printHeader = page.getByTestId("print-header");
+    const printFooter = page.getByTestId("print-footer");
+
+    // Elements should exist in DOM
+    await expect(printHeader).toBeAttached();
+    await expect(printFooter).toBeAttached();
+
+    // But hidden on screen (display: none via .hidden class)
+    await expect(printHeader).toBeHidden();
+    await expect(printFooter).toBeHidden();
+
+    // Print header should contain branding text
+    expect(await printHeader.innerText()).toContain("Sailing Yachts Database");
+
+    // Print footer should contain printed-from text
+    expect(await printFooter.innerText()).toContain("Printed from");
+  });
+
+  test("print CSS is loaded via globals.css", async ({ page }) => {
+    // Verify print-specific styles exist by checking computed styles in print mode
+    // We emulate print media and check that header/footer are visible
+    await page.emulateMedia({ media: "print" });
+
+    const printHeader = page.getByTestId("print-header");
+    const printFooter = page.getByTestId("print-footer");
+
+    // After emulating print, these should become visible
+    await expect(printHeader).toBeVisible({ timeout: 5000 });
+    await expect(printFooter).toBeVisible({ timeout: 5000 });
+  });
+
+  test("interactive elements are hidden in print mode", async ({ page }) => {
+    await page.emulateMedia({ media: "print" });
+
+    // Back to Browse button should be hidden (has no-print class)
+    const backBtn = page.locator("text=Back to Browse");
+    const backVisible = await backBtn.isVisible().catch(() => false);
+    expect(backVisible).toBe(false);
+
+    // Print Spec Sheet button should be hidden
+    const printBtn = page.getByTestId("print-spec-sheet-btn");
+    const printBtnVisible = await printBtn.isVisible().catch(() => false);
+    expect(printBtnVisible).toBe(false);
+
+    // Compare This Yacht button should be hidden
+    const compareBtn = page.locator("text=Compare This Yacht");
+    const compareVisible = await compareBtn.isVisible().catch(() => false);
+    expect(compareVisible).toBe(false);
+  });
+
+  test("spec sections are visible in print mode", async ({ page }) => {
+    await page.emulateMedia({ media: "print" });
+
+    // The yacht title should still be visible
+    const title = page.locator("h1").first();
+    await expect(title).toBeVisible();
+
+    // Spec groups should be present
+    const specItems = page.locator(".spec-item");
+    const count = await specItems.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test("print spec sheet button triggers window.print", async ({ page }) => {
+    // Listen for the beforeprint event to confirm print was triggered
+    const printTriggered = page.evaluate(() => {
+      return new Promise<boolean>((resolve) => {
+        window.addEventListener("beforeprint", () => resolve(true), {
+          once: true,
+        });
+        // Timeout fallback
+        setTimeout(() => resolve(false), 3000);
+      });
+    });
+
+    const printBtn = page.getByTestId("print-spec-sheet-btn");
+    await printBtn.click();
+
+    const wasTriggered = await printTriggered;
+    expect(wasTriggered).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds print-friendly layout for yacht detail pages so users can generate clean spec sheets for reference or sharing.

## Changes
- **Print CSS** (`globals.css`): @media print rules that hide nav, footer, interactive elements, similar yachts, and compare button. Clean black-on-white layout with page-break controls.
- **Print header/footer**: Hidden on screen, visible in print — branding header and date-stamped footer.
- **Print Spec Sheet button**: Added to yacht detail page toolbar with printer icon, calls `window.print()`.
- **Semantic classes**: Added `no-print`, `spec-group`, `spec-grid`, `spec-item`, `yacht-hero`, `yacht-detail-page` classes for print targeting.
- **Playwright tests**: 7 E2E tests verifying button visibility, print mode behavior, element hiding, and print trigger.

## Testing
- ✅ TypeScript typecheck passes
- ✅ `next build` succeeds
- ✅ 7 new Playwright test cases

Closes #45