### PR TITLE
feat: embeddable yacht comparison widget for sailboats.fr

### DIFF
--- a/app/embed/compare/EmbedCompareClient.tsx
+++ b/app/embed/compare/EmbedCompareClient.tsx
@@ -1,0 +1,324 @@
+"use client";
+import React from "react";
+
+import { useEffect } from "react";
+
+interface YachtDTO {
+  id: number;
+  manufacturer: string;
+  modelName: string;
+  slug: string | null;
+  year: number | null;
+  lengthOverall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  ballast: number | null;
+  sailAreaMain: number | null;
+  rigType: string | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  cabins: number | null;
+  berths: number | null;
+  heads: number | null;
+  maxOccupancy: number | null;
+  engineHp: number | null;
+  engineType: string | null;
+  fuelCapacity: number | null;
+  waterCapacity: number | null;
+  designNotes: string | null;
+  specsByGroup: Record<string, { name: string; value: string; unit: string | null }[]>;
+  priceTier: {
+    tier: string;
+    label: string;
+    range: string;
+    color: string;
+    bgColor: string;
+  };
+}
+
+interface FieldDef {
+  key: keyof YachtDTO;
+  label: string;
+  unit?: string;
+}
+
+interface SpecFieldGroup {
+  group: string;
+  fields: FieldDef[];
+}
+
+const COLORS = [
+  { bg: "#EFF6FF", border: "#93C5FD", text: "#1E40AF", dot: "#3B82F6" },
+  { bg: "#ECFDF5", border: "#6EE7B7", text: "#065F46", dot: "#10B981" },
+  { bg: "#FFFBEB", border: "#FCD34D", text: "#92400E", dot: "#F59E0B" },
+  { bg: "#FAF5FF", border: "#C4B5FD", text: "#6B21A8", dot: "#8B5CF6" },
+];
+
+export default function EmbedCompareClient({
+  yachts,
+  specFields,
+  siteUrl,
+}: {
+  yachts: YachtDTO[];
+  specFields: SpecFieldGroup[];
+  siteUrl: string;
+}) {
+  // Post height to parent for auto-resize
+  useEffect(() => {
+    const sendHeight = () => {
+      const height = document.documentElement.scrollHeight;
+      if (window.parent !== window) {
+        window.parent.postMessage({ type: "sailing-yachts-embed", height }, "*");
+      }
+    };
+    sendHeight();
+    const observer = new ResizeObserver(sendHeight);
+    observer.observe(document.body);
+    return () => observer.disconnect();
+  }, []);
+
+  const formatVal = (value: number | string | null | undefined, unit?: string) => {
+    if (value === null || value === undefined) return "—";
+    const suffix = unit ? ` ${unit}` : "";
+    if (typeof value === "number") {
+      return `${Number.isInteger(value) ? value.toLocaleString() : value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}${suffix}`;
+    }
+    return String(value) + suffix;
+  };
+
+  // Collect extra spec rows
+  const allExtraKeys = new Set<string>();
+  const extraData: Record<string, { name: string; unit: string | null; values: (string | null)[] }> = {};
+  const builtinLabels = new Set(specFields.flatMap((g) => g.fields.map((f) => f.label.toLowerCase())));
+
+  for (const y of yachts) {
+    for (const [group, entries] of Object.entries(y.specsByGroup || {})) {
+      for (const e of entries) {
+        const key = `${group}|${e.name}`;
+        if (!allExtraKeys.has(key)) {
+          allExtraKeys.add(key);
+          extraData[key] = { name: e.name, unit: e.unit, values: [] };
+        }
+      }
+    }
+  }
+  // Fill values
+  for (const key of [...allExtraKeys].sort()) {
+    const [group, name] = key.split("|");
+    const values = yachts.map((y) => {
+      const entries = y.specsByGroup?.[group] || [];
+      const entry = entries.find((e) => e.name === name);
+      return entry?.value ?? null;
+    });
+    extraData[key].values = values;
+  }
+
+  // Group extra specs
+  const extraByGroup: Record<string, { name: string; unit: string | null; values: (string | null)[] }[]> = {};
+  for (const key of [...allExtraKeys].sort()) {
+    const [group] = key.split("|");
+    const data = extraData[key];
+    if (builtinLabels.has(data.name.toLowerCase())) continue;
+    if (!extraByGroup[group]) extraByGroup[group] = [];
+    extraByGroup[group].push(data);
+  }
+
+  return (
+    <div style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif', maxWidth: 900, margin: "0 auto", padding: "16px", color: "#1f2937", fontSize: 14 }}>
+      {/* Branding Header */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16, paddingBottom: 12, borderBottom: "2px solid #e5e7eb" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ width: 28, height: 28, borderRadius: 6, background: "linear-gradient(135deg, #3B82F6, #1D4ED8)", display: "flex", alignItems: "center", justifyContent: "center", color: "white", fontSize: 14, fontWeight: 700 }}>
+            ⛵
+          </div>
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 15, color: "#111827", lineHeight: 1.2 }}>Yacht Comparison</div>
+            <div style={{ fontSize: 11, color: "#9ca3af", lineHeight: 1.2 }}>
+              {yachts.length} yachts · {yachts[0]?.year ?? "—"}
+            </div>
+          </div>
+        </div>
+        <a
+          href={`${siteUrl}/compare?ids=${yachts.map((y) => y.id).join(",")}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ fontSize: 12, color: "#3B82F6", textDecoration: "none", fontWeight: 500 }}
+        >
+          Full comparison →
+        </a>
+      </div>
+
+      {/* Yacht Name Headers */}
+      <div style={{ display: "grid", gridTemplateColumns: `120px repeat(${yachts.length}, 1fr)`, gap: 8, marginBottom: 12 }}>
+        <div />
+        {yachts.map((y, i) => {
+          const c = COLORS[i];
+          return (
+            <div key={y.id} style={{ background: c.bg, border: `1px solid ${c.border}`, borderRadius: 8, padding: "8px 10px", textAlign: "center" }}>
+              <a
+                href={`${siteUrl}/yachts/${y.slug || y.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", color: c.text }}
+              >
+                <div style={{ fontWeight: 700, fontSize: 13, lineHeight: 1.3 }}>{y.manufacturer}</div>
+                <div style={{ fontSize: 12, fontWeight: 500, opacity: 0.85, lineHeight: 1.3 }}>{y.modelName}</div>
+              </a>
+              {y.year && (
+                <div style={{ fontSize: 10, color: "#6b7280", marginTop: 2 }}>{y.year}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Price Tier Row */}
+      <div style={{ display: "grid", gridTemplateColumns: `120px repeat(${yachts.length}, 1fr)`, gap: 8, marginBottom: 4, background: "#f9fafb", borderRadius: 6, padding: "6px 0" }}>
+        <div style={{ paddingLeft: 10, display: "flex", alignItems: "center", fontWeight: 600, fontSize: 12, color: "#6b7280" }}>Est. Price</div>
+        {yachts.map((y) => (
+          <div key={y.id} style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 4 }}>
+            <span
+              style={{
+                display: "inline-block",
+                padding: "2px 8px",
+                borderRadius: 9999,
+                fontSize: 11,
+                fontWeight: 600,
+                background: y.priceTier.bgColor.replace("bg-", "").includes("green") ? "#dcfce7" : y.priceTier.tier === "mid-range" ? "#dbeafe" : y.priceTier.tier === "premium" ? "#f3e8ff" : y.priceTier.tier === "luxury" ? "#fef3c7" : "#f3f4f6",
+                color: y.priceTier.tier === "budget" ? "#15803d" : y.priceTier.tier === "mid-range" ? "#1d4ed8" : y.priceTier.tier === "premium" ? "#7c3aed" : y.priceTier.tier === "luxury" ? "#b45309" : "#6b7280",
+              }}
+            >
+              {y.priceTier.label}
+            </span>
+            <span style={{ fontSize: 10, color: "#9ca3af" }}>{y.priceTier.range}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Spec Table */}
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+        <tbody>
+          {specFields.map((sg) => (
+            <SpecGroupRow
+              key={sg.group}
+              group={sg.group}
+              fields={sg.fields}
+              yachts={yachts}
+              formatVal={formatVal}
+            />
+          ))}
+          {/* Extra specs from database */}
+          {Object.entries(extraByGroup).map(([group, rows]) => (
+            <React.Fragment key={`extra-${group}`}>
+              <GroupHeaderRow label={group} colSpan={yachts.length + 1} />
+              {rows.map((row) => (
+                <tr key={`extra-${group}-${row.name}`}>
+                  <LabelCell>{row.name}{row.unit ? ` (${row.unit})` : ""}</LabelCell>
+                  {row.values.map((v, vi) => (
+                    <ValueCell key={vi}>{v ?? "—"}</ValueCell>
+                  ))}
+                </tr>
+              ))}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Footer */}
+      <div style={{ marginTop: 16, paddingTop: 10, borderTop: "1px solid #e5e7eb", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 11, color: "#9ca3af" }}>
+          Data from manufacturer specifications
+        </span>
+        <a
+          href={siteUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ fontSize: 11, color: "#6b7280", textDecoration: "none" }}
+        >
+          Powered by Sailing Yachts Database
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function SpecGroupRow({
+  group,
+  fields,
+  yachts,
+  formatVal,
+}: {
+  group: string;
+  fields: FieldDef[];
+  yachts: YachtDTO[];
+  formatVal: (v: any, u?: string) => string;
+}) {
+  return (
+    <>
+      <GroupHeaderRow label={group} colSpan={yachts.length + 1} />
+      {fields.map((f) => (
+        <tr key={f.key}>
+          <LabelCell>{f.label}</LabelCell>
+          {yachts.map((y) => (
+            <ValueCell key={y.id}>{formatVal(y[f.key], f.unit)}</ValueCell>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function GroupHeaderRow({ label, colSpan }: { label: string; colSpan: number }) {
+  return (
+    <tr>
+      <td
+        colSpan={colSpan}
+        style={{
+          fontWeight: 700,
+          fontSize: 11,
+          textTransform: "uppercase" as const,
+          letterSpacing: "0.05em",
+          color: "#64748b",
+          padding: "10px 10px 4px",
+          borderBottom: "1px solid #e5e7eb",
+        }}
+      >
+        {label}
+      </td>
+    </tr>
+  );
+}
+
+function LabelCell({ children }: { children: React.ReactNode }) {
+  return (
+    <td
+      style={{
+        fontWeight: 500,
+        color: "#4b5563",
+        padding: "5px 10px",
+        whiteSpace: "nowrap",
+        borderBottom: "1px solid #f3f4f6",
+        fontSize: 12,
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function ValueCell({ children }: { children: React.ReactNode }) {
+  return (
+    <td
+      style={{
+        textAlign: "center",
+        padding: "5px 8px",
+        borderBottom: "1px solid #f3f4f6",
+        fontSize: 12,
+        color: "#1f2937",
+      }}
+    >
+      {children}
+    </td>
+  );
+}

--- a/app/embed/compare/page.tsx
+++ b/app/embed/compare/page.tsx
@@ -1,0 +1,241 @@
+import { pool } from "@/lib/db";
+import { calculatePriceTier } from "@/lib/price-tier";
+import EmbedCompareClient from "./EmbedCompareClient";
+
+export const dynamic = "force-dynamic";
+
+interface YachtRow {
+  id: number;
+  model_name: string;
+  manufacturer_name: string;
+  slug: string | null;
+  year: number | null;
+  length_overall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  ballast: number | null;
+  sail_area_main: number | null;
+  rig_type: string | null;
+  keel_type: string | null;
+  hull_material: string | null;
+  cabins: number | null;
+  berths: number | null;
+  heads: number | null;
+  max_occupancy: number | null;
+  engine_hp: number | null;
+  engine_type: string | null;
+  fuel_capacity: number | null;
+  water_capacity: number | null;
+  design_notes: string | null;
+}
+
+interface SpecValue {
+  yacht_model_id: number;
+  category_group: string;
+  category_name: string;
+  unit: string | null;
+  value_text: string | null;
+  value_numeric: number | null;
+}
+
+interface YachtDTO {
+  id: number;
+  manufacturer: string;
+  modelName: string;
+  slug: string | null;
+  year: number | null;
+  lengthOverall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  ballast: number | null;
+  sailAreaMain: number | null;
+  rigType: string | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  cabins: number | null;
+  berths: number | null;
+  heads: number | null;
+  maxOccupancy: number | null;
+  engineHp: number | null;
+  engineType: string | null;
+  fuelCapacity: number | null;
+  waterCapacity: number | null;
+  designNotes: string | null;
+  specsByGroup: Record<string, { name: string; value: string; unit: string | null }[]>;
+  priceTier: ReturnType<typeof calculatePriceTier>;
+}
+
+const SPEC_FIELDS: { group: string; fields: { key: keyof YachtDTO; label: string; unit?: string }[] }[] = [
+  {
+    group: "Dimensions",
+    fields: [
+      { key: "lengthOverall", label: "LOA", unit: "m" },
+      { key: "beam", label: "Beam", unit: "m" },
+      { key: "draft", label: "Draft", unit: "m" },
+      { key: "displacement", label: "Displacement", unit: "kg" },
+      { key: "ballast", label: "Ballast", unit: "kg" },
+    ],
+  },
+  {
+    group: "Rig & Sails",
+    fields: [
+      { key: "sailAreaMain", label: "Sail Area", unit: "m²" },
+      { key: "rigType", label: "Rig Type" },
+    ],
+  },
+  {
+    group: "Construction",
+    fields: [
+      { key: "keelType", label: "Keel" },
+      { key: "hullMaterial", label: "Hull" },
+    ],
+  },
+  {
+    group: "Accommodation",
+    fields: [
+      { key: "cabins", label: "Cabins" },
+      { key: "berths", label: "Berths" },
+      { key: "heads", label: "Heads" },
+      { key: "maxOccupancy", label: "Max Occupancy" },
+    ],
+  },
+  {
+    group: "Engine & Tankage",
+    fields: [
+      { key: "engineHp", label: "Engine HP" },
+      { key: "engineType", label: "Engine Type" },
+      { key: "fuelCapacity", label: "Fuel", unit: "L" },
+      { key: "waterCapacity", label: "Water", unit: "L" },
+    ],
+  },
+];
+
+export default async function EmbedComparePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ids?: string }>;
+}) {
+  const params = await searchParams;
+  const idsParam = params.ids;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://sailing-yachts.vercel.app";
+
+  if (!idsParam) {
+    return (
+      <div className="p-6 text-center text-gray-500">
+        <p className="text-lg font-medium">No yachts selected</p>
+        <p className="text-sm mt-1">
+          Usage: <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">/embed/compare?ids=1,2</code>
+        </p>
+      </div>
+    );
+  }
+
+  const ids = idsParam
+    .split(",")
+    .map((id) => parseInt(id.trim(), 10))
+    .filter((id) => !isNaN(id));
+
+  if (ids.length < 2 || ids.length > 4) {
+    return (
+      <div className="p-6 text-center text-gray-500">
+        <p className="text-lg font-medium">Invalid selection</p>
+        <p className="text-sm mt-1">Please provide 2–4 yacht IDs</p>
+      </div>
+    );
+  }
+
+  // Fetch yachts
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(",");
+  const yachtResult = await pool.query(
+    `SELECT y.id, y.model_name, m.name AS manufacturer_name, y.slug, y.year,
+       y.length_overall, y.beam, y.draft, y.displacement, y.ballast,
+       y.sail_area_main, y.rig_type, y.keel_type, y.hull_material,
+       y.cabins, y.berths, y.heads, y.max_occupancy,
+       y.engine_hp, y.engine_type, y.fuel_capacity, y.water_capacity,
+       y.design_notes
+     FROM yacht_models y
+     LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+     WHERE y.id IN (${placeholders})`,
+    ids
+  );
+
+  const rows = yachtResult.rows as YachtRow[];
+  if (rows.length === 0) {
+    return (
+      <div className="p-6 text-center text-gray-500">
+        <p>No yachts found for the given IDs.</p>
+      </div>
+    );
+  }
+
+  // Fetch spec values
+  const specResult = await pool.query(
+    `SELECT sv.yacht_model_id, sv.value_text, sv.value_numeric,
+       sc.name AS category_name, sc.category_group, sc.unit
+     FROM spec_values sv
+     JOIN spec_categories sc ON sv.spec_category_id = sc.id
+     WHERE sv.yacht_model_id IN (${placeholders})
+     ORDER BY sc.category_group, sc.name`,
+    ids
+  );
+  const specRows = specResult.rows as SpecValue[];
+
+  // Build specsByGroup per yacht
+  const specsMap: Record<number, Record<string, { name: string; value: string; unit: string | null }[]>> = {};
+  for (const sr of specRows) {
+    const yid = sr.yacht_model_id;
+    if (!specsMap[yid]) specsMap[yid] = {};
+    const group = sr.category_group || "Other";
+    if (!specsMap[yid][group]) specsMap[yid][group] = [];
+    let value = "—";
+    if (sr.value_numeric !== null) {
+      value = Number(sr.value_numeric).toLocaleString(undefined, { maximumFractionDigits: 2 });
+    } else if (sr.value_text) {
+      value = sr.value_text;
+    }
+    specsMap[yid][group].push({ name: sr.category_name, value, unit: sr.unit });
+  }
+
+  // Map to DTO
+  const yachts: YachtDTO[] = rows.map((row) => ({
+    id: row.id,
+    manufacturer: row.manufacturer_name ?? "",
+    modelName: row.model_name,
+    slug: row.slug,
+    year: row.year,
+    lengthOverall: row.length_overall ? Number(row.length_overall) : null,
+    beam: row.beam ? Number(row.beam) : null,
+    draft: row.draft ? Number(row.draft) : null,
+    displacement: row.displacement ? Number(row.displacement) : null,
+    ballast: row.ballast ? Number(row.ballast) : null,
+    sailAreaMain: row.sail_area_main ? Number(row.sail_area_main) : null,
+    rigType: row.rig_type,
+    keelType: row.keel_type,
+    hullMaterial: row.hull_material,
+    cabins: row.cabins,
+    berths: row.berths,
+    heads: row.heads,
+    maxOccupancy: row.max_occupancy,
+    engineHp: row.engine_hp ? Number(row.engine_hp) : null,
+    engineType: row.engine_type,
+    fuelCapacity: row.fuel_capacity ? Number(row.fuel_capacity) : null,
+    waterCapacity: row.water_capacity ? Number(row.water_capacity) : null,
+    designNotes: row.design_notes,
+    specsByGroup: specsMap[row.id] || {},
+    priceTier: calculatePriceTier({
+      lengthOverall: row.length_overall ? Number(row.length_overall) : null,
+      displacement: row.displacement ? Number(row.displacement) : null,
+      beam: row.beam ? Number(row.beam) : null,
+      cabins: row.cabins,
+      hullMaterial: row.hull_material,
+      keelType: row.keel_type,
+      rigType: row.rig_type,
+    }),
+  }));
+
+  return (
+    <EmbedCompareClient yachts={yachts} specFields={SPEC_FIELDS} siteUrl={siteUrl} />
+  );
+}

--- a/app/embed/layout.tsx
+++ b/app/embed/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "../globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+});
+
+export const metadata: Metadata = {
+  title: "Sailing Yachts Widget",
+  robots: { index: false, follow: false },
+};
+
+export default function EmbedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={`${inter.variable} antialiased`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Only apply to embed routes
+  if (request.nextUrl.pathname.startsWith("/embed")) {
+    const response = NextResponse.next();
+
+    // Allow embedding from sailboats.fr and same origin
+    response.headers.set(
+      "X-Frame-Options",
+      "ALLOW-FROM https://sailboats.fr"
+    );
+    response.headers.set(
+      "Content-Security-Policy",
+      "frame-ancestors 'self' https://sailboats.fr https://*.sailboats.fr http://localhost:*"
+    );
+
+    // CORS headers for API-like access
+    response.headers.set(
+      "Access-Control-Allow-Origin",
+      "https://sailboats.fr"
+    );
+    response.headers.set(
+      "Access-Control-Allow-Methods",
+      "GET"
+    );
+
+    return response;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/embed/:path*"],
+};

--- a/tests/embed-compare.spec.ts
+++ b/tests/embed-compare.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "https://sailing-yachts.vercel.app";
+
+test.describe("Embeddable Comparison Widget", () => {
+  test("should show usage hint without ids parameter", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare`);
+    await expect(page.locator("text=No yachts selected")).toBeVisible();
+    await expect(page.locator("text=/embed/compare?ids=1,2")).toBeVisible();
+  });
+
+  test("should show error for only 1 yacht ID", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1`);
+    await expect(page.locator("text=Invalid selection")).toBeVisible();
+    await expect(page.locator("text=2–4 yacht IDs")).toBeVisible();
+  });
+
+  test("should show error for more than 4 yacht IDs", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2,3,4,5`);
+    await expect(page.locator("text=Invalid selection")).toBeVisible();
+  });
+
+  test("should render comparison of 2 yachts", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    // Should show branding header
+    await expect(page.locator("text=Yacht Comparison")).toBeVisible();
+    await expect(page.locator("text=Powered by Sailing Yachts Database")).toBeVisible();
+    await expect(page.locator("text=Full comparison →")).toBeVisible();
+
+    // Should show spec group headers
+    await expect(page.locator("text=DIMENSIONS").first()).toBeVisible();
+
+    // Should have "Est. Price" row
+    await expect(page.locator("text=Est. Price")).toBeVisible();
+
+    // Should not have the main site header/nav (embed layout is minimal)
+    await expect(page.locator("header")).toHaveCount(0);
+    await expect(page.locator("nav")).toHaveCount(0);
+  });
+
+  test("should link yacht names to detail pages", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    // Yacht name links should point to /yachts/ paths
+    const yachtLinks = page.locator('a[href*="/yachts/"]');
+    const count = await yachtLinks.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("full comparison link should have correct URL", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    const link = page.locator('a:has-text("Full comparison")');
+    const href = await link.getAttribute("href");
+    expect(href).toContain("/compare?ids=1,2");
+    expect(href).toContain("target");
+  });
+
+  test("should render comparison of 3 yachts", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2,3`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("text=Yacht Comparison")).toBeVisible();
+    // Should show 3 yacht name cards
+    const yachtLinks = page.locator('a[href*="/yachts/"]');
+    const count = await yachtLinks.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("should show Est. Price badges", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    // Price tier badges should be visible (Budget, Mid-Range, Premium, Luxury, or Unknown)
+    const priceSection = page.locator("text=Est. Price");
+    await expect(priceSection).toBeVisible();
+  });
+
+  test("should show spec labels (LOA, Beam, Draft)", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("text=LOA").first()).toBeVisible();
+    await expect(page.locator("text=Beam").first()).toBeVisible();
+    await expect(page.locator("text=Draft").first()).toBeVisible();
+  });
+
+  test("should have no main site footer", async ({ page }) => {
+    await page.goto(`${BASE_URL}/embed/compare?ids=1,2`);
+    await page.waitForLoadState("networkidle");
+
+    // The main site has "All rights reserved" — embed should not
+    await expect(page.locator("text=All rights reserved")).toHaveCount(0);
+    // But should have the embed footer
+    await expect(page.locator("text=Powered by Sailing Yachts Database")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #49

Adds an embeddable iframe widget that allows sailboats.fr blog posts to display yacht comparison tables.

### What's included
- **Embed page**: `/embed/compare?ids=1,2,3,4` — minimal layout without site header/footer
- **Branded design**: Clean card-style yacht names, spec comparison table, price tier badges
- **Auto-height**: Uses `postMessage` + `ResizeObserver` to notify parent iframe of height changes
- **CORS middleware**: Allows embedding from sailboats.fr via `X-Frame-Options` and `Content-Security-Policy`
- **Links**: Yacht names link to detail pages, "Full comparison →" links to the full compare page
- **Tests**: 9 Playwright test cases covering embed functionality

### Usage on sailboats.fr
```html
<iframe
  src="https://sailing-yachts.vercel.app/embed/compare?ids=1,2,3"
  width="100%"
  height="600"
  frameborder="0"
  style="max-width: 900px; margin: 0 auto;"
></iframe>
```

### Files changed
- `app/embed/layout.tsx` — Minimal embed layout (no header/footer)
- `app/embed/compare/page.tsx` — Server component, fetches yacht data
- `app/embed/compare/EmbedCompareClient.tsx` — Client component with render + postMessage
- `middleware.ts` — CORS/X-Frame headers for /embed routes
- `tests/embed-compare.spec.ts` — 9 Playwright tests