### PR TITLE
fix: use inline SVG fallback for yacht images instead of missing file

### DIFF
--- a/app/components/yacht/YachtImage.tsx
+++ b/app/components/yacht/YachtImage.tsx
@@ -8,6 +8,11 @@ const SHIMMER_BLUR = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(
   '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><defs><linearGradient id="s" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="%23e2e8f0"/><stop offset="50%" stop-color="%23cbd5e1"/><stop offset="100%" stop-color="%23e2e8f0"/></linearGradient></defs><rect width="20" height="20" fill="url(%23s)"/></svg>'
 )
 
+// Inline SVG fallback as data URI — always works, no file dependency
+const FALLBACK_IMAGE = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(
+  '<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg"><rect width="400" height="300" fill="%23f3f4f6"/><text x="200" y="155" text-anchor="middle" fill="%239ca3af" font-family="Arial,sans-serif" font-size="14">No image available</text></svg>'
+)
+
 interface YachtImageProps {
   src: string
   alt: string
@@ -28,7 +33,7 @@ export default function YachtImage({
   height,
   className = '',
   priority = false,
-  fallback = '/placeholder-yacht.jpg',
+  fallback = FALLBACK_IMAGE,
   sizes,
   fill = false,
   quality = 80,
@@ -57,6 +62,7 @@ export default function YachtImage({
           onError={handleError}
           placeholder="blur"
           blurDataURL={SHIMMER_BLUR}
+          unoptimized={imgSrc.startsWith('data:')}
         />
       </div>
     )
@@ -76,6 +82,7 @@ export default function YachtImage({
         onError={handleError}
         placeholder="blur"
         blurDataURL={SHIMMER_BLUR}
+        unoptimized={imgSrc.startsWith('data:')}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes console errors (404/400) when yacht images fail to load.

### Problem
- The YachtImage fallback was set to `/placeholder-yacht.jpg` which doesn't exist
- Only `/placeholder-yacht.svg` exists in public/
- When a yacht image URL fails (e.g., placeholder `example.com` URLs), the fallback also fails with a 400 error
- This causes two console errors per broken yacht image

### Fix
- Replace file-based fallback with inline data URI SVG (always works, no file dependency)
- Add `unoptimized` prop for data URI images to skip Next.js Image optimization on the fallback
- The inline SVG shows a clean 'No image available' placeholder