### PR TITLE
fix: add ensureSchema() to newsletter API routes

### DIFF
--- a/app/api/admin/newsletter/route.ts
+++ b/app/api/admin/newsletter/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db, newsletterSubscribers } from "@/lib/db";
+import { db, ensureSchema, newsletterSubscribers } from "@/lib/db";
 import { desc, sql } from "drizzle-orm";
 
 export async function GET(request: NextRequest) {
   try {
+    await ensureSchema();
+
     // Get query params for pagination
     const { searchParams } = new URL(request.url);
     const page = parseInt(searchParams.get("page") || "1");
@@ -43,6 +45,8 @@ export async function GET(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
+    await ensureSchema();
+
     const body = await request.json();
     const { id } = body;
 

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db, newsletterSubscribers } from "@/lib/db";
+import { db, ensureSchema, newsletterSubscribers } from "@/lib/db";
 import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
+    await ensureSchema();
+
     const body = await request.json();
     const { email, source } = body;
 


### PR DESCRIPTION
The newsletter API routes were missing `ensureSchema()` calls, causing 500 errors when the `newsletter_subscribers` table doesn't exist yet in the database.

This fix adds `ensureSchema()` to both `/api/newsletter` and `/api/admin/newsletter` routes, consistent with how other API routes handle auto table creation.