### PR TITLE
feat: Add AggregateRating to yacht JSON-LD structured data

### DIFF
--- a/app/(main)/yachts/[slug]/page.tsx
+++ b/app/(main)/yachts/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { db, yachtModels, manufacturers, images } from "@/lib/db";
+import { db, yachtModels, manufacturers, images, reviews } from "@/lib/db";
 import { eq } from "drizzle-orm";
 import {
   generateYachtPageMetadata,
@@ -109,6 +109,26 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
     .limit(1);
   const primaryImage = yachtImages.find((img: any) => img.isPrimary) || yachtImages[0];
 
+  // Fetch reviews for AggregateRating in JSON-LD
+  const yachtReviews = await db
+    .select({
+      rating: reviews.rating,
+      summary: reviews.summary,
+      authorName: reviews.authorName,
+      reviewDate: reviews.reviewDate,
+    })
+    .from(reviews)
+    .where(eq(reviews.yachtModelId, yachtData.id));
+
+  const reviewData = yachtReviews.length > 0
+    ? yachtReviews.map((r: any) => ({
+        rating: r.rating ? parseFloat(r.rating) : 0,
+        summary: r.summary,
+        authorName: r.authorName,
+        reviewDate: r.reviewDate,
+      }))
+    : undefined;
+
   const jsonLd = generateYachtJsonLd({
     manufacturer: manufacturerName,
     modelName: yachtData.modelName,
@@ -123,6 +143,7 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
     rigType: yachtData.rigType,
     cabins: yachtData.cabins,
     primaryImage: primaryImage?.url,
+    reviews: reviewData,
   });
 
   // Add Offer schema if price data exists

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -83,6 +83,20 @@ export interface JsonLdProduct {
     value: string | number;
     unitCode?: string;
   }>;
+  aggregateRating?: {
+    "@type": "AggregateRating";
+    ratingValue: number;
+    reviewCount: number;
+    bestRating: number;
+    worstRating: number;
+  };
+  review?: Array<{
+    "@type": "Review";
+    author: { "@type": "Person"; name: string };
+    datePublished?: string;
+    reviewRating: { "@type": "Rating"; ratingValue: number; bestRating: number; worstRating: number };
+    reviewBody?: string;
+  }>;
 }
 
 export function generateYachtJsonLd(yacht: {
@@ -99,6 +113,12 @@ export function generateYachtJsonLd(yacht: {
   rigType?: string | null;
   cabins?: number | null;
   primaryImage?: string;
+  reviews?: Array<{
+    rating: number;
+    summary?: string | null;
+    authorName?: string | null;
+    reviewDate?: Date | null;
+  }> | null;
 }): JsonLdProduct {
   const props: JsonLdProduct["additionalProperty"] = [];
 
@@ -110,7 +130,7 @@ export function generateYachtJsonLd(yacht: {
   if (yacht.rigType) props.push({ "@type": "PropertyValue", name: "Rig Type", value: yacht.rigType });
   if (yacht.cabins) props.push({ "@type": "PropertyValue", name: "Cabins", value: yacht.cabins });
 
-  return {
+  const result: JsonLdProduct = {
     "@context": "https://schema.org",
     "@type": "Product",
     name: `${yacht.manufacturer} ${yacht.modelName} (${yacht.year})`,
@@ -123,6 +143,49 @@ export function generateYachtJsonLd(yacht: {
     image: yacht.primaryImage,
     additionalProperty: props,
   };
+
+  // Add AggregateRating and Review entries if reviews exist
+  if (yacht.reviews && yacht.reviews.length > 0) {
+    const ratings = yacht.reviews
+      .map((r) => r.rating)
+      .filter((r) => r > 0);
+    const avgRating =
+      ratings.length > 0
+        ? Math.round((ratings.reduce((a, b) => a + b, 0) / ratings.length) * 10) / 10
+        : 0;
+
+    if (avgRating > 0) {
+      result.aggregateRating = {
+        "@type": "AggregateRating",
+        ratingValue: avgRating,
+        reviewCount: ratings.length,
+        bestRating: 5,
+        worstRating: 1,
+      };
+
+      result.review = yacht.reviews
+        .filter((r) => r.rating > 0)
+        .map((r) => ({
+          "@type": "Review" as const,
+          author: {
+            "@type": "Person" as const,
+            name: r.authorName || "Anonymous",
+          },
+          ...(r.reviewDate
+            ? { datePublished: r.reviewDate.toISOString().split("T")[0] }
+            : {}),
+          reviewRating: {
+            "@type": "Rating" as const,
+            ratingValue: r.rating,
+            bestRating: 5,
+            worstRating: 1,
+          },
+          ...(r.summary ? { reviewBody: r.summary } : {}),
+        }));
+    }
+  }
+
+  return result;
 }
 
 export interface JsonLdBreadcrumb {


### PR DESCRIPTION
## Summary
Adds `AggregateRating` and individual `Review` entries to the Product JSON-LD structured data on yacht detail pages. This enables Google to show star ratings in search results for yachts that have admin-managed reviews.

## Changes
- Updated `JsonLdProduct` interface in `lib/seo.ts` with optional `aggregateRating` and `review` fields
- Modified `generateYachtJsonLd()` to accept optional reviews array and compute average rating
- When reviews exist, adds `AggregateRating` (ratingValue, reviewCount, bestRating=5, worstRating=1) and individual `Review` entries
- Updated yacht detail page (`yacht/[slug]/page.tsx`) to fetch reviews from DB and pass to the JSON-LD generator
- Yachts without reviews gracefully omit rating data (no empty schema)

## Testing
- ✅ Typecheck passes
- ✅ Build passes
- Live verification pending after deploy

Closes #65