### PR TITLE
fix: set JSON-LD bestRating to 10 to match review scale

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -159,7 +159,7 @@ export function generateYachtJsonLd(yacht: {
         "@type": "AggregateRating",
         ratingValue: avgRating,
         reviewCount: ratings.length,
-        bestRating: 5,
+        bestRating: 10,
         worstRating: 1,
       };
 
@@ -177,7 +177,7 @@ export function generateYachtJsonLd(yacht: {
           reviewRating: {
             "@type": "Rating" as const,
             ratingValue: r.rating,
-            bestRating: 5,
+            bestRating: 10,
             worstRating: 1,
           },
           ...(r.summary ? { reviewBody: r.summary } : {}),


### PR DESCRIPTION
Follow-up to #66 (PR #67 had merge conflict). Reviews are on a 1-10 scale, bestRating was incorrectly set to 5.