### PR TITLE
fix: handle string rating from Neon DB in review display

### DIFF
--- a/app/(main)/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/(main)/yachts/[slug]/YachtDetailClient.tsx
@@ -433,7 +433,7 @@ export default function YachtDetailClient() {
                   {review.rating && (
                     <div className="flex items-center gap-1">
                       <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-                      <span>{review.rating.toFixed(1)}</span>
+                      <span>{parseFloat(String(review.rating)).toFixed(1)}</span>
                     </div>
                   )}
                 </div>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -159,7 +159,7 @@ export function generateYachtJsonLd(yacht: {
         "@type": "AggregateRating",
         ratingValue: avgRating,
         reviewCount: ratings.length,
-        bestRating: 5,
+        bestRating: 10,
         worstRating: 1,
       };
 
@@ -177,7 +177,7 @@ export function generateYachtJsonLd(yacht: {
           reviewRating: {
             "@type": "Rating" as const,
             ratingValue: r.rating,
-            bestRating: 5,
+            bestRating: 10,
             worstRating: 1,
           },
           ...(r.summary ? { reviewBody: r.summary } : {}),


### PR DESCRIPTION
Caught during live verification of #65. Neon DB numeric columns return strings, causing `TypeError: e.rating.toFixed is not a function` on yacht detail pages with reviews.