### PR TITLE
feat: add public API v1 with rate limiting, docs, and tests

### DIFF
--- a/app/api/docs/index.md
+++ b/app/api/docs/index.md
@@ -1,0 +1,193 @@
+# Sailing Yachts API Documentation
+
+The public API provides access to sailing yacht data for external applications. All responses follow JSON API conventions with consistent envelope structure and CORS headers.
+
+## Base URL
+```
+https://sailing-yachts.vercel.app/api/v1
+```
+
+## Rate Limiting
+- **Free tier**: 100 requests per minute per IP address
+- **Headers included**: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+- **Rate limit exceeded**: Returns HTTP 429 with Retry-After header
+- **Reset time**: Provided in Unix timestamp
+
+## Response Format
+
+### Success Response
+```json
+{
+  "data": [/* array of objects */],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total": 201,
+    "totalPages": 11
+  }
+}
+```
+
+### Error Response
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Yacht with slug 'test-123' not found",
+    "details": "Additional error details when available"
+  }
+}
+```
+
+## Endpoints
+
+### GET /yachts
+List all yachts with pagination, filtering, and sorting.
+
+**Query Parameters:**
+- `page` (int, default=1) - Page number
+- `limit` (int, default=20, max=100) - Items per page
+- `sort` (string, default="id") - Sort field: `id`, `modelName`, `year`, `lengthOverall`, `beam`, `draft`, `displacement`, `cabins`, `berths`
+- `order` (string, default="asc") - Sort order: `asc` or `desc`
+- `manufacturer` (string) - Filter by manufacturer name (partial match)
+- `manufacturerId` (int) - Filter by manufacturer ID (exact match)
+- `rigType` (string) - Filter by rig type
+- `keelType` (string) - Filter by keel type
+- `hullMaterial` (string) - Filter by hull material
+- `lengthMin` (number) - Minimum length overall (meters)
+- `lengthMax` (number) - Maximum length overall (meters)
+- `yearMin` (int) - Minimum year built
+- `yearMax` (int) - Maximum year built
+- `cabinsMin` (int) - Minimum number of cabins
+
+**Example:**
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/yachts?sort=lengthOverall&order=desc&limit=10"
+```
+
+### GET /yachts/[slug]
+Get single yacht by slug with manufacturer details, images, and reviews.
+
+**Parameters:**
+- `slug` (string) - Yacht slug (e.g., "beneteau-oceanis-30-1")
+
+**Example:**
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/yachts/beneteau-oceanis-30-1"
+```
+
+### GET /manufacturers
+List all manufacturers with yacht count.
+
+**Query Parameters:**
+- `country` (string) - Filter by country (exact match)
+- `name` (string) - Filter by name (partial match)
+
+**Example:**
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/manufacturers?country=France"
+```
+
+### GET /manufacturers/[id]
+Get single manufacturer with all its yachts.
+
+**Parameters:**
+- `id` (int) - Manufacturer ID
+
+**Example:**
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/manufacturers/82"
+```
+
+### GET /search
+Search yachts by name, manufacturer, or other fields.
+
+**Query Parameters:**
+- `q` (string, required) - Search query (min 2 characters)
+- `limit` (int, default=20, max=50) - Maximum results
+
+**Example:**
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/search?q=oceanis&limit=5"
+```
+
+## Data Schema
+
+### Yacht Object
+```typescript
+interface Yacht {
+  id: number;
+  slug: string;
+  modelName: string;
+  manufacturer: {
+    id: number;
+    name: string;
+    country?: string;
+  };
+  year?: number;
+  lengthOverall?: number;
+  beam?: number;
+  draft?: number;
+  displacement?: number;
+  ballast?: number;
+  sailAreaMain?: number;
+  rigType?: string;
+  keelType?: string;
+  hullMaterial?: string;
+  cabins?: number;
+  berths?: number;
+  heads?: number;
+  maxOccupancy?: number;
+  engineHp?: number;
+  engineType?: string;
+  fuelCapacity?: number;
+  waterCapacity?: number;
+  designNotes?: string;
+  description?: string;
+  images?: Image[];
+  reviews?: Review[];
+}
+```
+
+### Manufacturer Object
+```typescript
+interface Manufacturer {
+  id: number;
+  name: string;
+  country?: string;
+  foundedYear?: number;
+  website?: string;
+  description?: string;
+  yachtCount: number;
+  yachts?: YachtBrief[];
+}
+```
+
+## CORS Policy
+All endpoints support cross-origin requests with appropriate headers:
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, OPTIONS`
+- `Access-Control-Allow-Headers: Content-Type, X-API-Key`
+
+## Common Error Codes
+- `INVALID_PARAM` - Invalid request parameter
+- `NOT_FOUND` - Resource not found
+- `RATE_LIMIT_EXCEEDED` - Rate limit exceeded
+- `INTERNAL_ERROR` - Server error
+
+## Examples
+
+### Find all Bavaria Yachts over 30 feet
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/yachts?manufacturer=bavaria&lengthMin=10"
+```
+
+### Search for catamarans
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/search?q=catamaran"
+```
+
+### Get manufacturer with all yachts
+```bash
+curl "https://sailing-yachts.vercel.app/api/v1/manufacturers/57"
+```

--- a/app/api/docs/page.tsx
+++ b/app/api/docs/page.tsx
@@ -1,0 +1,74 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Sailing Yachts API Documentation',
+  description: 'Public API for accessing sailing yacht data from the Sailing Yachts Database',
+};
+
+export default function ApiPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Sailing Yachts API</h1>
+        <p className="text-gray-600">Access sailing yacht data for your applications</p>
+      </div>
+
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-8">
+        <h2 className="text-lg font-semibold mb-2">Quick Links</h2>
+        <ul className="space-y-2">
+          <li>
+            <Link href="/api/v1/yachts" className="text-blue-600 hover:underline">
+              GET /api/v1/yachts
+            </Link>
+            <span className="text-gray-600 ml-2">— List all yachts</span>
+          </li>
+          <li>
+            <Link href="/api/v1/yachts/[slug]" className="text-blue-600 hover:underline">
+              GET /api/v1/yachts/[slug]
+            </Link>
+            <span className="text-gray-600 ml-2">— Single yacht details</span>
+          </li>
+          <li>
+            <Link href="/api/v1/manufacturers" className="text-blue-600 hover:underline">
+              GET /api/v1/manufacturers
+            </Link>
+            <span className="text-gray-600 ml-2">— List manufacturers</span>
+          </li>
+          <li>
+            <Link href="/api/v1/manufacturers/[id]" className="text-blue-600 hover:underline">
+              GET /api/v1/manufacturers/[id]
+            </Link>
+            <span className="text-gray-600 ml-2">— Manufacturer with yachts</span>
+          </li>
+          <li>
+            <Link href="/api/v1/search" className="text-blue-600 hover:underline">
+              GET /api/v1/search
+            </Link>
+            <span className="text-gray-600 ml-2">— Search yachts</span>
+          </li>
+        </ul>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-4">Rate Limits</h2>
+        <p className="mb-2">Free tier: <strong>100 requests per minute</strong> per IP address</p>
+        <p>Response headers include rate limit information: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset</p>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-4">Interactive Testing</h2>
+        <div className="bg-gray-100 rounded-lg p-4 font-mono text-sm">
+          <p className="mb-2">Try from your terminal:</p>
+          <div className="bg-white p-3 rounded border">
+            <p>$ curl "https://sailing-yachts.vercel.app/api/v1/yachts?limit=3"</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="prose prose-blue">
+        <div dangerouslySetInnerHTML={{ __html: '<!-- Include markdown content -->' }} />
+      </div>
+    </div>
+  );
+}

--- a/app/api/v1/manufacturers/[id]/route.ts
+++ b/app/api/v1/manufacturers/[id]/route.ts
@@ -1,0 +1,81 @@
+import { pool } from '@/lib/db';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { apiSuccess, apiError, corsOptionsResponse } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/manufacturers/[id] — Single manufacturer with its yachts.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(ip);
+  if (!rl.allowed) {
+    return apiError('RATE_LIMIT_EXCEEDED', 'Rate limit exceeded.', 429, { rateLimit: rl });
+  }
+
+  try {
+    const manufacturerId = parseInt(params.id, 10);
+    if (isNaN(manufacturerId)) {
+      return apiError('INVALID_PARAM', 'Manufacturer ID must be a number', 400, { rateLimit: rl });
+    }
+
+    const mfrResult = await pool.query(
+      `SELECT id, name, country, founded_year, website_url, description, logo_url
+       FROM manufacturers WHERE id = $1`,
+      [manufacturerId]
+    );
+
+    if (mfrResult.rows.length === 0) {
+      return apiError('NOT_FOUND', `Manufacturer with ID ${manufacturerId} not found`, 404, { rateLimit: rl });
+    }
+
+    const mfr = mfrResult.rows[0];
+
+    const yachtsResult = await pool.query(
+      `SELECT id, model_name, slug, year, length_overall, beam, draft, displacement,
+        rig_type, keel_type, hull_material, cabins, berths
+       FROM yacht_models
+       WHERE manufacturer_id = $1
+       ORDER BY length_overall DESC NULLS LAST`,
+      [manufacturerId]
+    );
+
+    const manufacturer = {
+      id: mfr.id,
+      name: mfr.name,
+      country: mfr.country ?? undefined,
+      foundedYear: mfr.founded_year ?? undefined,
+      website: mfr.website_url ?? undefined,
+      description: mfr.description ?? undefined,
+      logoUrl: mfr.logo_url ?? undefined,
+      yachts: yachtsResult.rows.map((row: any) => ({
+        id: row.id,
+        modelName: row.model_name,
+        slug: row.slug ?? undefined,
+        year: row.year ?? undefined,
+        lengthOverall: row.length_overall != null ? parseFloat(row.length_overall) : undefined,
+        beam: row.beam != null ? parseFloat(row.beam) : undefined,
+        draft: row.draft != null ? parseFloat(row.draft) : undefined,
+        displacement: row.displacement != null ? parseFloat(row.displacement) : undefined,
+        rigType: row.rig_type ?? undefined,
+        keelType: row.keel_type ?? undefined,
+        hullMaterial: row.hull_material ?? undefined,
+        cabins: row.cabins ?? undefined,
+        berths: row.berths ?? undefined,
+      })),
+    };
+
+    return apiSuccess(manufacturer, { rateLimit: rl });
+  } catch (error: any) {
+    console.error('API v1 manufacturer detail error:', error);
+    return apiError('INTERNAL_ERROR', 'Failed to fetch manufacturer', 500, { details: error.message, rateLimit: rl });
+  }
+}
+
+export async function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/app/api/v1/manufacturers/route.ts
+++ b/app/api/v1/manufacturers/route.ts
@@ -1,0 +1,66 @@
+import { pool } from '@/lib/db';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { apiSuccess, apiError, corsOptionsResponse } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/manufacturers — List all manufacturers.
+ * Optional query: country (exact match), name (partial match)
+ */
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(ip);
+  if (!rl.allowed) {
+    return apiError('RATE_LIMIT_EXCEEDED', 'Rate limit exceeded.', 429, { rateLimit: rl });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let idx = 1;
+
+    const country = searchParams.get('country');
+    if (country) {
+      conditions.push(`m.country = $${idx++}`);
+      params.push(country);
+    }
+
+    const name = searchParams.get('name');
+    if (name) {
+      conditions.push(`m.name ILIKE $${idx++}`);
+      params.push(`%${name}%`);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const result = await pool.query(
+      `SELECT m.id, m.name, m.country, m.founded_year, m.website_url, m.description,
+        (SELECT COUNT(*)::int FROM yacht_models y WHERE y.manufacturer_id = m.id) as yacht_count
+       FROM manufacturers m
+       ${where}
+       ORDER BY m.name`,
+      params
+    );
+
+    const manufacturers = result.rows.map((row: any) => ({
+      id: row.id,
+      name: row.name,
+      country: row.country ?? undefined,
+      foundedYear: row.founded_year ?? undefined,
+      website: row.website_url ?? undefined,
+      description: row.description ?? undefined,
+      yachtCount: row.yacht_count,
+    }));
+
+    return apiSuccess(manufacturers, { rateLimit: rl });
+  } catch (error: any) {
+    console.error('API v1 manufacturers error:', error);
+    return apiError('INTERNAL_ERROR', 'Failed to fetch manufacturers', 500, { details: error.message, rateLimit: rl });
+  }
+}
+
+export async function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/app/api/v1/search/route.ts
+++ b/app/api/v1/search/route.ts
@@ -1,0 +1,107 @@
+import { pool } from '@/lib/db';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { apiSuccess, apiError, corsOptionsResponse } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/search?q=...&limit=N — Search yachts by name, manufacturer, rig type, keel type, hull material, description.
+ */
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(ip);
+  if (!rl.allowed) {
+    return apiError('RATE_LIMIT_EXCEEDED', 'Rate limit exceeded.', 429, { rateLimit: rl });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get('q')?.trim();
+    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)));
+
+    if (!q || q.length < 2) {
+      return apiError('INVALID_PARAM', 'Query parameter "q" must be at least 2 characters', 400, { rateLimit: rl });
+    }
+
+    const escapedQ = q.replace(/[%;_]/g, '\\$&');
+
+    const countResult = await pool.query(
+      `SELECT COUNT(*) as total
+       FROM yacht_models y
+       LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+       WHERE (
+         y.model_name ILIKE $1
+         OR m.name ILIKE $1
+         OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
+         OR y.rig_type ILIKE $1
+         OR y.keel_type ILIKE $1
+         OR y.hull_material ILIKE $1
+         OR y.description ILIKE $1
+       )`,
+      [`%${escapedQ}%`]
+    );
+    const total = parseInt(countResult.rows[0]?.total || '0', 10);
+
+    const dataResult = await pool.query(
+      `SELECT
+        y.id, y.model_name, y.slug, y.year,
+        y.length_overall, y.beam, y.draft, y.displacement,
+        y.rig_type, y.keel_type, y.hull_material,
+        y.cabins, y.berths,
+        m.name as manufacturer_name, m.country as manufacturer_country
+       FROM yacht_models y
+       LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+       WHERE (
+         y.model_name ILIKE $1
+         OR m.name ILIKE $1
+         OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
+         OR y.rig_type ILIKE $1
+         OR y.keel_type ILIKE $1
+         OR y.hull_material ILIKE $1
+         OR y.description ILIKE $1
+       )
+       ORDER BY
+         CASE
+           WHEN y.model_name ILIKE $2 THEN 0
+           WHEN m.name ILIKE $2 THEN 1
+           ELSE 2
+         END,
+         y.length_overall DESC NULLS LAST
+       LIMIT $3`,
+      [`%${escapedQ}%`, `${escapedQ}%`, limit]
+    );
+
+    const yachts = dataResult.rows.map((row: any) => ({
+      id: row.id,
+      slug: row.slug ?? undefined,
+      modelName: row.model_name,
+      manufacturer: {
+        id: row.manufacturer_id ?? undefined,
+        name: row.manufacturer_name ?? '',
+        country: row.manufacturer_country ?? undefined,
+      },
+      year: row.year ?? undefined,
+      lengthOverall: row.length_overall != null ? parseFloat(row.length_overall) : undefined,
+      beam: row.beam != null ? parseFloat(row.beam) : undefined,
+      draft: row.draft != null ? parseFloat(row.draft) : undefined,
+      displacement: row.displacement != null ? parseFloat(row.displacement) : undefined,
+      rigType: row.rig_type ?? undefined,
+      keelType: row.keel_type ?? undefined,
+      hullMaterial: row.hull_material ?? undefined,
+      cabins: row.cabins ?? undefined,
+      berths: row.berths ?? undefined,
+    }));
+
+    return apiSuccess(yachts, {
+      meta: { total, limit },
+      rateLimit: rl,
+    });
+  } catch (error: any) {
+    console.error('API v1 search error:', error);
+    return apiError('INTERNAL_ERROR', 'Search failed', 500, { details: error.message, rateLimit: rl });
+  }
+}
+
+export async function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/app/api/v1/yachts/[slug]/route.ts
+++ b/app/api/v1/yachts/[slug]/route.ts
@@ -1,0 +1,109 @@
+import { pool } from '@/lib/db';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { apiSuccess, apiError, corsOptionsResponse } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/yachts/[slug] — Single yacht by slug.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { slug: string } }
+) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(ip);
+  if (!rl.allowed) {
+    return apiError('RATE_LIMIT_EXCEEDED', 'Rate limit exceeded.', 429, { rateLimit: rl });
+  }
+
+  try {
+    const { slug } = params;
+
+    const result = await pool.query(
+      `SELECT
+        y.*,
+        m.name as manufacturer_name, m.country as manufacturer_country,
+        m.website_url as manufacturer_website, m.description as manufacturer_description
+       FROM yacht_models y
+       LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+       WHERE y.slug = $1`,
+      [slug]
+    );
+
+    if (result.rows.length === 0) {
+      return apiError('NOT_FOUND', `Yacht with slug '${slug}' not found`, 404, { rateLimit: rl });
+    }
+
+    const row = result.rows[0];
+
+    // Fetch images
+    const imagesResult = await pool.query(
+      `SELECT id, url, caption, alt_text, is_primary, sort_order FROM images WHERE yacht_model_id = $1 ORDER BY sort_order, id`,
+      [row.id]
+    );
+
+    // Fetch reviews
+    const reviewsResult = await pool.query(
+      `SELECT id, source, rating, summary, author_name, review_date, source_url
+       FROM reviews WHERE yacht_model_id = $1 AND rating IS NOT NULL
+       ORDER BY review_date DESC NULLS LAST`,
+      [row.id]
+    );
+
+    const yacht = {
+      id: row.id,
+      slug: row.slug ?? undefined,
+      modelName: row.model_name,
+      manufacturer: {
+        id: row.manufacturer_id,
+        name: row.manufacturer_name ?? '',
+        country: row.manufacturer_country ?? undefined,
+        website: row.manufacturer_website ?? undefined,
+        description: row.manufacturer_description ?? undefined,
+      },
+      year: row.year ?? undefined,
+      lengthOverall: row.length_overall != null ? parseFloat(row.length_overall) : undefined,
+      beam: row.beam != null ? parseFloat(row.beam) : undefined,
+      draft: row.draft != null ? parseFloat(row.draft) : undefined,
+      displacement: row.displacement != null ? parseFloat(row.displacement) : undefined,
+      ballast: row.ballast != null ? parseFloat(row.ballast) : undefined,
+      sailAreaMain: row.sail_area_main != null ? parseFloat(row.sail_area_main) : undefined,
+      rigType: row.rig_type ?? undefined,
+      keelType: row.keel_type ?? undefined,
+      hullMaterial: row.hull_material ?? undefined,
+      cabins: row.cabins ?? undefined,
+      berths: row.berths ?? undefined,
+      heads: row.heads ?? undefined,
+      maxOccupancy: row.max_occupancy ?? undefined,
+      engineHp: row.engine_hp != null ? parseFloat(row.engine_hp) : undefined,
+      engineType: row.engine_type ?? undefined,
+      fuelCapacity: row.fuel_capacity != null ? parseFloat(row.fuel_capacity) : undefined,
+      waterCapacity: row.water_capacity != null ? parseFloat(row.water_capacity) : undefined,
+      designNotes: row.design_notes ?? undefined,
+      description: row.description ?? undefined,
+      images: imagesResult.rows.map((img: any) => ({
+        url: img.url,
+        caption: img.caption ?? undefined,
+        alt: img.alt_text ?? undefined,
+        isPrimary: img.is_primary ?? false,
+      })),
+      reviews: reviewsResult.rows.map((rev: any) => ({
+        source: rev.source ?? undefined,
+        rating: rev.rating != null ? parseFloat(rev.rating) : undefined,
+        summary: rev.summary ?? undefined,
+        author: rev.author_name ?? undefined,
+        date: rev.review_date ?? undefined,
+      })),
+    };
+
+    return apiSuccess(yacht, { rateLimit: rl });
+  } catch (error: any) {
+    console.error('API v1 yacht detail error:', error);
+    return apiError('INTERNAL_ERROR', 'Failed to fetch yacht', 500, { details: error.message, rateLimit: rl });
+  }
+}
+
+export async function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/app/api/v1/yachts/route.ts
+++ b/app/api/v1/yachts/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+import { checkRateLimit, getClientIp, rateLimitHeaders, DEFAULT_RATE_LIMIT } from '@/lib/rate-limit';
+import { apiSuccess, apiError, corsOptionsResponse } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/yachts — List yachts with pagination, filtering, sorting.
+ *
+ * Query params:
+ *   page (default 1), limit (default 20, max 100)
+ *   sort (id|modelName|year|lengthOverall|beam|draft|displacement|cabins|berths)
+ *   order (asc|desc)
+ *   manufacturer — manufacturer name (partial match)
+ *   manufacturerId — exact manufacturer ID
+ *   rigType, keelType, hullMaterial — exact match
+ *   lengthMin, lengthMax — LOA range in meters
+ *   yearMin, yearMax — year range
+ *   cabinsMin — minimum cabins
+ */
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(ip);
+  if (!rl.allowed) {
+    return apiError('RATE_LIMIT_EXCEEDED', 'Rate limit exceeded. Please slow down.', 429, { rateLimit: rl });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)));
+
+    // Sorting
+    const sortMap: Record<string, string> = {
+      id: 'y.id',
+      modelName: 'y.model_name',
+      year: 'y.year',
+      lengthOverall: 'y.length_overall',
+      beam: 'y.beam',
+      draft: 'y.draft',
+      displacement: 'y.displacement',
+      cabins: 'y.cabins',
+      berths: 'y.berths',
+    };
+    const sortKey = searchParams.get('sort') || 'id';
+    const sortCol = sortMap[sortKey] || 'y.id';
+    const sortOrder = searchParams.get('order')?.toLowerCase() === 'desc' ? 'DESC' : 'ASC';
+
+    // Build filters
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let idx = 1;
+
+    const manufacturer = searchParams.get('manufacturer');
+    if (manufacturer) {
+      conditions.push(`m.name ILIKE $${idx++}`);
+      params.push(`%${manufacturer}%`);
+    }
+
+    const manufacturerId = searchParams.get('manufacturerId');
+    if (manufacturerId) {
+      const mid = parseInt(manufacturerId, 10);
+      if (!isNaN(mid)) {
+        conditions.push(`y.manufacturer_id = $${idx++}`);
+        params.push(mid);
+      }
+    }
+
+    const rigType = searchParams.get('rigType');
+    if (rigType) {
+      conditions.push(`y.rig_type = $${idx++}`);
+      params.push(rigType);
+    }
+
+    const keelType = searchParams.get('keelType');
+    if (keelType) {
+      conditions.push(`y.keel_type = $${idx++}`);
+      params.push(keelType);
+    }
+
+    const hullMaterial = searchParams.get('hullMaterial');
+    if (hullMaterial) {
+      conditions.push(`y.hull_material = $${idx++}`);
+      params.push(hullMaterial);
+    }
+
+    const lengthMin = parseFloat(searchParams.get('lengthMin') || '');
+    if (!isNaN(lengthMin)) {
+      conditions.push(`y.length_overall >= $${idx++}`);
+      params.push(lengthMin);
+    }
+
+    const lengthMax = parseFloat(searchParams.get('lengthMax') || '');
+    if (!isNaN(lengthMax)) {
+      conditions.push(`y.length_overall <= $${idx++}`);
+      params.push(lengthMax);
+    }
+
+    const yearMin = parseInt(searchParams.get('yearMin') || '', 10);
+    if (!isNaN(yearMin)) {
+      conditions.push(`y.year >= $${idx++}`);
+      params.push(yearMin);
+    }
+
+    const yearMax = parseInt(searchParams.get('yearMax') || '', 10);
+    if (!isNaN(yearMax)) {
+      conditions.push(`y.year <= $${idx++}`);
+      params.push(yearMax);
+    }
+
+    const cabinsMin = parseInt(searchParams.get('cabinsMin') || '', 10);
+    if (!isNaN(cabinsMin)) {
+      conditions.push(`y.cabins >= $${idx++}`);
+      params.push(cabinsMin);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Count
+    const countResult = await pool.query(
+      `SELECT COUNT(*)::int as count FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id ${where}`,
+      params
+    );
+    const total = countResult.rows[0]?.count || 0;
+
+    // Data
+    const offset = (page - 1) * limit;
+    const dataResult = await pool.query(
+      `SELECT
+        y.id, y.model_name, y.slug, y.year, y.manufacturer_id,
+        y.length_overall, y.beam, y.draft, y.displacement, y.ballast,
+        y.sail_area_main, y.rig_type, y.keel_type, y.hull_material,
+        y.cabins, y.berths, y.heads, y.max_occupancy,
+        y.engine_hp, y.engine_type, y.fuel_capacity, y.water_capacity,
+        y.design_notes, y.description,
+        m.name as manufacturer_name, m.country as manufacturer_country
+       FROM yacht_models y
+       LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+       ${where}
+       ORDER BY ${sortCol} ${sortOrder} NULLS LAST
+       LIMIT $${idx++} OFFSET $${idx++}`,
+      [...params, limit, offset]
+    );
+
+    const yachts = dataResult.rows.map((row: any) => ({
+      id: row.id,
+      slug: row.slug ?? undefined,
+      modelName: row.model_name,
+      manufacturer: {
+        id: row.manufacturer_id,
+        name: row.manufacturer_name ?? '',
+        country: row.manufacturer_country ?? undefined,
+      },
+      year: row.year ?? undefined,
+      lengthOverall: row.length_overall != null ? parseFloat(row.length_overall) : undefined,
+      beam: row.beam != null ? parseFloat(row.beam) : undefined,
+      draft: row.draft != null ? parseFloat(row.draft) : undefined,
+      displacement: row.displacement != null ? parseFloat(row.displacement) : undefined,
+      ballast: row.ballast != null ? parseFloat(row.ballast) : undefined,
+      sailAreaMain: row.sail_area_main != null ? parseFloat(row.sail_area_main) : undefined,
+      rigType: row.rig_type ?? undefined,
+      keelType: row.keel_type ?? undefined,
+      hullMaterial: row.hull_material ?? undefined,
+      cabins: row.cabins ?? undefined,
+      berths: row.berths ?? undefined,
+      heads: row.heads ?? undefined,
+      maxOccupancy: row.max_occupancy ?? undefined,
+      engineHp: row.engine_hp != null ? parseFloat(row.engine_hp) : undefined,
+      engineType: row.engine_type ?? undefined,
+      fuelCapacity: row.fuel_capacity != null ? parseFloat(row.fuel_capacity) : undefined,
+      waterCapacity: row.water_capacity != null ? parseFloat(row.water_capacity) : undefined,
+      designNotes: row.design_notes ?? undefined,
+      description: row.description ?? undefined,
+    }));
+
+    return apiSuccess(yachts, {
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+      rateLimit: rl,
+    });
+  } catch (error: any) {
+    console.error('API v1 yachts error:', error);
+    return apiError('INTERNAL_ERROR', 'Failed to fetch yachts', 500, { details: error.message, rateLimit: rl });
+  }
+}
+
+export async function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+
+export interface ApiError {
+  error: {
+    code: string;
+    message: string;
+    details?: string;
+  };
+}
+
+/**
+ * Standard CORS headers for the public API.
+ */
+export function corsHeaders(): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, X-API-Key',
+    'Access-Control-Max-Age': '86400',
+    'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+  };
+}
+
+/**
+ * Create a success response with CORS and rate limit headers.
+ */
+export function apiSuccess<T>(
+  data: T,
+  opts?: {
+    meta?: { page?: number; limit?: number; total?: number; totalPages?: number };
+    rateLimit?: { remaining: number; resetAt: number; limit: number };
+    status?: number;
+  }
+): NextResponse {
+  const headers: Record<string, string> = { ...corsHeaders() };
+  if (opts?.rateLimit) {
+    headers['X-RateLimit-Limit'] = String(opts.rateLimit.limit);
+    headers['X-RateLimit-Remaining'] = String(opts.rateLimit.remaining);
+    headers['X-RateLimit-Reset'] = String(Math.ceil(opts.rateLimit.resetAt / 1000));
+  }
+  return NextResponse.json({ data, ...(opts?.meta ? { meta: opts.meta } : {}) }, { status: opts?.status ?? 200, headers });
+}
+
+/**
+ * Create an error response with CORS.
+ */
+export function apiError(
+  code: string,
+  message: string,
+  status: number,
+  opts?: {
+    details?: string;
+    rateLimit?: { remaining: number; resetAt: number; limit: number };
+  }
+): NextResponse {
+  const headers: Record<string, string> = { ...corsHeaders() };
+  if (opts?.rateLimit) {
+    headers['X-RateLimit-Limit'] = String(opts.rateLimit.limit);
+    headers['X-RateLimit-Remaining'] = String(opts.rateLimit.remaining);
+    headers['X-RateLimit-Reset'] = String(Math.ceil(opts.rateLimit.resetAt / 1000));
+  }
+  if (status === 429 && opts?.rateLimit) {
+    headers['Retry-After'] = String(Math.ceil((opts.rateLimit.resetAt - Date.now()) / 1000));
+  }
+  return NextResponse.json(
+    { error: { code, message, details: opts?.details } },
+    { status, headers }
+  );
+}
+
+/**
+ * Handle CORS preflight (OPTIONS).
+ */
+export function corsOptionsResponse(): NextResponse {
+  return new NextResponse(null, { status: 204, headers: corsHeaders() });
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,77 @@
+/**
+ * Simple in-memory rate limiter for API routes.
+ * Uses a sliding window counter per IP/key.
+ */
+
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+// Clean up expired entries every 5 minutes
+if (typeof setInterval !== 'undefined') {
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (now > entry.resetTime) {
+        store.delete(key);
+      }
+    }
+  }, 5 * 60 * 1000);
+}
+
+export interface RateLimitOptions {
+  /** Max requests per window */
+  limit: number;
+  /** Window duration in seconds */
+  windowSeconds: number;
+}
+
+export const DEFAULT_RATE_LIMIT: RateLimitOptions = {
+  limit: 100,
+  windowSeconds: 60,
+};
+
+export function checkRateLimit(
+  key: string,
+  options: RateLimitOptions = DEFAULT_RATE_LIMIT
+): { allowed: boolean; remaining: number; resetAt: number; limit: number } {
+  const now = Date.now();
+  const entry = store.get(key);
+
+  if (!entry || now > entry.resetTime) {
+    // New window
+    const resetAt = now + options.windowSeconds * 1000;
+    store.set(key, { count: 1, resetTime: resetAt });
+    return { allowed: true, remaining: options.limit - 1, resetAt, limit: options.limit };
+  }
+
+  if (entry.count >= options.limit) {
+    return { allowed: false, remaining: 0, resetAt: entry.resetTime, limit: options.limit };
+  }
+
+  entry.count++;
+  return { allowed: true, remaining: options.limit - entry.count, resetAt: entry.resetTime, limit: options.limit };
+}
+
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) {
+    return realIp.trim();
+  }
+  return 'unknown';
+}
+
+export function rateLimitHeaders(result: { remaining: number; resetAt: number; limit: number }): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
+  };
+}

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,49 +1,47 @@
-# Sailing Yachts Builder Session Summary - 2026-04-03
+# Sailing Yachts — Session Notes
 
-## Issue Worked On
-- **Issue #58**: Admin review management (CRUD for yacht reviews)
+## 2026-04-04: AggregateRating JSON-LD + Bug Fixes
 
-## What Was Implemented
-- **Discovered**: The admin review CRUD functionality was already fully implemented!
-  - API routes: `app/api/admin/reviews/route.ts` and `app/api/admin/reviews/[id]/route.ts`
-  - UI pages: `app/(main)/admin/reviews/page.tsx`, `app/(main)/admin/reviews/new/NewReviewForm.tsx`, `app/(main)/admin/reviews/[id]/edit/EditReviewForm.tsx`
-  - Admin dashboard integration
-- **Added**: Missing Playwright E2E tests for admin review management (`tests/admin-reviews.spec.ts`)
-  - 14 test cases covering all CRUD operations
-  - Form validation and error handling
-  - Navigation and access control
-  - Console error monitoring
+### Issue #65: Add AggregateRating to yacht JSON-LD
+- **Status**: ✅ Complete
+- **PRs**: #66 (initial), #68 (bestRating fix), #69 (rating.toFixed fix)
 
-## Build/Test Results
-- **Type-check**: ✅ PASS
-- **Build**: ✅ PASS 
-- **Playwright Tests**: 10/14 passed (70% pass rate)
-  - Passes: auth, navigation, form operations, console errors, date handling
-  - Failures: related to empty database states (table visibility expectations)
-- **CI Pipeline**: ✅ All checks passed (TypeScript, Lint, Build)
-- **Test Coverage**: Comprehensive coverage of admin review management functionality
+### What was implemented
+1. Added `AggregateRating` and `Review` schema entries to yacht Product JSON-LD
+2. Updated `generateYachtJsonLd()` in `lib/seo.ts` to accept optional reviews
+3. Yacht detail page now fetches reviews from DB and passes to JSON-LD generator
+4. Fixed `bestRating` to be 10 (reviews use 1-10 scale, not 1-5)
+5. Fixed pre-existing `TypeError: e.rating.toFixed is not a function` on yacht detail pages with reviews (Neon DB returns numeric columns as strings)
 
-## Deploy Status
-- **Branch**: `feature/issue-58-admin-review-tests`
-- **PR**: #61 (merged successfully)
-- **Vercel**: ✅ Production deployment complete
-- **Auto-deployment**: Successfully deployed to `https://sailing-yachts.vercel.app`
+### Verification
+- ✅ Typecheck: PASS
+- ✅ Build: PASS
+- ✅ All critical pages: OK (/, /yachts, /search, /compare)
+- ✅ API: OK (201 yachts)
+- ✅ JSON-LD: AggregateRating 8.5/10 (3 reviews) + 3 Review entries on beneteau-oceanis-30-1
+- ✅ Browser console: No JS errors (only pre-existing 404 for test image on example.com)
+- ✅ Page snapshot: Full render confirmed
 
-## Live Verification Results
-- **Critical Pages**: ✅ All pass
-  - `/` - OK
-  - `/yachts` - OK  
-  - `/search` - OK
-  - `/compare` - OK
-- **API**: ✅ Returns valid data (201 yachts)
-- **Client-side**: ✅ No console errors detected
+### Key findings
+- Reviews in the database use a 1-10 scale, not 1-5
+- Neon DB numeric columns return strings — always use `parseFloat()` before `.toFixed()`
+- Only 1 yacht has reviews: beneteau-oceanis-30-1 (6 reviews in DB, 3 with non-null ratings)
+- The `reviews` table has columns: rating (numeric), summary, authorName, reviewDate, source
 
-## Issues Found and Fixed
-- **Syntax Errors**: Fixed template string issues in test file (backtick and quote problems)
-- **Test Robustness**: Adjusted tests to handle empty database states gracefully
-- **Test Limitations**: Some tests expect UI elements that only appear with data
+### Pre-existing test failures (not caused by this change)
+- admin-reviews tests: table/heading not found (6 failures)
+- compare tests: strict mode violation, table not loading (3 failures)
+- embed-compare: regex syntax error in test, target assertion (2 failures)
+- filter-presets: URL encoding mismatch (%5B vs [) (3 failures)
+- favorites/mobile-ux/newsletter: localhost:3000 not running (~30 failures)
+- price-tier: element not found (2 failures)
+- print-spec-sheet: timeout clicking yacht link (3 failures)
 
-## Next Recommended Task
-- Admin review CRUD functionality is complete and well-tested
-- Consider adding sample review data to improve test coverage for edit/delete operations
-- Review ROADMAP.md for next auto-build items if no other issues exist
+### ROADMAP status
+- Phase 5 item "Yacht review system" now complete
+- Remaining Phase 5 items:
+  - [ ] API for external consumption (rate-limited, documented)
+  - [ ] Performance monitoring (Core Web Vitals tracking)
+
+### Next recommended task
+- Pick from remaining Phase 5 items, or Phase 4 (Yacht manufacturer guides on sailboats.fr linking back to database)

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Public API v1 Endpoints', () => {
+  const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://sailing-yachts.vercel.app';
+
+  test.describe('/api/v1/yachts', () => {
+    test('should return valid yacht list with pagination', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts?limit=3`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      expect(Array.isArray(data.data)).toBe(true);
+      expect(data.data.length).toBeLessThanOrEqual(3);
+      expect(data).toHaveProperty('meta');
+    });
+
+    test('should support sorting and filtering', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts?sort=year&order=desc&limit=5`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      const yachts = data.data;
+      
+      // Check that yachts are sorted by year descending
+      for (let i = 0; i < yachts.length - 1; i++) {
+        if (yachts[i].year && yachts[i + 1].year) {
+          expect(yachts[i].year).toBeGreaterThanOrEqual(yachts[i + 1].year);
+        }
+      }
+    });
+
+    test('should support manufacturer filtering', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts?manufacturer=bavaria&limit=5`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      const yachts = data.data;
+      
+      // All yachts should match "bavaria" in manufacturer name
+      yachts.forEach((yacht: any) => {
+        if (yacht.manufacturer.name) {
+          expect(yacht.manufacturer.name.toLowerCase()).toContain('bavaria');
+        }
+      });
+    });
+
+    test('should include CORS headers', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts?limit=1`);
+      expect(response.headers()).toMatchObject({
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, OPTIONS',
+      });
+    });
+  });
+
+  test.describe('/api/v1/yachts/[slug]', () => {
+    test('should return single yacht by slug', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts/beneteau-oceanis-30-1`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      expect(data.data).toHaveProperty('slug', 'beneteau-oceanis-30-1');
+      expect(data.data).toHaveProperty('manufacturer');
+    });
+
+    test('should return 404 for non-existent slug', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts/non-existent-slug`);
+      expect(response.status()).toBe(404);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+      expect(data.error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  test.describe('/api/v1/manufacturers', () => {
+    test('should return valid manufacturer list', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/manufacturers?limit=5`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      expect(Array.isArray(data.data)).toBe(true);
+      expect(data.data.length).toBeLessThanOrEqual(5);
+      expect(data.data[0]).toHaveProperty('id');
+      expect(data.data[0]).toHaveProperty('name');
+      expect(data.data[0]).toHaveProperty('yachtCount');
+    });
+
+    test('should support country filtering', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/manufacturers?country=France`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      data.data.forEach((mfr: any) => {
+        if (mfr.country) {
+          expect(mfr.country).toBe('France');
+        }
+      });
+    });
+  });
+
+  test.describe('/api/v1/manufacturers/[id]', () => {
+    test('should return single manufacturer with yachts', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/manufacturers/82`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      expect(data.data).toHaveProperty('yachts');
+      expect(Array.isArray(data.data.yachts)).toBe(true);
+    });
+
+    test('should return 404 for non-existent ID', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/manufacturers/999999`);
+      expect(response.status()).toBe(404);
+    });
+  });
+
+  test.describe('/api/v1/search', () => {
+    test('should return search results', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/search?q=oceanis&limit=5`);
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('data');
+      expect(Array.isArray(data.data)).toBe(true);
+      expect(data.meta).toHaveProperty('total');
+    });
+
+    test('should require valid query parameter', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/search?q=a`);
+      expect(response.status()).toBe(400);
+
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+      expect(data.error.code).toBe('INVALID_PARAM');
+    });
+  });
+
+  test.describe('Rate Limiting', () => {
+    test('should include rate limit headers in responses', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/yachts?limit=1`);
+      expect(response.headers()).toHaveProperty('x-ratelimit-limit');
+      expect(response.headers()).toHaveProperty('x-ratelimit-remaining');
+      expect(response.headers()).toHaveProperty('x-ratelimit-reset');
+    });
+  });
+});


### PR DESCRIPTION
- GET /api/v1/yachts with pagination, filtering, sorting
- GET /api/v1/yachts/[slug] with details, images, reviews
- GET /api/v1/manufacturers with yacht counts
- GET /api/v1/manufacturers/[id] with all yachts
- GET /api/v1/search with full-text search
- Rate limiting (100 req/min per IP)
- CORS headers for public access
- API documentation at /api/docs
- Playwright tests for all endpoints
- Consistent JSON response format

Closes #70
