### PR TITLE
P6.6: Split sitemaps + image sitemap with lastmod from DB

### DIFF
--- a/app/(main)/robots.txt/route.ts
+++ b/app/(main)/robots.txt/route.ts
@@ -1,12 +1,19 @@
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://sailing-yachts.vercel.app";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const body = `User-agent: *
 Allow: /
 
 # Sitemaps
 Sitemap: ${SITE_URL}/sitemap.xml
+Sitemap: ${SITE_URL}/sitemap-yachts.xml
+Sitemap: ${SITE_URL}/sitemap-manufacturers.xml
+Sitemap: ${SITE_URL}/sitemap-compare.xml
+Sitemap: ${SITE_URL}/sitemap-images.xml
+Sitemap: ${SITE_URL}/sitemap-pages.xml
 
 # Crawl-delay (polite crawling)
 Crawl-delay: 1

--- a/app/(main)/sitemap-compare.xml/route.ts
+++ b/app/(main)/sitemap-compare.xml/route.ts
@@ -1,0 +1,51 @@
+import { unstable_cache } from "next/cache";
+import { db, yachtModels } from "@/lib/db";
+import { isNotNull } from "drizzle-orm";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 3600;
+
+async function getCompareEntries(): Promise<SitemapEntry[]> {
+  return unstable_cache(
+    async () => {
+      // Fetch top 50 yachts by ID for comparison pairs
+      const topYachts = await db
+        .select({ id: yachtModels.id, slug: yachtModels.slug })
+        .from(yachtModels)
+        .where(isNotNull(yachtModels.slug))
+        .limit(50)
+        .orderBy(yachtModels.id);
+
+      const entries: SitemapEntry[] = [];
+
+      for (let i = 0; i < topYachts.length; i++) {
+        for (let j = i + 1; j < topYachts.length; j++) {
+          const yachtA = topYachts[i];
+          const yachtB = topYachts[j];
+
+          if (yachtA.slug && yachtB.slug) {
+            entries.push({
+              loc: `${SITE_URL}/compare/${yachtA.slug}-vs-${yachtB.slug}`,
+              changefreq: "monthly",
+              priority: "0.5",
+            });
+          }
+        }
+      }
+
+      return entries;
+    },
+    ["sitemap-compare"],
+    { tags: ["yachts"], revalidate: 3600 }
+  )();
+}
+
+export async function GET() {
+  try {
+    const entries = await getCompareEntries();
+    return sitemapResponse(buildSitemapXml(entries));
+  } catch (error) {
+    console.error("[sitemap-compare] Error:", error);
+    return sitemapResponse(buildSitemapXml([]));
+  }
+}

--- a/app/(main)/sitemap-images.xml/route.ts
+++ b/app/(main)/sitemap-images.xml/route.ts
@@ -1,0 +1,71 @@
+import { unstable_cache } from "next/cache";
+import { db, yachtModels, images } from "@/lib/db";
+import { isNotNull, eq, sql } from "drizzle-orm";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 3600;
+
+async function getImageEntries(): Promise<SitemapEntry[]> {
+  return unstable_cache(
+    async () => {
+      // Join yachts with their images to build the image sitemap
+      const rows = await db
+        .select({
+          yachtSlug: yachtModels.slug,
+          imageUrl: images.url,
+          caption: images.caption,
+          altText: images.altText,
+        })
+        .from(yachtModels)
+        .innerJoin(images, eq(images.yachtModelId, yachtModels.id))
+        .where(isNotNull(yachtModels.slug))
+        .orderBy(yachtModels.id);
+
+      // Group by yacht slug
+      const yachtImageMap = new Map<
+        string,
+        Array<{ loc: string; caption?: string; title?: string }>
+      >();
+
+      for (const row of rows) {
+        if (!row.yachtSlug) continue;
+        const slug = row.yachtSlug;
+
+        if (!yachtImageMap.has(slug)) {
+          yachtImageMap.set(slug, []);
+        }
+
+        yachtImageMap.get(slug)!.push({
+          loc: row.imageUrl,
+          caption: row.caption || row.altText || undefined,
+          title: row.altText || undefined,
+        });
+      }
+
+      // Build entries, limiting to 10 images per yacht (Google's recommendation)
+      const entries: SitemapEntry[] = [];
+      for (const [slug, imgs] of yachtImageMap) {
+        entries.push({
+          loc: `${SITE_URL}/yachts/${slug}`,
+          changefreq: "weekly",
+          priority: "0.7",
+          images: imgs.slice(0, 10),
+        });
+      }
+
+      return entries;
+    },
+    ["sitemap-images"],
+    { tags: ["yachts"], revalidate: 3600 }
+  )();
+}
+
+export async function GET() {
+  try {
+    const entries = await getImageEntries();
+    return sitemapResponse(buildSitemapXml(entries));
+  } catch (error) {
+    console.error("[sitemap-images] Error:", error);
+    return sitemapResponse(buildSitemapXml([]));
+  }
+}

--- a/app/(main)/sitemap-manufacturers.xml/route.ts
+++ b/app/(main)/sitemap-manufacturers.xml/route.ts
@@ -1,0 +1,38 @@
+import { unstable_cache } from "next/cache";
+import { db, manufacturers } from "@/lib/db";
+import { slugify } from "@/lib/utils/slugify";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 3600;
+
+async function getManufacturerEntries(): Promise<SitemapEntry[]> {
+  return unstable_cache(
+    async () => {
+      const mfrs = await db
+        .select({
+          name: manufacturers.name,
+        })
+        .from(manufacturers);
+
+      return mfrs
+        .filter((m: { name: string | null }) => m.name !== null)
+        .map((m: { name: string | null }) => ({
+          loc: `${SITE_URL}/manufacturers/${slugify(m.name!)}`,
+          changefreq: "weekly" as const,
+          priority: "0.6",
+        }));
+    },
+    ["sitemap-manufacturers"],
+    { tags: ["manufacturers"], revalidate: 3600 }
+  )();
+}
+
+export async function GET() {
+  try {
+    const entries = await getManufacturerEntries();
+    return sitemapResponse(buildSitemapXml(entries));
+  } catch (error) {
+    console.error("[sitemap-manufacturers] Error:", error);
+    return sitemapResponse(buildSitemapXml([]));
+  }
+}

--- a/app/(main)/sitemap-pages.xml/route.ts
+++ b/app/(main)/sitemap-pages.xml/route.ts
@@ -1,0 +1,24 @@
+import { LANDING_PAGES } from "@/data/landing-pages";
+import type { LandingPageDefinition } from "@/data/landing-pages";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 86400;
+
+export async function GET() {
+  const entries: SitemapEntry[] = [
+    { loc: `${SITE_URL}/`, changefreq: "daily", priority: "1.0" },
+    { loc: `${SITE_URL}/yachts`, changefreq: "daily", priority: "0.9" },
+    { loc: `${SITE_URL}/manufacturers`, changefreq: "weekly", priority: "0.8" },
+    { loc: `${SITE_URL}/compare`, changefreq: "weekly", priority: "0.7" },
+    { loc: `${SITE_URL}/search`, changefreq: "monthly", priority: "0.6" },
+    { loc: `${SITE_URL}/favorites`, changefreq: "monthly", priority: "0.4" },
+    // Landing pages from /best/[slug]
+    ...LANDING_PAGES.map((lp: LandingPageDefinition) => ({
+      loc: `${SITE_URL}/best/${lp.slug}`,
+      changefreq: "weekly" as const,
+      priority: "0.8",
+    })),
+  ];
+
+  return sitemapResponse(buildSitemapXml(entries));
+}

--- a/app/(main)/sitemap-yachts.xml/route.ts
+++ b/app/(main)/sitemap-yachts.xml/route.ts
@@ -1,0 +1,40 @@
+import { unstable_cache } from "next/cache";
+import { db, yachtModels } from "@/lib/db";
+import { isNotNull } from "drizzle-orm";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 3600;
+
+async function getYachtEntries(): Promise<SitemapEntry[]> {
+  return unstable_cache(
+    async () => {
+      const yachts: Array<{ slug: string | null; updatedAt: Date | null }> =
+        await db
+          .select({
+            slug: yachtModels.slug,
+            updatedAt: yachtModels.updatedAt,
+          })
+          .from(yachtModels)
+          .where(isNotNull(yachtModels.slug));
+
+      return yachts.map((y: { slug: string | null; updatedAt: Date | null }) => ({
+        loc: `${SITE_URL}/yachts/${y.slug}`,
+        lastmod: y.updatedAt ? new Date(y.updatedAt).toISOString() : undefined,
+        changefreq: "weekly" as const,
+        priority: "0.8",
+      }));
+    },
+    ["sitemap-yachts"],
+    { tags: ["yachts"], revalidate: 3600 }
+  )();
+}
+
+export async function GET() {
+  try {
+    const entries = await getYachtEntries();
+    return sitemapResponse(buildSitemapXml(entries));
+  } catch (error) {
+    console.error("[sitemap-yachts] Error:", error);
+    return sitemapResponse(buildSitemapXml([]));
+  }
+}

--- a/app/(main)/sitemap.xml/route.ts
+++ b/app/(main)/sitemap.xml/route.ts
@@ -1,155 +1,46 @@
 import { unstable_cache } from "next/cache";
 import { db, yachtModels, manufacturers } from "@/lib/db";
-import { isNotNull } from "drizzle-orm";
-import { slugify } from "@/lib/utils/slugify";
-import { pool } from "@/lib/db";
+import { isNotNull, sql } from "drizzle-orm";
+import {
+  SITE_URL,
+  buildSitemapIndexXml,
+  sitemapResponse,
+} from "@/lib/sitemap";
 
-// ISR: Revalidate sitemap every hour
+// ISR: Revalidate sitemap index every hour
 export const revalidate = 3600;
 
-const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://sailing-yachts.vercel.app";
-
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
-interface SitemapEntry {
-  loc: string;
-  lastmod?: string;
-  changefreq?: string;
-  priority?: string;
-}
-
-function buildUrl(entry: SitemapEntry): string {
-  const lastmod = entry.lastmod
-    ? `<lastmod>${escapeXml(entry.lastmod)}</lastmod>`
-    : "";
-  const changefreq = entry.changefreq
-    ? `<changefreq>${escapeXml(entry.changefreq)}</changefreq>`
-    : "";
-  const priority = entry.priority
-    ? `<priority>${escapeXml(entry.priority)}</priority>`
-    : "";
-
-  return `  <url>
-    <loc>${escapeXml(entry.loc)}</loc>
-    ${lastmod}${changefreq}${priority}
-  </url>`;
-}
-
-// Cache sitemap entries with tags for invalidation
-async function getSitemapEntries(): Promise<SitemapEntry[]> {
-  return unstable_cache(
-    async () => {
-      // Fetch yacht slugs with updatedAt
-      const yachts: Array<{ slug: string | null; updatedAt: Date | null }> =
-        await db
-          .select({
-            slug: yachtModels.slug,
-            updatedAt: yachtModels.updatedAt,
-          })
-          .from(yachtModels);
-
-      // Fetch manufacturers
-      const mfrs: Array<{ id: number | null; name: string | null }> =
-        await db.select({ id: manufacturers.id, name: manufacturers.name }).from(manufacturers);
-
-      const entries: SitemapEntry[] = [
-        // Static pages
-        { loc: `${SITE_URL}/`, changefreq: "daily", priority: "1.0" },
-        { loc: `${SITE_URL}/yachts`, changefreq: "daily", priority: "0.9" },
-        { loc: `${SITE_URL}/manufacturers`, changefreq: "weekly", priority: "0.8" },
-        { loc: `${SITE_URL}/compare`, changefreq: "weekly", priority: "0.7" },
-      ];
-
-      // Dynamic yacht pages
-      for (const y of yachts) {
-        if (y.slug) {
-          entries.push({
-            loc: `${SITE_URL}/yachts/${y.slug}`,
-            lastmod: y.updatedAt ? new Date(y.updatedAt).toISOString() : undefined,
-            changefreq: "weekly",
-            priority: "0.8",
-          });
-        }
-      }
-
-      // Dynamic manufacturer pages
-      for (const m of mfrs) {
-        if (m.name) {
-          const slug = slugify(m.name);
-          entries.push({
-            loc: `${SITE_URL}/manufacturers/${slug}`,
-            changefreq: "weekly",
-            priority: "0.6",
-          });
-        }
-      }
-
-      // Canonical comparison pages (subset of popular pairs)
-      // We limit to top yachts by ID to keep sitemap manageable
-      const topYachtIds = await pool.query(
-        `SELECT id, slug FROM yacht_models WHERE id <= 50 ORDER BY id`
-      );
-      
-      const topYachts = topYachtIds.rows as Array<{ id: number; slug: string }>;
-      
-      // Generate comparison pairs for top 50 yachts
-      for (let i = 0; i < topYachts.length; i++) {
-        for (let j = i + 1; j < topYachts.length; j++) {
-          const yachtA = topYachts[i];
-          const yachtB = topYachts[j];
-          
-          if (yachtA.slug && yachtB.slug) {
-            entries.push({
-              loc: `${SITE_URL}/compare/${yachtA.slug}-vs-${yachtB.slug}`,
-              changefreq: "monthly",
-              priority: "0.5",
-            });
-          }
-        }
-      }
-
-      return entries;
-    },
-    ["sitemap-entries"],
-    { tags: ["yachts", "manufacturers"], revalidate: 3600 }
-  )();
+async function getLastMod(): Promise<string> {
+  const result = await db
+    .select({ maxUpdate: sql<string>`COALESCE(MAX(${yachtModels.updatedAt}), NOW())` })
+    .from(yachtModels);
+  return new Date(result[0]?.maxUpdate || Date.now()).toISOString();
 }
 
 export async function GET() {
   try {
-    const entries = await getSitemapEntries();
+    const lastmod = await getLastMod();
 
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${entries.map(buildUrl).join("\n")}
-</urlset>`;
+    const sitemaps = [
+      { loc: `${SITE_URL}/sitemap-pages.xml`, lastmod },
+      { loc: `${SITE_URL}/sitemap-yachts.xml`, lastmod },
+      { loc: `${SITE_URL}/sitemap-manufacturers.xml`, lastmod },
+      { loc: `${SITE_URL}/sitemap-compare.xml`, lastmod },
+      { loc: `${SITE_URL}/sitemap-images.xml`, lastmod },
+    ];
 
-    return new Response(xml, {
-      headers: {
-        "Content-Type": "application/xml",
-        "Cache-Control": "public, max-age=3600, s-maxage=3600",
-      },
-    });
+    const xml = buildSitemapIndexXml(sitemaps);
+    return sitemapResponse(xml);
   } catch (error) {
-    console.error("[sitemap] Error generating sitemap:", error);
+    console.error("[sitemap-index] Error:", error);
 
-    // Return a minimal valid sitemap even on error
+    // Return a minimal valid sitemap index on error
     const fallback = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>${SITE_URL}/</loc>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>`;
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>${SITE_URL}/sitemap-pages.xml</loc>
+  </sitemap>
+</sitemapindex>`;
 
     return new Response(fallback, {
       status: 200,

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared sitemap utilities for generating XML sitemap entries.
+ */
+
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://sailing-yachts.vercel.app";
+
+export function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+  changefreq?: string;
+  priority?: string;
+  /** Image extensions for image sitemap */
+  images?: Array<{
+    loc: string;
+    caption?: string;
+    title?: string;
+  }>;
+}
+
+export function buildUrl(entry: SitemapEntry): string {
+  const lastmod = entry.lastmod
+    ? `<lastmod>${escapeXml(entry.lastmod)}</lastmod>`
+    : "";
+  const changefreq = entry.changefreq
+    ? `<changefreq>${escapeXml(entry.changefreq)}</changefreq>`
+    : "";
+  const priority = entry.priority
+    ? `<priority>${escapeXml(entry.priority)}</priority>`
+    : "";
+
+  const imageTags = entry.images
+    ? entry.images
+        .map(
+          (img) =>
+            `    <image:image>
+      <image:loc>${escapeXml(img.loc)}</image:loc>${
+              img.caption
+                ? `\n      <image:caption>${escapeXml(img.caption)}</image:caption>`
+                : ""
+            }${
+              img.title
+                ? `\n      <image:title>${escapeXml(img.title)}</image:title>`
+                : ""
+            }
+    </image:image>`
+        )
+        .join("\n")
+    : "";
+
+  return `  <url>
+    <loc>${escapeXml(entry.loc)}</loc>
+    ${lastmod}${changefreq}${priority}${imageTags ? "\n" + imageTags : ""}
+  </url>`;
+}
+
+export function buildSitemapXml(entries: SitemapEntry[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+${entries.map(buildUrl).join("\n")}
+</urlset>`;
+}
+
+export function buildSitemapIndexXml(
+  sitemaps: Array<{ loc: string; lastmod?: string }>
+): string {
+  const entries = sitemaps
+    .map(
+      (s) =>
+        `  <sitemap>
+    <loc>${escapeXml(s.loc)}</loc>${
+          s.lastmod ? `\n    <lastmod>${escapeXml(s.lastmod)}</lastmod>` : ""
+        }
+  </sitemap>`
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</sitemapindex>`;
+}
+
+export function sitemapResponse(xml: string): Response {
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/tests/sitemap-split.spec.ts
+++ b/tests/sitemap-split.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Split Sitemap System", () => {
+  const BASE = process.env.PLAYWRIGHT_BASE_URL || "https://sailing-yachts.vercel.app";
+
+  test("sitemap index should be valid XML with sub-sitemaps", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap.xml`);
+    expect(resp.status()).toBe(200);
+    expect(resp.headers()["content-type"]).toContain("xml");
+
+    const xml = await resp.text();
+
+    // Validate it's a sitemap index
+    expect(xml).toContain("<sitemapindex");
+    expect(xml).toContain("</sitemapindex>");
+
+    // Validate all sub-sitemaps are listed
+    expect(xml).toContain("/sitemap-pages.xml");
+    expect(xml).toContain("/sitemap-yachts.xml");
+    expect(xml).toContain("/sitemap-manufacturers.xml");
+    expect(xml).toContain("/sitemap-compare.xml");
+    expect(xml).toContain("/sitemap-images.xml");
+
+    // Each sub-sitemap should have a <sitemap> wrapper with <loc>
+    const sitemapCount = (xml.match(/<sitemap>/g) || []).length;
+    expect(sitemapCount).toBe(5);
+  });
+
+  test("sitemap-pages.xml should list static pages", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap-pages.xml`);
+    expect(resp.status()).toBe(200);
+    expect(resp.headers()["content-type"]).toContain("xml");
+
+    const xml = await resp.text();
+
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain("</urlset>");
+
+    // Must contain core pages
+    expect(xml).toContain("/yachts");
+    expect(xml).toContain("/manufacturers");
+    expect(xml).toContain("/compare");
+    expect(xml).toContain("/search");
+
+    // Verify URL entries have required fields
+    expect(xml).toContain("<loc>");
+    expect(xml).toContain("<priority>");
+  });
+
+  test("sitemap-yachts.xml should list yacht pages with lastmod", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap-yachts.xml`);
+    expect(resp.status()).toBe(200);
+
+    const xml = await resp.text();
+
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain("/yachts/");
+    expect(xml).toContain("<lastmod>");
+
+    // Should have multiple yacht entries
+    const urlCount = (xml.match(/<url>/g) || []).length;
+    expect(urlCount).toBeGreaterThan(10);
+  });
+
+  test("sitemap-manufacturers.xml should list manufacturer pages", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap-manufacturers.xml`);
+    expect(resp.status()).toBe(200);
+
+    const xml = await resp.text();
+
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain("/manufacturers/");
+
+    // Should have multiple manufacturer entries
+    const urlCount = (xml.match(/<url>/g) || []).length;
+    expect(urlCount).toBeGreaterThan(5);
+  });
+
+  test("sitemap-compare.xml should list comparison pages", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap-compare.xml`);
+    expect(resp.status()).toBe(200);
+
+    const xml = await resp.text();
+
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain("/compare/");
+    expect(xml).toContain("-vs-");
+
+    // Should have comparison pair entries
+    const urlCount = (xml.match(/<url>/g) || []).length;
+    expect(urlCount).toBeGreaterThan(0);
+  });
+
+  test("sitemap-images.xml should include image:image tags", async ({ request }) => {
+    const resp = await request.get(`${BASE}/sitemap-images.xml`);
+    expect(resp.status()).toBe(200);
+
+    const xml = await resp.text();
+
+    expect(xml).toContain("<urlset");
+    // Should include image namespace
+    expect(xml).toContain("xmlns:image");
+
+    // If there are entries, they should have image:image children
+    const urlCount = (xml.match(/<url>/g) || []).length;
+    if (urlCount > 0) {
+      expect(xml).toContain("<image:image>");
+      expect(xml).toContain("<image:loc>");
+    }
+  });
+
+  test("robots.txt should reference all sitemaps", async ({ request }) => {
+    const resp = await request.get(`${BASE}/robots.txt`);
+    expect(resp.status()).toBe(200);
+
+    const text = await resp.text();
+
+    // Should allow all crawlers
+    expect(text).toContain("User-agent: *");
+    expect(text).toContain("Allow: /");
+
+    // Should reference the main sitemap index
+    expect(text).toContain("Sitemap:");
+    expect(text).toContain("/sitemap.xml");
+
+    // Should also reference individual sitemaps for broader crawl coverage
+    expect(text).toContain("/sitemap-yachts.xml");
+    expect(text).toContain("/sitemap-manufacturers.xml");
+    expect(text).toContain("/sitemap-compare.xml");
+    expect(text).toContain("/sitemap-images.xml");
+  });
+});
+
+test.describe("Sitemap XML Validity", () => {
+  const BASE = process.env.PLAYWRIGHT_BASE_URL || "https://sailing-yachts.vercel.app";
+
+  async function validateXmlStructure(request: any, url: string) {
+    const resp = await request.get(url);
+    expect(resp.status()).toBe(200);
+
+    const xml = await resp.text();
+
+    // Must start with XML declaration
+    expect(xml.startsWith("<?xml")).toBe(true);
+
+    // No unescaped ampersands (except in entities)
+    const bodyWithoutEntities = xml.replace(/&[a-z]+;/g, "").replace(/&#\d+;/g, "");
+    const unescapedAmpersands = (bodyWithoutEntities.match(/&/g) || []).length;
+    expect(unescapedAmpersands).toBe(0);
+  }
+
+  test("sitemap index has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap.xml`);
+  });
+
+  test("sitemap-pages.xml has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap-pages.xml`);
+  });
+
+  test("sitemap-yachts.xml has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap-yachts.xml`);
+  });
+
+  test("sitemap-manufacturers.xml has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap-manufacturers.xml`);
+  });
+
+  test("sitemap-compare.xml has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap-compare.xml`);
+  });
+
+  test("sitemap-images.xml has valid XML structure", async ({ request }) => {
+    await validateXmlStructure(request, `${BASE}/sitemap-images.xml`);
+  });
+});


### PR DESCRIPTION
Implements P6.6 from FUTURE_ROADMAP.md

**Changes:**
- Create sitemap index at /sitemap.xml referencing 5 sub-sitemaps
- Add /sitemap-pages.xml for static pages + landing pages (/best/*)
- Add /sitemap-yachts.xml with lastmod timestamps from DB
- Add /sitemap-manufacturers.xml for all manufacturers
- Add /sitemap-compare.xml for canonical X vs Y comparison pages
- Add /sitemap-images.xml with image:image tags for Google image search
- Update robots.txt to list all sitemaps explicitly
- Add shared lib/sitemap.ts utilities (escapeXml, buildUrl, buildSitemapXml)
- Add comprehensive Playwright test coverage (13 tests)
- Use unstable_cache with tag-based revalidation (tags: yachts, manufacturers)

**SEO Impact:**
- Better crawl efficiency with split sitemaps
- Image sitemap for enhanced image search visibility
- Accurate lastmod timestamps for better crawl scheduling
- Individual sitemaps for targeted revalidation when data changes