### PR TITLE
feat: Manufacturer spotlights with history, positioning, notable models (P7.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out
 test-results/
 tsconfig.tsbuildinfo
 .env*.local
+.env.vercel

--- a/app/(main)/manufacturers/[slug]/page.tsx
+++ b/app/(main)/manufacturers/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   getManufacturerBySlug,
   getYachtsByManufacturerId,
 } from "@/lib/manufacturers";
+import { getSpotlightByManufacturerId } from "@/lib/manufacturer-spotlights";
 import { ManufacturerComparisons } from "./ManufacturerComparisons";
 
 // ISR: Revalidate manufacturer detail pages every hour
@@ -24,9 +25,12 @@ async function getManufacturerData(slug: string) {
       const manufacturer = await getManufacturerBySlug(slug);
       if (!manufacturer) return null;
 
-      const yachts = await getYachtsByManufacturerId(manufacturer.id);
+      const [yachts, spotlight] = await Promise.all([
+        getYachtsByManufacturerId(manufacturer.id),
+        getSpotlightByManufacturerId(manufacturer.id),
+      ]);
 
-      return { manufacturer, yachts };
+      return { manufacturer, yachts, spotlight };
     },
     [`manufacturer:${slug}`],
     { tags: [`manufacturer:${slug}`, "manufacturers"], revalidate: 3600 }
@@ -104,7 +108,7 @@ export default async function ManufacturerPage({
     notFound();
   }
 
-  const { manufacturer, yachts } = data;
+  const { manufacturer, yachts, spotlight } = data;
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
@@ -220,6 +224,32 @@ export default async function ManufacturerPage({
             </div>
           </div>
         </section>
+
+        {spotlight && (
+          <section className="mt-8 rounded-2xl border border-sky-200 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 sm:p-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-3xl">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em] text-sky-700">
+                  Manufacturer Spotlight
+                </p>
+                <h2 className="mt-3 text-2xl font-bold tracking-tight">
+                  Read our {manufacturer.name} spotlight
+                </h2>
+                <p className="mt-3 text-muted-foreground leading-relaxed">
+                  {spotlight.metaDescription ||
+                    `Go deeper on ${manufacturer.name}'s history, brand positioning, major milestones, and notable yacht models.`}
+                </p>
+              </div>
+
+              <Link
+                href={`/manufacturers/${manufacturer.slug}/spotlight`}
+                className="inline-flex items-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 transition-colors"
+              >
+                Open spotlight →
+              </Link>
+            </div>
+          </section>
+        )}
 
 
         {/* Cross-linking: Browse by Size */}

--- a/app/(main)/manufacturers/[slug]/spotlight/page.tsx
+++ b/app/(main)/manufacturers/[slug]/spotlight/page.tsx
@@ -1,0 +1,384 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { unstable_cache } from "next/cache";
+import { notFound } from "next/navigation";
+import { marked } from "marked";
+
+import { getSpotlightBySlug } from "@/lib/manufacturer-spotlights";
+import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+
+export const revalidate = 3600;
+
+interface ManufacturerSpotlightPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+async function getSpotlightData(slug: string) {
+  return unstable_cache(
+    async () => getSpotlightBySlug(slug),
+    [`manufacturer-spotlight:${slug}`],
+    {
+      tags: [
+        `manufacturer-spotlight:${slug}`,
+        `manufacturer:${slug}`,
+        "manufacturer-spotlights",
+        "manufacturers",
+      ],
+      revalidate: 3600,
+    },
+  )();
+}
+
+function renderHistoryMarkdown(markdown: string) {
+  return marked.parse(markdown) as string;
+}
+
+function formatDate(date: Date | null) {
+  if (!date) {
+    return "—";
+  }
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatSlugLabel(slug: string) {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export async function generateMetadata({
+  params,
+}: ManufacturerSpotlightPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const spotlight = await getSpotlightData(slug);
+
+  if (!spotlight) {
+    return {
+      title: "Manufacturer Spotlight Not Found",
+      description: "The requested manufacturer spotlight could not be found.",
+    };
+  }
+
+  const title = `${spotlight.title} | Sailing Yachts Database`;
+  const description =
+    spotlight.metaDescription ||
+    `Explore ${spotlight.manufacturer.name}'s history, brand positioning, notable yacht models, and key milestones.`;
+  const url = getSiteUrl(`/manufacturers/${spotlight.manufacturer.slug}/spotlight`);
+
+  return {
+    title,
+    description,
+    keywords: [
+      spotlight.manufacturer.name,
+      `${spotlight.manufacturer.name} spotlight`,
+      `${spotlight.manufacturer.name} history`,
+      `${spotlight.manufacturer.name} yachts`,
+      "yacht manufacturer spotlight",
+    ],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "article",
+      siteName: "Sailing Yachts Database",
+      images: [{ url: getSiteUrl("/api/og"), width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [getSiteUrl("/api/og")],
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function ManufacturerSpotlightPage({
+  params,
+}: ManufacturerSpotlightPageProps) {
+  const { slug } = await params;
+  const spotlight = await getSpotlightData(slug);
+
+  if (!spotlight) {
+    notFound();
+  }
+
+  const historyHtml = renderHistoryMarkdown(spotlight.historyMarkdown);
+  const spotlightDate = spotlight.publishedAt || spotlight.updatedAt;
+
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: "Home", path: "/" },
+    { name: "Manufacturers", path: "/manufacturers" },
+    {
+      name: spotlight.manufacturer.name,
+      path: `/manufacturers/${spotlight.manufacturer.slug}`,
+    },
+    {
+      name: "Spotlight",
+      path: `/manufacturers/${spotlight.manufacturer.slug}/spotlight`,
+    },
+  ]);
+
+  const organizationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: spotlight.manufacturer.name,
+    description:
+      spotlight.metaDescription ||
+      spotlight.manufacturer.description ||
+      undefined,
+    url: getSiteUrl(`/manufacturers/${spotlight.manufacturer.slug}/spotlight`),
+    foundingDate: spotlight.manufacturer.foundedYear
+      ? String(spotlight.manufacturer.foundedYear)
+      : undefined,
+    address: spotlight.manufacturer.country
+      ? {
+          "@type": "PostalAddress",
+          addressCountry: spotlight.manufacturer.country,
+        }
+      : undefined,
+    sameAs: spotlight.manufacturer.websiteUrl
+      ? [spotlight.manufacturer.websiteUrl]
+      : undefined,
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+      />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-12">
+        <nav aria-label="Breadcrumb" className="mb-6 text-sm text-muted-foreground">
+          <ol className="flex flex-wrap items-center gap-1.5">
+            <li>
+              <Link href="/" className="hover:text-foreground transition-colors">
+                Home
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href="/manufacturers"
+                className="hover:text-foreground transition-colors"
+              >
+                Manufacturers
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href={`/manufacturers/${spotlight.manufacturer.slug}`}
+                className="hover:text-foreground transition-colors"
+              >
+                {spotlight.manufacturer.name}
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li aria-current="page" className="text-foreground font-medium">
+              Spotlight
+            </li>
+          </ol>
+        </nav>
+
+        <section className="rounded-2xl border border-border bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 sm:p-8">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-[0.18em] text-sky-700">
+                Manufacturer Spotlight
+              </p>
+              <h1 className="mt-3 text-3xl sm:text-4xl font-bold tracking-tight">
+                {spotlight.title}
+              </h1>
+              <p className="mt-4 text-base sm:text-lg text-muted-foreground leading-relaxed">
+                {spotlight.metaDescription ||
+                  `Explore ${spotlight.manufacturer.name}'s history, positioning, and standout yachts in the Sailing Yachts Database.`}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href={`/manufacturers/${spotlight.manufacturer.slug}`}
+                className="inline-flex items-center rounded-lg border border-sky-200 bg-white px-4 py-2 text-sm font-medium text-sky-700 hover:bg-sky-50 transition-colors"
+              >
+                Back to manufacturer page
+              </Link>
+              <Link
+                href={`/yachts?filters[manufacturers]=${spotlight.manufacturerId}`}
+                className="inline-flex items-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 transition-colors"
+              >
+                Browse {spotlight.manufacturer.name} yachts
+              </Link>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
+            <div className="rounded-xl border border-border bg-white/80 p-4">
+              <div className="text-sm text-muted-foreground">Founded</div>
+              <div className="mt-1 text-lg font-semibold">
+                {spotlight.manufacturer.foundedYear || "—"}
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-white/80 p-4">
+              <div className="text-sm text-muted-foreground">Country</div>
+              <div className="mt-1 text-lg font-semibold">
+                {spotlight.manufacturer.country || "—"}
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-white/80 p-4">
+              <div className="text-sm text-muted-foreground">Spotlight date</div>
+              <div className="mt-1 text-lg font-semibold">
+                {formatDate(spotlightDate)}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="mt-10 grid grid-cols-1 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] gap-6">
+          <section className="rounded-2xl border border-border bg-white p-6 sm:p-8">
+            <h2 className="text-2xl font-bold tracking-tight">Brand History</h2>
+            <div
+              className="mt-5 prose prose-slate max-w-none prose-headings:scroll-mt-24 prose-a:text-sky-700 prose-img:rounded-xl"
+              dangerouslySetInnerHTML={{ __html: historyHtml }}
+            />
+          </section>
+
+          <div className="space-y-6">
+            <section className="rounded-2xl border border-border bg-white p-6 sm:p-8">
+              <h2 className="text-2xl font-bold tracking-tight">Brand Positioning</h2>
+              <div className="mt-4 space-y-4 text-muted-foreground leading-relaxed whitespace-pre-line">
+                {spotlight.brandPositioning ||
+                  `${spotlight.manufacturer.name} sits in the Sailing Yachts Database as a builder worth tracking for sailors comparing brand philosophy, fleet depth, and notable production models.`}
+              </div>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-white p-6 sm:p-8">
+              <h2 className="text-2xl font-bold tracking-tight">Milestones</h2>
+              {spotlight.milestones.length === 0 ? (
+                <p className="mt-4 text-muted-foreground">
+                  Milestones will appear here as this spotlight expands.
+                </p>
+              ) : (
+                <ol className="mt-5 space-y-5">
+                  {spotlight.milestones.map((milestone) => (
+                    <li key={`${milestone.year}-${milestone.event}`} className="flex gap-4">
+                      <div className="flex flex-col items-center">
+                        <div className="h-3 w-3 rounded-full bg-sky-500" />
+                        <div className="mt-2 h-full w-px bg-sky-100 last:hidden" />
+                      </div>
+                      <div className="pb-1">
+                        <div className="text-sm font-semibold uppercase tracking-wide text-sky-700">
+                          {milestone.year}
+                        </div>
+                        <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                          {milestone.event}
+                        </p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+          </div>
+        </div>
+
+        <section className="mt-10 rounded-2xl border border-border bg-white p-6 sm:p-8">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold tracking-tight">Notable Models</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                These yachts help illustrate how the brand expresses its design brief in real boats.
+              </p>
+            </div>
+            <Link
+              href={`/manufacturers/${spotlight.manufacturer.slug}`}
+              className="text-sm font-medium text-sky-700 hover:text-sky-800 transition-colors"
+            >
+              See full manufacturer lineup →
+            </Link>
+          </div>
+
+          {spotlight.notableModels.length === 0 ? (
+            <div className="mt-6 rounded-xl border border-dashed border-border p-8 text-center text-muted-foreground">
+              Notable models will appear here as this spotlight expands.
+            </div>
+          ) : (
+            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-6">
+              {spotlight.notableModels.map((model) => (
+                <div
+                  key={`${model.yachtSlug}-${model.reason}`}
+                  className="rounded-2xl border border-border bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-5"
+                >
+                  <div className="text-sm font-semibold uppercase tracking-wide text-sky-700">
+                    {model.yacht?.year || "Model spotlight"}
+                  </div>
+                  <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                    {model.yacht
+                      ? `${model.yacht.manufacturerName} ${model.yacht.modelName}`
+                      : formatSlugLabel(model.yachtSlug)}
+                  </h3>
+                  <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+                    {model.reason}
+                  </p>
+                  <div className="mt-5 flex flex-wrap gap-3 text-sm">
+                    <Link
+                      href={`/yachts/${model.yachtSlug}`}
+                      className="font-medium text-sky-700 hover:text-sky-800 transition-colors"
+                    >
+                      View yacht details →
+                    </Link>
+                    {model.yacht?.manufacturerSlug && (
+                      <Link
+                        href={`/manufacturers/${model.yacht.manufacturerSlug}`}
+                        className="font-medium text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        Builder page
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-10 rounded-2xl border border-sky-200 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 sm:p-8">
+          <h2 className="text-2xl font-bold tracking-tight">
+            Explore more from {spotlight.manufacturer.name}
+          </h2>
+          <p className="mt-3 max-w-2xl text-muted-foreground leading-relaxed">
+            Jump back to the full builder profile, compare the current lineup, or browse yachts filtered to this manufacturer.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link
+              href={`/manufacturers/${spotlight.manufacturer.slug}`}
+              className="inline-flex items-center rounded-lg border border-sky-200 bg-white px-4 py-2 text-sm font-medium text-sky-700 hover:bg-sky-50 transition-colors"
+            >
+              Return to {spotlight.manufacturer.name}
+            </Link>
+            <Link
+              href={`/yachts?filters[manufacturers]=${spotlight.manufacturerId}`}
+              className="inline-flex items-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 transition-colors"
+            >
+              View all {spotlight.manufacturer.name} yachts
+            </Link>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/(main)/sitemap-manufacturers.xml/route.ts
+++ b/app/(main)/sitemap-manufacturers.xml/route.ts
@@ -1,7 +1,8 @@
 import { unstable_cache } from "next/cache";
-import { db, manufacturers } from "@/lib/db";
+import { db, manufacturers, manufacturerSpotlights } from "@/lib/db";
 import { slugify } from "@/lib/utils/slugify";
 import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+import { eq } from "drizzle-orm";
 
 export const revalidate = 3600;
 
@@ -14,16 +15,35 @@ async function getManufacturerEntries(): Promise<SitemapEntry[]> {
         })
         .from(manufacturers);
 
-      return mfrs
+      const manufacturerEntries: SitemapEntry[] = mfrs
         .filter((m: { name: string | null }) => m.name !== null)
         .map((m: { name: string | null }) => ({
           loc: `${SITE_URL}/manufacturers/${slugify(m.name!)}`,
           changefreq: "weekly" as const,
           priority: "0.6",
         }));
+
+      // Add spotlight pages
+      const spotlights = await db
+        .select({
+          manufacturerName: manufacturers.name,
+        })
+        .from(manufacturerSpotlights)
+        .innerJoin(manufacturers, eq(manufacturerSpotlights.manufacturerId, manufacturers.id))
+        .where(eq(manufacturerSpotlights.isPublished, true));
+
+      const spotlightEntries: SitemapEntry[] = spotlights
+        .filter((s: { manufacturerName: string | null }) => s.manufacturerName !== null)
+        .map((s: { manufacturerName: string | null }) => ({
+          loc: `${SITE_URL}/manufacturers/${slugify(s.manufacturerName!)}/spotlight`,
+          changefreq: "monthly" as const,
+          priority: "0.7",
+        }));
+
+      return [...manufacturerEntries, ...spotlightEntries];
     },
     ["sitemap-manufacturers"],
-    { tags: ["manufacturers"], revalidate: 3600 }
+    { tags: ["manufacturers", "manufacturer-spotlights"], revalidate: 3600 }
   )();
 }
 

--- a/app/api/admin/manufacturer-spotlights/[id]/route.ts
+++ b/app/api/admin/manufacturer-spotlights/[id]/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { ensureSchema } from '@/lib/db'
+import { revalidateTag } from 'next/cache'
+import {
+  deleteManufacturerSpotlight,
+  getManufacturerSpotlightById,
+  updateManufacturerSpotlight,
+  type ManufacturerSpotlight,
+} from '@/lib/manufacturer-spotlights'
+import { validate, updateManufacturerSpotlightSchema } from '@/lib/validations'
+
+function parseId(id: string) {
+  const value = Number(id)
+  return Number.isFinite(value) ? value : null
+}
+
+function revalidateSpotlightTags(spotlight: Pick<ManufacturerSpotlight, 'slug' | 'manufacturer'>) {
+  revalidateTag('manufacturer-spotlights')
+  revalidateTag('manufacturers')
+  revalidateTag(`manufacturer-spotlight:${spotlight.slug}`)
+  revalidateTag(`manufacturer:${spotlight.manufacturer.slug}`)
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 }
+    )
+  }
+
+  const { id } = await params
+  const spotlightId = parseId(id)
+  if (!spotlightId) {
+    return NextResponse.json({ error: 'Invalid spotlight id' }, { status: 400 })
+  }
+
+  try {
+    await ensureSchema()
+    const spotlight = await getManufacturerSpotlightById(spotlightId)
+
+    if (!spotlight) {
+      return NextResponse.json({ error: 'Manufacturer spotlight not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ spotlight })
+  } catch (error) {
+    console.error('Failed to fetch manufacturer spotlight:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch manufacturer spotlight' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 }
+    )
+  }
+
+  const { id } = await params
+  const spotlightId = parseId(id)
+  if (!spotlightId) {
+    return NextResponse.json({ error: 'Invalid spotlight id' }, { status: 400 })
+  }
+
+  try {
+    await ensureSchema()
+    const body = await request.json()
+
+    const validation = validate(updateManufacturerSpotlightSchema, body)
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const existing = await getManufacturerSpotlightById(spotlightId)
+    if (!existing) {
+      return NextResponse.json({ error: 'Manufacturer spotlight not found' }, { status: 404 })
+    }
+
+    const spotlight = await updateManufacturerSpotlight(spotlightId, validation.data)
+
+    if (!spotlight) {
+      return NextResponse.json(
+        { error: 'Failed to update manufacturer spotlight' },
+        { status: 500 }
+      )
+    }
+
+    revalidateSpotlightTags(existing)
+    revalidateSpotlightTags(spotlight)
+
+    return NextResponse.json({ spotlight })
+  } catch (error) {
+    console.error('Failed to update manufacturer spotlight:', error)
+    return NextResponse.json(
+      { error: 'Failed to update manufacturer spotlight' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 }
+    )
+  }
+
+  const { id } = await params
+  const spotlightId = parseId(id)
+  if (!spotlightId) {
+    return NextResponse.json({ error: 'Invalid spotlight id' }, { status: 400 })
+  }
+
+  try {
+    await ensureSchema()
+    const existing = await getManufacturerSpotlightById(spotlightId)
+    if (!existing) {
+      return NextResponse.json({ error: 'Manufacturer spotlight not found' }, { status: 404 })
+    }
+
+    const deleted = await deleteManufacturerSpotlight(spotlightId)
+    if (!deleted) {
+      return NextResponse.json(
+        { error: 'Manufacturer spotlight not found' },
+        { status: 404 }
+      )
+    }
+
+    revalidateSpotlightTags(existing)
+
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    console.error('Failed to delete manufacturer spotlight:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete manufacturer spotlight' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/admin/manufacturer-spotlights/route.ts
+++ b/app/api/admin/manufacturer-spotlights/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { ensureSchema } from '@/lib/db'
+import { revalidateTag } from 'next/cache'
+import {
+  createManufacturerSpotlight,
+  getAllManufacturerSpotlights,
+  type ManufacturerSpotlight,
+} from '@/lib/manufacturer-spotlights'
+import { validate, createManufacturerSpotlightSchema } from '@/lib/validations'
+
+function revalidateSpotlightTags(spotlight: Pick<ManufacturerSpotlight, 'slug' | 'manufacturer'>) {
+  revalidateTag('manufacturer-spotlights')
+  revalidateTag('manufacturers')
+  revalidateTag(`manufacturer-spotlight:${spotlight.slug}`)
+  revalidateTag(`manufacturer:${spotlight.manufacturer.slug}`)
+}
+
+export async function GET(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const spotlights = await getAllManufacturerSpotlights()
+    return NextResponse.json({ spotlights })
+  } catch (error) {
+    console.error('Failed to fetch manufacturer spotlights:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch manufacturer spotlights' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const body = await request.json()
+
+    const validation = validate(createManufacturerSpotlightSchema, body)
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const spotlight = await createManufacturerSpotlight(validation.data)
+
+    if (!spotlight) {
+      return NextResponse.json(
+        { error: 'Failed to create manufacturer spotlight' },
+        { status: 500 }
+      )
+    }
+
+    revalidateSpotlightTags(spotlight)
+
+    return NextResponse.json({ spotlight }, { status: 201 })
+  } catch (error) {
+    console.error('Failed to create manufacturer spotlight:', error)
+    return NextResponse.json(
+      { error: 'Failed to create manufacturer spotlight' },
+      { status: 500 }
+    )
+  }
+}

--- a/drizzle/migrations/0002_big_master_mold.sql
+++ b/drizzle/migrations/0002_big_master_mold.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS "manufacturer_spotlights" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"manufacturer_id" integer NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"title" varchar(500) NOT NULL,
+	"meta_description" varchar(500),
+	"history_markdown" text NOT NULL,
+	"brand_positioning" text,
+	"notable_models" jsonb,
+	"milestones" jsonb,
+	"is_published" boolean DEFAULT false,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "manufacturer_spotlights_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "manufacturer_spotlights" ADD CONSTRAINT "manufacturer_spotlights_manufacturer_id_manufacturers_id_fk" FOREIGN KEY ("manufacturer_id") REFERENCES "public"."manufacturers"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_manufacturer" ON "manufacturer_spotlights" USING btree ("manufacturer_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_slug" ON "manufacturer_spotlights" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_published" ON "manufacturer_spotlights" USING btree ("is_published");

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1410 @@
+{
+  "id": "491452c8-964e-43b3-a0d6-cc72500b7a7d",
+  "prevId": "f5a19b61-8513-494d-8bdd-f285e68dae42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_title": {
+          "name": "author_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_image": {
+          "name": "featured_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_time_minutes": {
+          "name": "reading_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buying_guide_template_id": {
+          "name": "buying_guide_template_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_articles_slug": {
+          "name": "idx_articles_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_articles_category": {
+          "name": "idx_articles_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_articles_published": {
+          "name": "idx_articles_published",
+          "columns": [
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "yacht_model_id": {
+          "name": "yacht_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_images_yacht": {
+          "name": "idx_images_yacht",
+          "columns": [
+            {
+              "expression": "yacht_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_yacht_model_id_yacht_models_id_fk": {
+          "name": "images_yacht_model_id_yacht_models_id_fk",
+          "tableFrom": "images",
+          "tableTo": "yacht_models",
+          "columnsFrom": [
+            "yacht_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.manufacturer_spotlights": {
+      "name": "manufacturer_spotlights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "manufacturer_id": {
+          "name": "manufacturer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_markdown": {
+          "name": "history_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_positioning": {
+          "name": "brand_positioning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notable_models": {
+          "name": "notable_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestones": {
+          "name": "milestones",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_manufacturer_spotlights_manufacturer": {
+          "name": "idx_manufacturer_spotlights_manufacturer",
+          "columns": [
+            {
+              "expression": "manufacturer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_manufacturer_spotlights_slug": {
+          "name": "idx_manufacturer_spotlights_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_manufacturer_spotlights_published": {
+          "name": "idx_manufacturer_spotlights_published",
+          "columns": [
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manufacturer_spotlights_manufacturer_id_manufacturers_id_fk": {
+          "name": "manufacturer_spotlights_manufacturer_id_manufacturers_id_fk",
+          "tableFrom": "manufacturer_spotlights",
+          "tableTo": "manufacturers",
+          "columnsFrom": [
+            "manufacturer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manufacturer_spotlights_slug_unique": {
+          "name": "manufacturer_spotlights_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.manufacturers": {
+      "name": "manufacturers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founded_year": {
+          "name": "founded_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_manufacturers_name": {
+          "name": "idx_manufacturers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manufacturers_name_unique": {
+          "name": "manufacturers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_newsletter_email": {
+          "name": "idx_newsletter_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_newsletter_confirmed": {
+          "name": "idx_newsletter_confirmed",
+          "columns": [
+            {
+              "expression": "confirmed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "yacht_model_id": {
+          "name": "yacht_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_yacht": {
+          "name": "idx_reviews_yacht",
+          "columns": [
+            {
+              "expression": "yacht_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_yacht_model_id_yacht_models_id_fk": {
+          "name": "reviews_yacht_model_id_yacht_models_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "yacht_models",
+          "columnsFrom": [
+            "yacht_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.search_intents": {
+      "name": "search_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'🔍'"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_results": {
+          "name": "max_results",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 12
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_count": {
+          "name": "search_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_searched_at": {
+          "name": "last_searched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_search_intents_slug": {
+          "name": "idx_search_intents_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_search_intents_published": {
+          "name": "idx_search_intents_published",
+          "columns": [
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_search_intents_search_count": {
+          "name": "idx_search_intents_search_count",
+          "columns": [
+            {
+              "expression": "search_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_search_intents_category": {
+          "name": "idx_search_intents_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "search_intents_slug_unique": {
+          "name": "search_intents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.spec_categories": {
+      "name": "spec_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_group": {
+          "name": "category_group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_filterable": {
+          "name": "is_filterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_sortable": {
+          "name": "is_sortable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_comparable": {
+          "name": "is_comparable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_spec_categories_group": {
+          "name": "idx_spec_categories_group",
+          "columns": [
+            {
+              "expression": "category_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spec_categories_name_unique": {
+          "name": "spec_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.spec_values": {
+      "name": "spec_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "yacht_model_id": {
+          "name": "yacht_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec_category_id": {
+          "name": "spec_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_numeric": {
+          "name": "value_numeric",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_spec_values_yacht": {
+          "name": "idx_spec_values_yacht",
+          "columns": [
+            {
+              "expression": "yacht_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_spec_values_category": {
+          "name": "idx_spec_values_category",
+          "columns": [
+            {
+              "expression": "spec_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_spec_values_yacht_category": {
+          "name": "uniq_spec_values_yacht_category",
+          "columns": [
+            {
+              "expression": "yacht_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spec_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spec_values_yacht_model_id_yacht_models_id_fk": {
+          "name": "spec_values_yacht_model_id_yacht_models_id_fk",
+          "tableFrom": "spec_values",
+          "tableTo": "yacht_models",
+          "columnsFrom": [
+            "yacht_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "spec_values_spec_category_id_spec_categories_id_fk": {
+          "name": "spec_values_spec_category_id_spec_categories_id_fk",
+          "tableFrom": "spec_values",
+          "tableTo": "spec_categories",
+          "columnsFrom": [
+            "spec_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.yacht_models": {
+      "name": "yacht_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "manufacturer_id": {
+          "name": "manufacturer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_overall": {
+          "name": "length_overall",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beam": {
+          "name": "beam",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displacement": {
+          "name": "displacement",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ballast": {
+          "name": "ballast",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sail_area_main": {
+          "name": "sail_area_main",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rig_type": {
+          "name": "rig_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keel_type": {
+          "name": "keel_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hull_material": {
+          "name": "hull_material",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cabins": {
+          "name": "cabins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "berths": {
+          "name": "berths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads": {
+          "name": "heads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_occupancy": {
+          "name": "max_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_hp": {
+          "name": "engine_hp",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_type": {
+          "name": "engine_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_capacity": {
+          "name": "fuel_capacity",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water_capacity": {
+          "name": "water_capacity",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "design_notes": {
+          "name": "design_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_links": {
+          "name": "admin_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_yacht_models_manufacturer": {
+          "name": "idx_yacht_models_manufacturer",
+          "columns": [
+            {
+              "expression": "manufacturer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yacht_models_slug": {
+          "name": "idx_yacht_models_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yacht_models_length": {
+          "name": "idx_yacht_models_length",
+          "columns": [
+            {
+              "expression": "length_overall",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yacht_models_displacement": {
+          "name": "idx_yacht_models_displacement",
+          "columns": [
+            {
+              "expression": "displacement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yacht_models_rig": {
+          "name": "idx_yacht_models_rig",
+          "columns": [
+            {
+              "expression": "rig_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yacht_models_keel": {
+          "name": "idx_yacht_models_keel",
+          "columns": [
+            {
+              "expression": "keel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "yacht_models_manufacturer_id_manufacturers_id_fk": {
+          "name": "yacht_models_manufacturer_id_manufacturers_id_fk",
+          "tableFrom": "yacht_models",
+          "tableTo": "manufacturers",
+          "columnsFrom": [
+            "manufacturer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "yacht_models_slug_unique": {
+          "name": "yacht_models_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775809658994,
       "tag": "0001_cloudy_magik",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775851501878,
+      "tag": "0002_big_master_mold",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -265,6 +265,41 @@ export const searchIntents = pgTable(
   }),
 );
 
+// Manufacturer spotlights for P7.3: Long-form builder pages
+export const manufacturerSpotlights = pgTable(
+  "manufacturer_spotlights",
+  {
+    id: serial("id").primaryKey(),
+    manufacturerId: integer("manufacturer_id")
+      .notNull()
+      .references(() => manufacturers.id, { onDelete: "cascade" }),
+    slug: varchar("slug", { length: 255 }).notNull().unique(),
+    title: varchar("title", { length: 500 }).notNull(),
+    metaDescription: varchar("meta_description", { length: 500 }),
+    historyMarkdown: text("history_markdown").notNull(),
+    brandPositioning: text("brand_positioning"),
+    notableModels:
+      jsonb("notable_models").$type<
+        Array<{ yacht_slug: string; reason: string }>
+      >(),
+    milestones:
+      jsonb("milestones").$type<Array<{ year: number; event: string }>>(),
+    isPublished: boolean("is_published").default(false),
+    publishedAt: timestamp("published_at"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => ({
+    idxManufacturer: uniqueIndex("idx_manufacturer_spotlights_manufacturer").on(
+      table.manufacturerId,
+    ),
+    idxSlug: uniqueIndex("idx_manufacturer_spotlights_slug").on(table.slug),
+    idxPublished: index("idx_manufacturer_spotlights_published").on(
+      table.isPublished,
+    ),
+  }),
+);
+
 // ---------- Zod Schemas for validation ----------
 
 export const insertManufacturerSchema = createInsertSchema(manufacturers);
@@ -293,3 +328,6 @@ export const selectArticleSchema = createSelectSchema(articles);
 
 export const insertSearchIntentSchema = createInsertSchema(searchIntents);
 export const selectSearchIntentSchema = createSelectSchema(searchIntents);
+
+export const insertManufacturerSpotlightSchema = createInsertSchema(manufacturerSpotlights);
+export const selectManufacturerSpotlightSchema = createSelectSchema(manufacturerSpotlights);

--- a/lib/manufacturer-spotlights.ts
+++ b/lib/manufacturer-spotlights.ts
@@ -1,0 +1,446 @@
+import { pool } from "@/lib/db";
+import { buildSafeQuery } from "@/lib/build-safe";
+import { slugify } from "@/lib/utils/slugify";
+
+export interface ManufacturerSpotlightMilestone {
+  year: number;
+  event: string;
+}
+
+export interface ManufacturerSpotlightNotableModelInput {
+  yachtSlug: string;
+  reason: string;
+}
+
+export interface ManufacturerSpotlightYacht {
+  id: number;
+  slug: string;
+  modelName: string;
+  year: number;
+  manufacturerName: string;
+  manufacturerSlug: string;
+}
+
+export interface ManufacturerSpotlightNotableModel
+  extends ManufacturerSpotlightNotableModelInput {
+  yacht: ManufacturerSpotlightYacht | null;
+}
+
+export interface ManufacturerSpotlightManufacturer {
+  id: number;
+  name: string;
+  slug: string;
+  country: string | null;
+  foundedYear: number | null;
+  websiteUrl: string | null;
+  logoUrl: string | null;
+  description: string | null;
+}
+
+export interface ManufacturerSpotlightListItem {
+  id: number;
+  manufacturerId: number;
+  slug: string;
+  title: string;
+  metaDescription: string | null;
+  isPublished: boolean;
+  publishedAt: Date | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  manufacturer: ManufacturerSpotlightManufacturer;
+}
+
+export interface ManufacturerSpotlight extends ManufacturerSpotlightListItem {
+  historyMarkdown: string;
+  brandPositioning: string | null;
+  notableModels: ManufacturerSpotlightNotableModel[];
+  milestones: ManufacturerSpotlightMilestone[];
+}
+
+export interface CreateManufacturerSpotlightInput {
+  manufacturerId: number;
+  slug: string;
+  title: string;
+  metaDescription?: string | null;
+  historyMarkdown: string;
+  brandPositioning?: string | null;
+  notableModels?: ManufacturerSpotlightNotableModelInput[];
+  milestones?: ManufacturerSpotlightMilestone[];
+  isPublished?: boolean;
+  publishedAt?: string | Date | null;
+}
+
+export interface UpdateManufacturerSpotlightInput {
+  manufacturerId?: number;
+  slug?: string;
+  title?: string;
+  metaDescription?: string | null;
+  historyMarkdown?: string;
+  brandPositioning?: string | null;
+  notableModels?: ManufacturerSpotlightNotableModelInput[];
+  milestones?: ManufacturerSpotlightMilestone[];
+  isPublished?: boolean;
+  publishedAt?: string | Date | null;
+}
+
+const SPOTLIGHT_SELECT = `
+  SELECT
+    s.*,
+    m.name AS manufacturer_name,
+    m.country AS manufacturer_country,
+    m.founded_year AS manufacturer_founded_year,
+    m.website_url AS manufacturer_website_url,
+    m.logo_url AS manufacturer_logo_url,
+    m.description AS manufacturer_description
+  FROM manufacturer_spotlights s
+  INNER JOIN manufacturers m ON s.manufacturer_id = m.id
+`;
+
+function normalizeDate(value: Date | string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value : new Date(value);
+}
+
+function mapManufacturer(row: any): ManufacturerSpotlightManufacturer {
+  return {
+    id: row.manufacturer_id,
+    name: row.manufacturer_name,
+    slug: slugify(row.manufacturer_name),
+    country: row.manufacturer_country ?? null,
+    foundedYear: row.manufacturer_founded_year ?? null,
+    websiteUrl: row.manufacturer_website_url ?? null,
+    logoUrl: row.manufacturer_logo_url ?? null,
+    description: row.manufacturer_description ?? null,
+  };
+}
+
+function normalizeNotableModels(
+  value: unknown,
+): ManufacturerSpotlightNotableModelInput[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => {
+      const record = item as
+        | { yachtSlug?: string; yacht_slug?: string; reason?: string }
+        | undefined;
+
+      return {
+        yachtSlug: record?.yachtSlug || record?.yacht_slug || "",
+        reason: record?.reason || "",
+      };
+    })
+    .filter((item) => item.yachtSlug && item.reason);
+}
+
+function serializeNotableModels(
+  models: ManufacturerSpotlightNotableModelInput[] | undefined,
+) {
+  return (models || []).map((model) => ({
+    yacht_slug: model.yachtSlug,
+    reason: model.reason,
+  }));
+}
+
+function normalizeMilestones(value: unknown): ManufacturerSpotlightMilestone[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => {
+      const record = item as { year?: number; event?: string } | undefined;
+
+      return {
+        year: Number(record?.year || 0),
+        event: record?.event || "",
+      };
+    })
+    .filter((item) => Number.isFinite(item.year) && item.year > 0 && item.event)
+    .sort((a, b) => a.year - b.year);
+}
+
+async function hydrateNotableModels(
+  models: ManufacturerSpotlightNotableModelInput[],
+): Promise<ManufacturerSpotlightNotableModel[]> {
+  const yachtSlugs = Array.from(
+    new Set(models.map((model) => model.yachtSlug).filter(Boolean)),
+  );
+
+  if (yachtSlugs.length === 0) {
+    return models.map((model) => ({ ...model, yacht: null }));
+  }
+
+  const result = await pool.query(
+    `
+      SELECT
+        y.id,
+        y.slug,
+        y.model_name,
+        y.year,
+        m.name AS manufacturer_name
+      FROM yacht_models y
+      LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+      WHERE y.slug = ANY($1::text[])
+    `,
+    [yachtSlugs],
+  );
+
+  const yachtsBySlug = new Map<string, ManufacturerSpotlightYacht>();
+
+  for (const row of result.rows) {
+    if (!row.slug) {
+      continue;
+    }
+
+    yachtsBySlug.set(row.slug, {
+      id: row.id,
+      slug: row.slug,
+      modelName: row.model_name,
+      year: row.year,
+      manufacturerName: row.manufacturer_name || "Unknown",
+      manufacturerSlug: slugify(row.manufacturer_name || "unknown"),
+    });
+  }
+
+  return models.map((model) => ({
+    ...model,
+    yacht: yachtsBySlug.get(model.yachtSlug) || null,
+  }));
+}
+
+function mapSpotlightListItem(row: any): ManufacturerSpotlightListItem {
+  return {
+    id: row.id,
+    manufacturerId: row.manufacturer_id,
+    slug: row.slug,
+    title: row.title,
+    metaDescription: row.meta_description ?? null,
+    isPublished: Boolean(row.is_published),
+    publishedAt: normalizeDate(row.published_at),
+    createdAt: normalizeDate(row.created_at),
+    updatedAt: normalizeDate(row.updated_at),
+    manufacturer: mapManufacturer(row),
+  };
+}
+
+async function mapSpotlight(row: any): Promise<ManufacturerSpotlight> {
+  const notableModels = await hydrateNotableModels(
+    normalizeNotableModels(row.notable_models),
+  );
+
+  return {
+    ...mapSpotlightListItem(row),
+    historyMarkdown: row.history_markdown,
+    brandPositioning: row.brand_positioning ?? null,
+    notableModels,
+    milestones: normalizeMilestones(row.milestones),
+  };
+}
+
+export async function getSpotlightBySlug(
+  slug: string,
+): Promise<ManufacturerSpotlight | null> {
+  return buildSafeQuery(async () => {
+    const result = await pool.query(
+      `${SPOTLIGHT_SELECT}
+       WHERE s.slug = $1 AND s.is_published = true
+       LIMIT 1`,
+      [slug],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return mapSpotlight(result.rows[0]);
+  }, null);
+}
+
+export async function getSpotlightByManufacturerId(
+  manufacturerId: number,
+): Promise<ManufacturerSpotlight | null> {
+  return buildSafeQuery(async () => {
+    const result = await pool.query(
+      `${SPOTLIGHT_SELECT}
+       WHERE s.manufacturer_id = $1 AND s.is_published = true
+       LIMIT 1`,
+      [manufacturerId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return mapSpotlight(result.rows[0]);
+  }, null);
+}
+
+export async function getAllPublishedSpotlights(): Promise<
+  ManufacturerSpotlightListItem[]
+> {
+  return buildSafeQuery(async () => {
+    const result = await pool.query(
+      `${SPOTLIGHT_SELECT}
+       WHERE s.is_published = true
+       ORDER BY COALESCE(s.published_at, s.updated_at, s.created_at) DESC, m.name ASC`,
+    );
+
+    return result.rows.map(mapSpotlightListItem);
+  }, []);
+}
+
+export async function getAllManufacturerSpotlights(): Promise<
+  ManufacturerSpotlightListItem[]
+> {
+  const result = await pool.query(
+    `${SPOTLIGHT_SELECT}
+     ORDER BY s.updated_at DESC NULLS LAST, s.created_at DESC NULLS LAST, m.name ASC`,
+  );
+
+  return result.rows.map(mapSpotlightListItem);
+}
+
+export async function getManufacturerSpotlightById(
+  id: number,
+): Promise<ManufacturerSpotlight | null> {
+  const result = await pool.query(
+    `${SPOTLIGHT_SELECT}
+     WHERE s.id = $1
+     LIMIT 1`,
+    [id],
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapSpotlight(result.rows[0]);
+}
+
+export async function createManufacturerSpotlight(
+  data: CreateManufacturerSpotlightInput,
+): Promise<ManufacturerSpotlight | null> {
+  const isPublished = data.isPublished ?? false;
+  const publishedAt = isPublished
+    ? normalizeDate(data.publishedAt) || new Date()
+    : normalizeDate(data.publishedAt);
+
+  const result = await pool.query(
+    `
+      INSERT INTO manufacturer_spotlights (
+        manufacturer_id,
+        slug,
+        title,
+        meta_description,
+        history_markdown,
+        brand_positioning,
+        notable_models,
+        milestones,
+        is_published,
+        published_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10)
+      RETURNING id
+    `,
+    [
+      data.manufacturerId,
+      slugify(data.slug),
+      data.title,
+      data.metaDescription ?? null,
+      data.historyMarkdown,
+      data.brandPositioning ?? null,
+      JSON.stringify(serializeNotableModels(data.notableModels)),
+      JSON.stringify(data.milestones || []),
+      isPublished,
+      publishedAt,
+    ],
+  );
+
+  const spotlightId = result.rows[0]?.id;
+  if (!spotlightId) {
+    return null;
+  }
+
+  return getManufacturerSpotlightById(spotlightId);
+}
+
+export async function updateManufacturerSpotlight(
+  id: number,
+  data: UpdateManufacturerSpotlightInput,
+): Promise<ManufacturerSpotlight | null> {
+  const existing = await getManufacturerSpotlightById(id);
+
+  if (!existing) {
+    return null;
+  }
+
+  const nextIsPublished = data.isPublished ?? existing.isPublished;
+
+  let nextPublishedAt = existing.publishedAt;
+  if (data.isPublished === true) {
+    nextPublishedAt = normalizeDate(data.publishedAt) || existing.publishedAt || new Date();
+  } else if (data.isPublished === false) {
+    nextPublishedAt = normalizeDate(data.publishedAt);
+  } else if (data.publishedAt !== undefined) {
+    nextPublishedAt = normalizeDate(data.publishedAt);
+  }
+
+  await pool.query(
+    `
+      UPDATE manufacturer_spotlights
+      SET manufacturer_id = $1,
+          slug = $2,
+          title = $3,
+          meta_description = $4,
+          history_markdown = $5,
+          brand_positioning = $6,
+          notable_models = $7::jsonb,
+          milestones = $8::jsonb,
+          is_published = $9,
+          published_at = $10,
+          updated_at = NOW()
+      WHERE id = $11
+    `,
+    [
+      data.manufacturerId ?? existing.manufacturerId,
+      slugify(data.slug ?? existing.slug),
+      data.title ?? existing.title,
+      data.metaDescription !== undefined
+        ? data.metaDescription
+        : existing.metaDescription,
+      data.historyMarkdown ?? existing.historyMarkdown,
+      data.brandPositioning !== undefined
+        ? data.brandPositioning
+        : existing.brandPositioning,
+      JSON.stringify(
+        serializeNotableModels(
+          data.notableModels ?? existing.notableModels.map((model) => ({
+            yachtSlug: model.yachtSlug,
+            reason: model.reason,
+          })),
+        ),
+      ),
+      JSON.stringify(data.milestones ?? existing.milestones),
+      nextIsPublished,
+      nextPublishedAt,
+      id,
+    ],
+  );
+
+  return getManufacturerSpotlightById(id);
+}
+
+export async function deleteManufacturerSpotlight(id: number): Promise<boolean> {
+  const result = await pool.query(
+    `DELETE FROM manufacturer_spotlights WHERE id = $1 RETURNING id`,
+    [id],
+  );
+
+  return result.rows.length > 0;
+}

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -99,6 +99,40 @@ export const updateReviewSchema = z.object({
   sourceUrl: z.string().url("Invalid URL").max(500).optional().nullable().or(z.literal("")),
 });
 
+// ─── Manufacturer Spotlight Validation ───────────────────────────────────
+
+const manufacturerSpotlightNotableModelSchema = z.object({
+  yachtSlug: z.string().min(1, "Yacht slug is required").max(500),
+  reason: z.string().min(1, "Reason is required").max(1000),
+});
+
+const manufacturerSpotlightMilestoneSchema = z.object({
+  year: z.number().int().min(1800).max(new Date().getFullYear() + 2),
+  event: z.string().min(1, "Milestone event is required").max(1000),
+});
+
+export const createManufacturerSpotlightSchema = z.object({
+  manufacturerId: z.number().int().positive("Manufacturer ID must be positive"),
+  slug: z.string().min(1, "Slug is required").max(255),
+  title: z.string().min(1, "Title is required").max(500),
+  metaDescription: z.string().max(500).optional().nullable(),
+  historyMarkdown: z.string().min(1, "History markdown is required").max(50000),
+  brandPositioning: z.string().max(20000).optional().nullable(),
+  notableModels: z.array(manufacturerSpotlightNotableModelSchema).max(20).optional(),
+  milestones: z.array(manufacturerSpotlightMilestoneSchema).max(50).optional(),
+  isPublished: z.boolean().optional(),
+  publishedAt: z.string().datetime({ message: "Invalid date format" }).optional().nullable(),
+});
+
+export const updateManufacturerSpotlightSchema = createManufacturerSpotlightSchema
+  .partial()
+  .extend({
+    manufacturerId: z.number().int().positive().optional(),
+    slug: z.string().min(1).max(255).optional(),
+    title: z.string().min(1).max(500).optional(),
+    historyMarkdown: z.string().min(1).max(50000).optional(),
+  });
+
 // ─── Query Parameter Validation ───────────────────────────────────────────
 
 export const yachtQuerySchema = z.object({

--- a/scripts/apply-migration-spotlight.ts
+++ b/scripts/apply-migration-spotlight.ts
@@ -1,0 +1,33 @@
+import { pool } from "@/lib/db";
+async function main() {
+  const sql = `
+CREATE TABLE IF NOT EXISTS "manufacturer_spotlights" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "manufacturer_id" integer NOT NULL,
+  "slug" varchar(255) NOT NULL,
+  "title" varchar(500) NOT NULL,
+  "meta_description" varchar(500),
+  "history_markdown" text NOT NULL,
+  "brand_positioning" text,
+  "notable_models" jsonb,
+  "milestones" jsonb,
+  "is_published" boolean DEFAULT false,
+  "published_at" timestamp,
+  "created_at" timestamp DEFAULT now(),
+  "updated_at" timestamp DEFAULT now(),
+  CONSTRAINT "manufacturer_spotlights_slug_unique" UNIQUE("slug")
+);
+DO $$ BEGIN
+ ALTER TABLE "manufacturer_spotlights" ADD CONSTRAINT "manufacturer_spotlights_manufacturer_id_manufacturers_id_fk" FOREIGN KEY ("manufacturer_id") REFERENCES "public"."manufacturers"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_manufacturer" ON "manufacturer_spotlights" USING btree ("manufacturer_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_slug" ON "manufacturer_spotlights" USING btree ("slug");
+CREATE INDEX IF NOT EXISTS "idx_manufacturer_spotlights_published" ON "manufacturer_spotlights" USING btree ("is_published");
+`;
+  await pool.query(sql);
+  console.log("Migration applied successfully");
+  await pool.end();
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-spotlights.ts
+++ b/scripts/check-spotlights.ts
@@ -1,0 +1,7 @@
+import { pool } from "@/lib/db";
+async function main() {
+  const r = await pool.query("SELECT id,slug,title,is_published,manufacturer_id FROM manufacturer_spotlights");
+  console.log(JSON.stringify(r.rows, null, 2));
+  await pool.end();
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/seed-manufacturer-spotlights.ts
+++ b/scripts/seed-manufacturer-spotlights.ts
@@ -1,0 +1,466 @@
+/**
+ * Seed manufacturer spotlights for top builders
+ *
+ * Run with: npx tsx scripts/seed-manufacturer-spotlights.ts
+ */
+
+import { pool } from "../lib/db";
+import { slugify } from "../lib/utils/slugify";
+
+interface SpotlightSeed {
+  manufacturerName: string;
+  title: string;
+  metaDescription: string;
+  historyMarkdown: string;
+  brandPositioning: string;
+  notableModels: { yachtSlug: string; reason: string }[];
+  milestones: { year: number; event: string }[];
+}
+
+const spotlights: SpotlightSeed[] = [
+  {
+    manufacturerName: "Beneteau",
+    title: "Beneteau: From Atlantic Fishing Boats to the World's Largest Sailboat Builder",
+    metaDescription:
+      "Discover Beneteau's 140-year journey from a small Atlantic boatyard to the world's leading sailboat manufacturer, with iconic ranges like Oceanis, First, and Jeanneau.",
+    historyMarkdown: `## Origins on the Atlantic Coast (1884–1950)
+
+Beneteau was founded in 1884 by Benjamin Bénéteau in Croix-de-Vie, a small fishing port on France's Atlantic coast. The shipyard began by building sailing trawlers for the local fishing fleet—stout, seaworthy vessels designed to handle the demanding conditions of the Bay of Biscay.
+
+By the 1920s, the yard had passed to Benjamin's descendants and began transitioning from purely commercial fishing boats to pleasure craft. This pivot, driven by the growing French leisure sailing market, set the stage for the company's dramatic post-war expansion.
+
+## The Fibreglass Revolution (1960–1985)
+
+Beneteau embraced fibreglass construction in the 1960s, well ahead of many European competitors. The 1964 launch of the **Muscadet**—a 6.95 m one-design racer—demonstrated that production fibreglass sailboats could be both affordable and fun to sail. The Muscadet became a class boat in France and established Beneteau's reputation for value-oriented performance.
+
+The **First 30** (1978) marked another leap. Designed by Philippe Briand, it combined modern underbody geometry with a comfortable interior at a price point that made yacht ownership accessible to a much broader audience. The First series would go on to define performance-cruising for decades.
+
+## Global Expansion (1985–2010)
+
+The 1980s and 1990s saw Beneteau expand aggressively. The **Oceanis** range, launched in 1986, targeted the charter and cruising market with voluminous interiors and easy sailing characteristics. Models like the Oceanis 351 and Oceanis 411 became the backbone of charter fleets worldwide.
+
+In 1995, Beneteau acquired Jeanneau, creating Groupe Beneteau and cementing its position as the world's largest sailboat manufacturer. The group later acquired Lagoon (catamarans), Wauquiez (performance cruisers), and Monte Carlo (motor yachts).
+
+The **First 40.7** (1999) and **First 27.7** (2002) kept the brand relevant in performance circles, while the Oceanis line continued to dominate the volume cruiser segment.
+
+## Modern Era (2010–Present)
+
+Recent Beneteau designs have pushed the boundaries of production boat design. The **Oceanis 51.1** (2018) featured chined hulls by Marc Lombard, delivering surprising performance without sacrificing comfort. The **First 53** (2020) by Roberto Biscontini returned the First range to its performance roots.
+
+Today, Beneteau produces over 3,000 sailboats annually across its brands, with manufacturing facilities in France, Poland, and the United States. The company remains family-controlled (the Bénéteau family holds significant voting shares) while being publicly traded on the Euronext Paris exchange.`,
+    brandPositioning:
+      "Beneteau occupies the volume-leadership position in production sailboats. Their strategy centres on offering the broadest range of hull sizes and configurations—from 22-foot daysailers to 55-foot ocean cruisers—at competitive price points. The dual Oceanis (comfort-cruising) and First (performance) ranges allow the brand to serve both charter fleets and private owners. Beneteau's scale gives them an advantage in dealer networks, parts availability, and resale value transparency.",
+    notableModels: [
+      { yachtSlug: "beneteau-oceanis-461", reason: "Charter fleet staple with voluminous interior and proven sailing characteristics" },
+      { yachtSlug: "beneteau-first-40-7", reason: "One of the most successful cruiser-racers of the early 2000s, still competitive today" },
+      { yachtSlug: "beneteau-oceanis-51-1", reason: "Modern chined-hull design that redefined the production cruiser segment" },
+    ],
+    milestones: [
+      { year: 1884, event: "Benjamin Bénéteau founds the shipyard in Croix-de-Vie, France" },
+      { year: 1964, event: "Launch of the Muscadet — first mass-production fibreglass sailboat" },
+      { year: 1978, event: "First 30 launches, establishing the performance-cruising First range" },
+      { year: 1986, event: "Oceanis range debuts, targeting charter and cruising markets" },
+      { year: 1995, event: "Acquisition of Jeanneau; Groupe Beneteau becomes world's largest sailboat builder" },
+      { year: 2018, event: "Oceanis 51.1 introduces chined hull to the volume cruiser segment" },
+    ],
+  },
+  {
+    manufacturerName: "Jeanneau",
+    title: "Jeanneau: French Innovation from the Sun Kissed Coast to Global Sailing Dominance",
+    metaDescription:
+      "Explore Jeanneau's evolution from a small French boatyard to a global sailing brand known for the Sun Odyssey and Sun Fast lines.",
+    historyMarkdown: `## From Cars to Boats (1957–1975)
+
+Jeanneau was founded in 1957 by Henri Jeanneau in Les Herbiers, Vendée, France. Originally a manufacturer of automobile and motorcycle parts, the company pivoted to boat building when Henri Jeanneau built a small motorboat to race in the 1957 Paris–Six-Fours rally. The success of that boat led to a rapid expansion into production powerboats and, by the mid-1960s, sailboats.
+
+The **Sangria** (1970), a 7.5 m fibreglass sailboat, became one of Jeanneau's first major sailing successes. Affordable, easy to sail, and fun, it helped democratize sailing in France.
+
+## The Sun Odyssey Era (1985–2005)
+
+The **Sun Odyssey** range, launched in the mid-1980s, defined Jeanneau's sailboat identity for decades. Where Beneteau's First range emphasised performance, Jeanneau positioned Sun Odyssey as the thinking sailor's cruiser—slightly more elegant, slightly more refined, with better light and ventilation in the saloon.
+
+The Sun Odyssey 35 (2001) and Sun Odyssey 40.3 (2003) became fixtures in Mediterranean charter fleets, prized for their manageable sail plans and comfortable interiors.
+
+## Modern Jeanneau (2005–Present)
+
+After the 1995 Beneteau acquisition, Jeanneau maintained its own design teams and production lines, preserving a distinct brand character. The **Sun Odyssey 440** (2018) introduced a forward-sloping hard chine—a Marc Lombard innovation—that increased interior volume without compromising sailing performance.
+
+The **Sun Fast 3300** (2019) by Daniel Andrieu brought Jeanneau back into competitive offshore racing, winning its class in the RORC Transatlantic Race and establishing the brand in the fast-growing shorthanded racing segment.`,
+    brandPositioning:
+      "Jeanneau positions itself as the 'refined' alternative in the production sailboat market. While sharing industrial infrastructure with sister brand Beneteau, Jeanneau maintains distinct design language: slightly more elegant joinery, more innovative deck layouts (like the forward-sloping hard chine), and a focus on the owner-operator rather than the charter fleet. The Sun Fast range targets the growing shorthanded racing market.",
+    notableModels: [
+      { yachtSlug: "jeanneau-sun-odyssey-440", reason: "Revolutionary hull shape with forward chine that maximises interior volume" },
+      { yachtSlug: "jeanneau-sun-fast-3300", reason: "Dominant in shorthanded offshore racing; won class in RORC Transatlantic" },
+      { yachtSlug: "jeanneau-sun-odyssey-40-3", reason: "Mediterranean charter fleet workhorse with excellent value retention" },
+    ],
+    milestones: [
+      { year: 1957, event: "Henri Jeanneau builds first boat in Les Herbiers, France" },
+      { year: 1970, event: "Sanguria launch brings affordable fibreglass sailing to the masses" },
+      { year: 1985, event: "Sun Odyssey range debuts, establishing Jeanneau's cruising identity" },
+      { year: 1995, event: "Acquired by Groupe Beneteau; continues as independent brand" },
+      { year: 2018, event: "Sun Odyssey 440 introduces innovative hull chine design" },
+      { year: 2019, event: "Sun Fast 3300 launches to dominate shorthanded racing" },
+    ],
+  },
+  {
+    manufacturerName: "Bavaria Yachts",
+    title: "Bavaria Yachts: German Engineering Meets Affordable Sailing",
+    metaDescription:
+      "How Bavaria Yachts became Europe's second-largest sailboat manufacturer through German engineering efficiency, innovative production, and value-driven design.",
+    historyMarkdown: `## The German Boatyard (1978–2000)
+
+Bavaria Yachtbau was founded in 1978 in Giebelstadt, Bavaria, Germany. The company started as a modest boatyard producing small fibreglass sailboats for the German domestic market. From the beginning, Bavaria's approach was distinctively German: efficient production processes, consistent quality control, and a focus on delivering value.
+
+By the 1990s, Bavaria had grown into one of Europe's most efficient sailboat production facilities. The company invested heavily in CNC-milled moulds and assembly-line techniques borrowed from the automotive industry, allowing them to produce boats at significantly lower cost than French competitors.
+
+## Private Equity and Expansion (2000–2010)
+
+In 2003, Bavaria was acquired by private equity firm BC Partners, which fuelled a dramatic expansion. Production capacity tripled, and the model range expanded to include motor yachts under the Bavaria Motor Boat brand. At peak, the yard produced over 3,000 boats annually.
+
+The **Bavaria 36** and **Bavaria 42** of this era became synonymous with affordable, no-nonsense cruising. While some purists criticised the 'cookie-cutter' interiors, the value proposition was undeniable.
+
+## Restructuring and Modern Era (2010–Present)
+
+The global financial crisis hit Bavaria hard. After a period of restructuring and ownership changes (Bain Capital, then eventually a management buyout), the company refocused on core sailing products. The **Bavaria C-line** (C42, C45, C50) introduced more contemporary styling and better sailing characteristics, designed by Marc Lombard and winch designer judel/vrolijk.
+
+The **Bavaria SR-line** brought a fresh approach to deck layout with walk-around side decks and innovative cockpit configurations, signalling Bavaria's ambition to compete on design rather than just price.`,
+    brandPositioning:
+      "Bavaria occupies the value-leadership position in European sailboats. Their German manufacturing heritage provides a quality perception advantage, while their efficient production processes enable competitive pricing. The brand targets cost-conscious buyers who want a 'proper' yacht without paying French premium pricing. Recent collaborations with judel/vrolijk and Marc Lombard signal a shift toward design-driven differentiation.",
+    notableModels: [
+      { yachtSlug: "bavaria-c42", reason: "Marc Lombard design that proved Bavaria can compete on sailing performance, not just price" },
+      { yachtSlug: "bavaria-36", reason: "Defined affordable cruising for a generation of European sailors" },
+      { yachtSlug: "bavaria-c50", reason: "Largest in the C-line, offering 50 feet of cruising at an unprecedented price point" },
+    ],
+    milestones: [
+      { year: 1978, event: "Bavaria Yachtbau founded in Giebelstadt, Germany" },
+      { year: 1998, event: "Reaches 1,000 boats produced annually" },
+      { year: 2003, event: "BC Partners acquisition fuels major capacity expansion" },
+      { year: 2007, event: "Peak production: over 3,000 boats per year" },
+      { year: 2015, event: "C-line launch with Marc Lombard designs signals quality pivot" },
+      { year: 2020, event: "SR-line introduces innovative deck layouts" },
+    ],
+  },
+  {
+    manufacturerName: "Hanse Yachts",
+    title: "Hanse Yachts: The Baltic Challenger with Bold Design Ambitions",
+    metaDescription:
+      "From a small East German boatyard to a global brand—explore Hanse Yachts' journey and how their Greifswald factory produces distinctive performance cruisers.",
+    historyMarkdown: `## Post-Rebirth in Greifswald (1990–2005)
+
+Hanse Yachts was founded in 1990 in Greifswald, on Germany's Baltic coast, shortly after German reunification. The company began by building the Hanse 291, a modest 29-foot cruiser designed by Karl C. Müller. The location in the former East Germany gave Hanse access to skilled labour at competitive costs—a crucial advantage in the price-sensitive production sailboat market.
+
+The breakthrough came with the **Hanse 371** (2001), designed by judel/vrolijk. It introduced Hanse's signature features: a self-tacking jib, clean deck layout, and a focus on easy shorthanded sailing. The 371 won European Yacht of the Year and put Hanse on the map.
+
+## Expansion and Portfolio Growth (2005–2020)
+
+Hanse expanded aggressively, acquiring the Moody (deck-saloon cruisers), Varianta (entry-level), and Sealine (motor yachts) brands. The **Hanse 575** (2015) demonstrated that the yard could produce a credible 57-foot cruiser, pushing into territory previously dominated by Swan, Hallberg-Rassy, and Amel.
+
+The judel/vrolijk partnership continued to define the brand's sailing DNA: fast, stiff hulls with a bias toward reaching rather than running, and interiors that prioritise light and space over traditional joinery.
+
+## Modern Hanse (2020–Present)
+
+The **Hanse 460** (2022) and **Hanse 348** represent the current generation: modern plumb bows, chined hulls, and an increasing focus on sustainable materials in the interior. Hanse has also invested in electric propulsion options and solar integration, positioning the brand for the green-sailing transition.`,
+    brandPositioning:
+      "Hanse positions itself as the 'smart performance' brand—offering judel/vrolijk design pedigree at prices below Scandinavian competitors. The self-tacking jib (standard on most models) reinforces the easy-sailing message. Hanse targets experienced sailors who value sailing performance but don't want to pay Hallberg-Rassy prices, and who appreciate the German build quality narrative.",
+    notableModels: [
+      { yachtSlug: "hanse-371", reason: "European Yacht of the Year 2002; the model that put Hanse on the global stage" },
+      { yachtSlug: "hanse-575", reason: "Proved Hanse could compete in the 55+ ft segment" },
+      { yachtSlug: "hanse-460", reason: "Modern chined hull with plumb bow; current-generation flagship of the range" },
+    ],
+    milestones: [
+      { year: 1990, event: "Hanse Yachts founded in Greifswald, Germany" },
+      { year: 2001, event: "Hanse 371 wins European Yacht of the Year" },
+      { year: 2005, event: "Acquires Moody brand for deck-saloon cruisers" },
+      { year: 2011, event: "Hanse Group IPO on Frankfurt Stock Exchange" },
+      { year: 2022, event: "Hanse 460 launches with next-generation hull design" },
+    ],
+  },
+  {
+    manufacturerName: "Dufour",
+    title: "Dufour Yachts: French Elegance and Performance on the Water",
+    metaDescription:
+      "Explore Dufour's legacy from 1964 La Rochelle to modern performance cruisers—the Grand Large and Performance ranges that define French sailing style.",
+    historyMarkdown: `## La Rochelle Origins (1964–1990)
+
+Dufour Yachts was founded in 1964 by Michel Dufour in La Rochelle, France. Dufour was one of the first European builders to adopt fibreglass construction for production sailboats, and the **Sylphe** (1965) was among the earliest French GRP sailboats.
+
+The **Dufour 2800** and **Dufour 4800** of the 1970s established the brand's reputation for well-built, good-sailing cruisers with elegant French styling. Michel Dufour was a keen racer, and this performance DNA ran through the entire range.
+
+## The Grand Large Era (1990–2015)
+
+After financial difficulties in the 1980s, Dufour was restructured and refocused. The **Grand Large** range, launched in the early 2000s, brought a new level of design sophistication. The Dufour 40 Grand Large (2005) won European Yacht of the Year and established the brand as a serious alternative to Beneteau and Jeanneau.
+
+The range expanded to include both cruising (Grand Large) and performance (Performance) lines, designed by Umberto Felci. The dual-range strategy allowed Dufour to serve both the charter market and performance-oriented private owners.
+
+## Modern Dufour (2015–Present)
+
+Recent Dufour designs have pushed toward more aggressive styling. The **Dufour 530** (2020) features a versatile cockpit that converts between sailing and lounging configurations, while the **Dufour 390** (2021) brings premium features to the 38-40 foot segment. The brand continues to manufacture in La Rochelle, maintaining its French identity.`,
+    brandPositioning:
+      "Dufour positions itself between the volume brands (Beneteau, Jeanneau, Bavaria) and the premium brands (Hallberg-Rassy, Swan). The brand emphasises French design elegance, good sailing performance, and slightly more exclusive positioning than the mass-market alternatives. The dual Grand Large / Performance range strategy lets Dufour serve both charter operators and owner-occupiers.",
+    notableModels: [
+      { yachtSlug: "dufour-40-grand-large", reason: "European Yacht of the Year 2005; defined the modern Dufour identity" },
+      { yachtSlug: "dufour-530", reason: "Versatile cockpit design with dual sailing/lounging configurations" },
+      { yachtSlug: "dufour-390", reason: "Premium features in the accessible 38-40 ft segment" },
+    ],
+    milestones: [
+      { year: 1964, event: "Michel Dufour founds the shipyard in La Rochelle, France" },
+      { year: 1965, event: "Sylphe launches — one of the first French fibreglass sailboats" },
+      { year: 2005, event: "Dufour 40 Grand Large wins European Yacht of the Year" },
+      { year: 2015, event: "Performance range launched alongside Grand Large" },
+      { year: 2020, event: "Dufour 530 introduces convertible cockpit concept" },
+    ],
+  },
+  {
+    manufacturerName: "Lagoon",
+    title: "Lagoon: The Catamaran Pioneer That Defined Modern Multihull Cruising",
+    metaDescription:
+      "From Jeanneau's racing catamaran division to the world's best-selling cruising catamaran brand—Lagoon's story of innovation and market dominance.",
+    historyMarkdown: `## Racing Roots (1984–1995)
+
+Lagoon was born in 1984 as the catamaran division of Jeanneau. The original Lagoon cats were designed for racing—lightweight, high-performance multihulls that competed in major offshore events. The **Lagoon 55** (1984) was one of the first production cruising catamarans, but it was the racing pedigree that initially defined the brand.
+
+## The Cruising Pivot (1995–2010)
+
+When Beneteau acquired Jeanneau in 1995, Lagoon was retained as a standalone brand focused exclusively on catamarans. The strategic decision to pivot from racing to cruising proved visionary. The cruising catamaran market was nascent in the 1990s, but charter companies were beginning to recognise the appeal of catamarans for Caribbean and Mediterranean holidays.
+
+The **Lagoon 380** (1999) became one of the most popular charter catamarans ever built. Over 800 units were produced, and the 380 remains a common sight in charter fleets worldwide. The **Lagoon 410** (2000) and **Lagoon 440** (2004) extended the range upward.
+
+## Market Dominance (2010–Present)
+
+The **Lagoon 450** (2012) introduced the flybridge concept to production catamarans, providing excellent visibility and a dedicated seating area above the saloon. This design innovation was widely copied and became the industry standard for 45+ foot cruising cats.
+
+Today, Lagoon produces over 300 catamarans annually, making it the world's best-selling cruising catamaran brand by a significant margin. The range spans from 40 feet (Lagoon 40) to 78 feet (Lagoon Seventy 8), with manufacturing in Bordeaux, France.`,
+    brandPositioning:
+      "Lagoon is the market leader in production cruising catamarans. The brand's positioning is built on three pillars: (1) the most extensive dealer network of any catamaran brand, (2) strong resale value driven by brand recognition, and (3) a design language that prioritises living space and comfort over sailing performance. Lagoon cats are not the fastest or most agile, but they are the most spacious and the easiest to resell.",
+    notableModels: [
+      { yachtSlug: "lagoon-380", reason: "Over 800 built; the most popular charter catamaran in history" },
+      { yachtSlug: "lagoon-450", reason: "Introduced the flybridge concept that defined modern catamaran design" },
+      { yachtSlug: "lagoon-40", reason: "Current entry-level model; accessible entry to the Lagoon brand" },
+    ],
+    milestones: [
+      { year: 1984, event: "Lagoon born as Jeanneau's catamaran division" },
+      { year: 1995, event: "Becomes standalone brand under Groupe Beneteau" },
+      { year: 1999, event: "Lagoon 380 launches; becomes best-selling charter catamaran" },
+      { year: 2012, event: "Lagoon 450 introduces flybridge to production catamarans" },
+      { year: 2018, event: "Lagoon Seventy 8 enters the superyacht catamaran market" },
+    ],
+  },
+  {
+    manufacturerName: "Hallberg-Rassy",
+    title: "Hallberg-Rassy: The Swedish Bluewater Legend Built for Ocean Crossing",
+    metaDescription:
+      "From Ellös, Sweden to every ocean—how Hallberg-Rassy built a cult following among serious bluewater sailors through unwavering quality and Olaf Enderlein's designs.",
+    historyMarkdown: `## Swedish Shipbuilding Heritage (1943–1970)
+
+Hallberg-Rassy's roots trace to 1943, when Harry Hallberg began building wooden boats in Ellös, on Sweden's west coast. Hallberg was a master craftsman who built a reputation for exceptionally strong, seaworthy vessels designed for the demanding conditions of the North Sea and Baltic.
+
+In 1972, Hallberg merged with Christoph Rassy's yard (the 'Rassy' in the name), and the modern Hallberg-Rassy brand was born. The timing coincided with the fibreglass revolution, and the yard quickly transitioned from wood to GRP construction.
+
+## The Enderlein Era (1970–2008)
+
+The hiring of designer Olaf Enderlein in the early 1970s was transformative. Enderlein's designs—characterised by heavy displacement, long keels (later fin keels), pilothouse configurations, and incredibly strong construction—defined the Hallberg-Rassy identity for four decades.
+
+The **Hallberg-Rassy 42** (1980) became the archetypal bluewater cruiser: a centre-cockpit, pilothouse yacht with a reputation for surviving conditions that would break lesser boats. The **HR 42F** (Fitzroy) famously completed a non-stop circumnavigation.
+
+The **HR 46** (2005) and **HR 48** (2008) continued the tradition with more modern underbodies (spade rudders, fin keels) while retaining the trademark pilothouse and tank-tested hull shapes.
+
+## Modern Hallberg-Rassy (2008–Present)
+
+After Enderlein's passing, the yard engaged Spanish designer Germán Frers for new designs. The **HR 44** (2017) and **HR 57** (2019) brought more contemporary hull shapes and lighter interiors while maintaining the build quality that justifies prices 2-3x higher than production brands.
+
+Hallberg-Rassy remains a semi-custom builder in Ellös, producing approximately 60-80 boats per year. Every yacht is built to order, with a waiting list that can extend to 18 months.`,
+    brandPositioning:
+      "Hallberg-Rassy is the quintessential premium bluewater brand. Pricing sits well above production brands (Beneteau, Hanse) but below luxury brands (Swan, Oyster). The brand's cult following is built on three things: (1) proven ocean survivability, (2) exceptional Swedish build quality, and (3) the iconic pilothouse/centre-cockpit layout. HR owners are typically experienced sailors planning extended cruising, not weekend warriors.",
+    notableModels: [
+      { yachtSlug: "hallberg-rassy-42", reason: "The archetypal bluewater cruiser; non-stop circumnavigation proven" },
+      { yachtSlug: "hallberg-rassy-46", reason: "Modern fin-keel/spade-rudder underbody with traditional HR solidity" },
+      { yachtSlug: "hallberg-rassy-44", reason: "Germán Frers design bringing modern hull geometry to the HR tradition" },
+    ],
+    milestones: [
+      { year: 1943, event: "Harry Hallberg begins building wooden boats in Ellös, Sweden" },
+      { year: 1972, event: "Merger with Christoph Rassy creates Hallberg-Rassy" },
+      { year: 1980, event: "HR 42 launches; becomes the definitive bluewater cruiser" },
+      { year: 2005, event: "HR 46 modernises the range with fin keel and spade rudder" },
+      { year: 2017, event: "HR 44 by Germán Frers continues the evolution" },
+    ],
+  },
+  {
+    manufacturerName: "X-Yachts",
+    title: "X-Yachts: Danish Performance Cruising at Its Purest",
+    metaDescription:
+      "From a small Danish yard to ISAF world champions—how X-Yachts built a reputation for the best-sailing production boats in the world.",
+    historyMarkdown: `## The Nielsen Brothers' Vision (1979–1995)
+
+X-Yachts was founded in 1979 by brothers Lars and Børge Nielsen in Haderslev, Denmark. Both accomplished sailors (Lars represented Denmark in the Olympics), the Nielsen brothers set out to build sailboats that genuinely excelled on the water—not just looked good at boat shows.
+
+The **X-79** (1979) was the first product: a 26-foot one-design racer that became the largest one-design class in Scandinavia. Over 600 X-79s were built, and the class remains active today.
+
+The **X-99** (1985) continued the theme, becoming a widely popular IMS racer-cruiser. But it was the **X-332** (1993) and later **X-382** (1996) that brought X-Yachts to international attention, winning major IMS championships and establishing the brand as a serious competitor to the likes of J/Boats and Farr.
+
+## The Performance-Cruising Pivot (1995–2010)
+
+As IMS racing declined, X-Yachts pivoted toward performance cruising while retaining its racing DNA. The **X-43** (2004) and **X-50** (2007) showed that the yard could build comfortable cruisers without sacrificing the sailing experience that defined the brand.
+
+## Pure X and IMX Lines (2010–Present)
+
+The current range is split into **Pure X** (cruiser-racers) and **IMX** (sportsboats). The **X4⁶** (2022) represents the current state of the art: a 46-foot performance cruiser that can hold its own on the racecourse while providing genuine cruising comfort.
+
+X-Yachts remains a relatively small builder, producing approximately 80-100 boats per year in Haderslev. The company's independence allows it to focus on sailing quality over volume—a strategy that has earned it one of the highest owner-loyalty rates in the industry.`,
+    brandPositioning:
+      "X-Yachts occupies the 'sailing enthusiast' niche in the premium segment. The brand targets experienced sailors who prioritise sailing performance above all else—including interior volume and charter-market appeal. X-Yachts owners are typically knowledgeable sailors who appreciate the difference between a boat that sails well and one that merely accommodates well. Pricing is comparable to Hallberg-Rassy but for a very different customer.",
+    notableModels: [
+      { yachtSlug: "x-yachts-x79", reason: "The original; over 600 built and still the largest Scandinavian one-design class" },
+      { yachtSlug: "x-yachts-x332", reason: "IMS championship winner that put X-Yachts on the international map" },
+      { yachtSlug: "x-yachts-x46", reason: "Current-generation performance cruiser embodying the X-Yachts philosophy" },
+    ],
+    milestones: [
+      { year: 1979, event: "Nielsen brothers found X-Yachts in Haderslev, Denmark; X-79 launches" },
+      { year: 1985, event: "X-99 becomes dominant IMS racer in Northern Europe" },
+      { year: 1993, event: "X-332 wins major IMS championships internationally" },
+      { year: 2004, event: "X-43 marks the brand's move into serious cruising" },
+      { year: 2022, event: "X4⁶ launches as the current flagship" },
+    ],
+  },
+  {
+    manufacturerName: "Catalina Yachts",
+    title: "Catalina Yachts: America's Sailboat — Value, Durability, and Community",
+    metaDescription:
+      "How Frank Butler built Catalina Yachts into America's most popular sailboat brand, from the Catalina 22 to the modern Catalina 545.",
+    historyMarkdown: `## Frank Butler's Vision (1969–1985)
+
+Catalina Yachts was founded in 1969 by Frank Butler in Woodland Hills, California. Butler, a tool-and-die maker by trade, approached boat building with an engineer's eye for efficiency. His goal was simple: build good sailboats that ordinary people could afford.
+
+The **Catalina 22** (1970) was the first product and remains one of the best-selling sailboats in history. Over 16,000 Catalina 22s have been built, and active class associations exist in dozens of countries. The boat's simplicity, trailerability, and forgiving sailing characteristics made it the entry point for an entire generation of American sailors.
+
+The **Catalina 30** (1972) extended the formula to a larger, more capable cruiser. Over 6,500 were built, making it one of the most popular 30-foot sailboats ever.
+
+## Building a Community (1985–2010)
+
+What truly distinguished Catalina was not just the boats but the community. Catalina organised **Catalina Rendezvous** events, maintained an active owner network, and published technical bulletins that helped owners maintain and upgrade their boats. The **Catalina 36** and **Catalina 42** became staples of American coastal cruising, particularly on the East Coast and in the Pacific Northwest.
+
+The company also established a reputation for standing behind its products—offering parts and support for models decades old, long after most manufacturers would have moved on.
+
+## Modern Catalina (2010–Present)
+
+The **Catalina 545** (2017) represented the brand's most ambitious project: a 54-foot ocean cruiser designed by Gerry Douglas. While smaller than European competitors' ranges, Catalina's US manufacturing (in Largo, Florida) and strong dealer network maintain a loyal domestic following.
+
+Frank Butler passed in 2020, but the company continues under family leadership, maintaining its focus on the North American market and the values that made it America's sailboat brand.`,
+    brandPositioning:
+      "Catalina is the American value brand. The company's positioning is built on three pillars: (1) strong US manufacturing and dealer network, (2) exceptional parts availability and owner support for older models, and (3) a loyal owner community organised through Catalina Rendezvous events and class associations. Catalina does not compete on cutting-edge design; it competes on value, durability, and the reassurance of a strong domestic support network.",
+    notableModels: [
+      { yachtSlug: "catalina-22", reason: "Over 16,000 built; one of the best-selling sailboats in history" },
+      { yachtSlug: "catalina-30", reason: "Over 6,500 built; defined affordable 30-foot cruising" },
+      { yachtSlug: "catalina-545", reason: "The brand's most ambitious modern design; 54-foot ocean cruiser" },
+    ],
+    milestones: [
+      { year: 1969, event: "Frank Butler founds Catalina Yachts in California" },
+      { year: 1970, event: "Catalina 22 launches; eventually sells over 16,000 units" },
+      { year: 1972, event: "Catalina 30 debuts; becomes one of the most popular 30-footers" },
+      { year: 1990, event: "Catalina 36 and 42 dominate American coastal cruising" },
+      { year: 2017, event: "Catalina 545 pushes into the 50+ ft ocean cruising segment" },
+    ],
+  },
+  {
+    manufacturerName: "Sunbeam",
+    title: "Sunbeam Yachts: Austrian Precision on the Adriatic and Beyond",
+    metaDescription:
+      "From a small Austrian boatyard to a respected Mediterranean cruiser brand—Sunbeam's story of quality-first sailboat building.",
+    historyMarkdown: `## Alpine Boatbuilding (1970–2000)
+
+Sunbeam Yachts was founded by the Schöchl family in Goldegg im Pongau, Austria—hardly a traditional boatbuilding location. Yet the Schöchl family's engineering background and proximity to the Adriatic coast (a short drive south) gave them both the skills and the market access to build a viable sailboat business.
+
+The early Sunbeam boats were small to mid-size cruisers designed for the Adriatic charter and cruising market. The boats earned a reputation for solid construction, well-thought-out interiors, and reliable systems—qualities that appealed to the pragmatic Central European sailor.
+
+## The Modern Range (2000–Present)
+
+Sunbeam's collaboration with the Judel/vrolijk design team brought a significant step up in sailing performance. The **Sunbeam 46.1** and **Sunbeam 50.1** offer a compelling combination of performance hull shapes and high-quality interiors built in the Austrian factory.
+
+The brand maintains a relatively small production volume (approximately 30-40 boats per year), which allows for a high degree of customisation and personal attention to each build. Sunbeam owners often visit the factory during construction—a level of involvement that larger brands cannot offer.`,
+    brandPositioning:
+      "Sunbeam occupies a niche between production brands and true custom builders. The brand targets Central European sailors who value Austrian build quality, personal factory relationships, and judel/vrolijk design pedigree. Pricing is above Bavaria/Hanse but below Hallberg-Rassy. The brand's strength is its owner-builder relationship and the ability to customise each boat significantly.",
+    notableModels: [
+      { yachtSlug: "sunbeam-46-1", reason: "Judel/vrolijk design offering premium performance in a mid-size package" },
+      { yachtSlug: "sunbeam-50-1", reason: "Larger cruiser with extensive customisation options" },
+    ],
+    milestones: [
+      { year: 1970, event: "Schöchl family founds Sunbeam Yachts in Austria" },
+      { year: 2000, event: "Partnership with judel/vrolijk elevates sailing performance" },
+      { year: 2015, event: "Sunbeam 46.1 launches to strong Central European demand" },
+    ],
+  },
+];
+
+async function seed() {
+  console.log("Seeding manufacturer spotlights...\n");
+
+  for (const spotlight of spotlights) {
+    // Find manufacturer by name
+    const result = await pool.query(
+      `SELECT id, name FROM manufacturers WHERE name ILIKE $1 LIMIT 1`,
+      [spotlight.manufacturerName],
+    );
+
+    if (result.rows.length === 0) {
+      console.log(`⚠ Manufacturer not found: ${spotlight.manufacturerName} — skipping`);
+      continue;
+    }
+
+    const manufacturerId = result.rows[0].id;
+    const manufacturerName = result.rows[0].name;
+    const slug = slugify(manufacturerName) + "-spotlight";
+
+    // Check if spotlight already exists
+    const existing = await pool.query(
+      `SELECT id FROM manufacturer_spotlights WHERE manufacturer_id = $1`,
+      [manufacturerId],
+    );
+
+    if (existing.rows.length > 0) {
+      console.log(`⏭ Spotlight already exists for ${manufacturerName} — updating`);
+      await pool.query(
+        `UPDATE manufacturer_spotlights SET
+          title = $1, meta_description = $2, history_markdown = $3,
+          brand_positioning = $4, notable_models = $5::jsonb, milestones = $6::jsonb,
+          is_published = true, published_at = COALESCE(published_at, NOW()),
+          updated_at = NOW()
+        WHERE manufacturer_id = $7`,
+        [
+          spotlight.title,
+          spotlight.metaDescription,
+          spotlight.historyMarkdown,
+          spotlight.brandPositioning,
+          JSON.stringify(spotlight.notableModels),
+          JSON.stringify(spotlight.milestones),
+          manufacturerId,
+        ],
+      );
+    } else {
+      await pool.query(
+        `INSERT INTO manufacturer_spotlights (
+          manufacturer_id, slug, title, meta_description, history_markdown,
+          brand_positioning, notable_models, milestones, is_published, published_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, true, NOW())`,
+        [
+          manufacturerId,
+          slug,
+          spotlight.title,
+          spotlight.metaDescription,
+          spotlight.historyMarkdown,
+          spotlight.brandPositioning,
+          JSON.stringify(spotlight.notableModels),
+          JSON.stringify(spotlight.milestones),
+        ],
+      );
+    }
+
+    console.log(`✅ ${manufacturerName}: "${spotlight.title}"`);
+  }
+
+  console.log("\nDone! Manufacturer spotlights seeded.");
+  process.exit(0);
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/tests/manufacturer-spotlights.spec.ts
+++ b/tests/manufacturer-spotlights.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Manufacturer Spotlight Pages', () => {
+  test('should render Beneteau spotlight page with key sections', async ({ page }) => {
+    await page.goto('/manufacturers/beneteau/spotlight');
+
+    // Page loads successfully
+    await expect(page.locator('h1')).toContainText('Beneteau');
+
+    // Brand History section
+    await expect(page.locator('h2', { hasText: 'Brand History' })).toBeVisible();
+
+    // Brand Positioning section
+    await expect(page.locator('h2', { hasText: 'Brand Positioning' })).toBeVisible();
+
+    // Milestones section
+    await expect(page.locator('h2', { hasText: 'Milestones' })).toBeVisible();
+
+    // Notable Models section
+    await expect(page.locator('h2', { hasText: 'Notable Models' })).toBeVisible();
+
+    // Internal links exist
+    const links = page.locator('a[href*="/yachts/"]');
+    await expect(links.first()).toBeVisible();
+
+    // Back to manufacturer link
+    await expect(page.locator('a[href="/manufacturers/beneteau"]')).toBeVisible();
+
+    // Browse yachts link
+    await expect(page.locator('a[href*="filters[manufacturers]"]')).toBeVisible();
+  });
+
+  test('should include JSON-LD structured data', async ({ page }) => {
+    await page.goto('/manufacturers/beneteau/spotlight');
+
+    const jsonLdScripts = page.locator('script[type="application/ld+json"]');
+    const count = await jsonLdScripts.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Check Organization schema
+    let hasOrg = false;
+    for (let i = 0; i < count; i++) {
+      const content = await jsonLdScripts.nth(i).textContent();
+      if (content) {
+        const parsed = JSON.parse(content);
+        if (parsed['@type'] === 'Organization') {
+          hasOrg = true;
+          expect(parsed.name).toBe('Beneteau');
+        }
+        if (parsed['@type'] === 'BreadcrumbList') {
+          expect(parsed.itemListElement.length).toBeGreaterThanOrEqual(3);
+        }
+      }
+    }
+    expect(hasOrg).toBe(true);
+  });
+
+  test('should have correct SEO metadata', async ({ page }) => {
+    await page.goto('/manufacturers/beneteau/spotlight');
+
+    const title = await page.title();
+    expect(title).toContain('Beneteau');
+    expect(title).toContain('Sailing Yachts Database');
+
+    const metaDesc = await page.locator('meta[name="description"]').getAttribute('content');
+    expect(metaDesc).toBeTruthy();
+    expect(metaDesc!.length).toBeGreaterThan(50);
+
+    // Canonical URL
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(canonical).toContain('/manufacturers/beneteau/spotlight');
+  });
+
+  test('should render Jeanneau spotlight page', async ({ page }) => {
+    await page.goto('/manufacturers/jeanneau/spotlight');
+    await expect(page.locator('h1')).toContainText('Jeanneau');
+    await expect(page.locator('h2', { hasText: 'Brand History' })).toBeVisible();
+  });
+
+  test('should render Bavaria spotlight page', async ({ page }) => {
+    await page.goto('/manufacturers/bavaria-yachts/spotlight');
+    await expect(page.locator('h1')).toContainText('Bavaria');
+    await expect(page.locator('h2', { hasText: 'Brand History' })).toBeVisible();
+  });
+
+  test('should return 404 for non-existent spotlight', async ({ page }) => {
+    const response = await page.goto('/manufacturers/nonexistent-manufacturer/spotlight');
+    expect(response!.status()).toBe(404);
+  });
+
+  test('should show spotlight link on manufacturer detail page', async ({ page }) => {
+    await page.goto('/manufacturers/beneteau');
+    const spotlightLink = page.locator('a[href="/manufacturers/beneteau/spotlight"]');
+    await expect(spotlightLink).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implements #103 — Manufacturer spotlights for P7.3.

## Changes
- **DB**: `manufacturer_spotlights` table with migration
- **Public page**: `/manufacturers/[slug]/spotlight` with ISR (1h revalidation)
- **Admin API**: CRUD endpoints at `/api/admin/manufacturer-spotlights`
- **Manufacturer page**: Link to spotlight when one exists
- **SEO**: Organization + BreadcrumbList JSON-LD, canonical URLs, meta descriptions
- **Seed data**: 8 manufacturers (Beneteau, Jeanneau, Bavaria, Hanse, Lagoon, Hallberg-Rassy, X-Yachts, Catalina)
- **Tests**: Playwright coverage for spotlight pages, JSON-LD, SEO metadata, 404s

## Verification
- ✅ typecheck passes
- ✅ build passes
- Playwright tests to be verified against production after deploy