### PR TITLE
feat: content freshness system with review tracking, staleness API, and guide display (refs #112)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -105,14 +105,14 @@ These are the first issue titles I would create for the cron agent, in order:
 
 ### Concrete PR-Sized Backlog
 
-- **P7.1 — Guides platform:** Introduce MDX or a lightweight content model for editorial content, including category pages, author metadata, RSS feed support, and article layouts. Tests: route generation tests, metadata checks, and smoke coverage for guide pages.
+- **P7.1 — Guides platform:** ✅ DONE — Introduce MDX or a lightweight content model for editorial content, including category pages, author metadata, RSS feed support, and article layouts. Tests: route generation tests, metadata checks, and smoke coverage for guide pages.
 - **P7.2 — Yacht buying guide templates:** ✅ DONE — Publish templates for “best sailboats for…”, “how to choose…”, “X vs Y explained”, “new vs used”, and “what size cruiser do I need?” pages. Tests: template render tests and structured data assertions for `Article`/`FAQPage`.
-- **P7.3 — Manufacturer spotlights:** Create long-form builder pages with history, brand positioning, notable models, and links into current manufacturer/yacht records. Tests: render and internal-link coverage.
-- **P7.4 — Sailing glossary:** Add glossary pages for LOA, beam, ballast ratio, fin keel, cutter rig, shoal draft, displacement, and other spec-related terms. Auto-link glossary terms from yacht detail pages and guides. Tests: glossary route tests and inline link insertion assertions.
+- **P7.3 — Manufacturer spotlights:** ✅ DONE — Create long-form builder pages with history, brand positioning, notable models, and links into current manufacturer/yacht records. Tests: render and internal-link coverage.
+- **P7.4 — Sailing glossary:** ✅ DONE — Add glossary pages for LOA, beam, ballast ratio, fin keel, cutter rig, shoal draft, displacement, and other spec-related terms. Auto-link glossary terms from yacht detail pages and guides. Tests: glossary route tests and inline link insertion assertions.
 - **P7.5 — Content cluster linking engine:** ✅ DONE — Add reusable “related guides” blocks to yacht pages and reusable “related yachts” blocks to guide pages. Tests: Playwright verification that guides and yacht pages cross-link properly.
 - **P7.6 — FAQ harvesting pipeline:** Use site search data, newsletter replies, and popular compare pairs to propose new FAQ entries and guide topics. Tests: unit tests for topic-prioritization logic.
 - **P7.7 — Content freshness system:** Add “last reviewed” dates, editorial review reminders, and automated issue creation for stale guides. Tests: scheduler logic tests and stale-content query tests.
-- **P7.8 — Best-of editorial series:** Launch curated collections like “best 30-35 ft cruisers,” “best liveaboard sailboats,” “best bluewater cruisers under 45 ft,” and “best beginner sailboats.” Tests: content template tests plus comparison/yacht page linking assertions.
+- **P7.8 — Best-of editorial series:** ✅ DONE — Launch curated collections like “best 30-35 ft cruisers,” “best liveaboard sailboats,” “best bluewater cruisers under 45 ft,” and “best beginner sailboats.” Tests: content template tests plus comparison/yacht page linking assertions.
 
 ### Notes
 

--- a/app/(main)/guides/[slug]/page.tsx
+++ b/app/(main)/guides/[slug]/page.tsx
@@ -249,6 +249,9 @@ export default async function GuideArticlePage({ params }: PageProps) {
               {article.readingTimeMinutes && (
                 <span>{article.readingTimeMinutes} min read</span>
               )}
+              {article.lastReviewedAt && (
+                <span className="text-green-600">Reviewed {formatDate(article.lastReviewedAt)}</span>
+              )}
             </div>
           </div>
         </header>

--- a/app/api/content-freshness/route.ts
+++ b/app/api/content-freshness/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/content-freshness
+ * Get stale content report: articles that haven't been reviewed in a while.
+ *
+ * Query params:
+ *   days - staleness threshold in days (default 90)
+ *   status - filter by review_status (fresh, due, stale)
+ *   limit - max results (default 20)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const sp = request.nextUrl.searchParams;
+    const days = parseInt(sp.get("days") || "90", 10);
+    const status = sp.get("status");
+    const limit = Math.min(parseInt(sp.get("limit") || "20", 10), 50);
+
+    let query = `
+      SELECT
+        id, slug, title, category, published_at, updated_at,
+        last_reviewed_at, review_status,
+        CASE
+          WHEN last_reviewed_at IS NULL THEN 'never reviewed'
+          WHEN updated_at > last_reviewed_at THEN 'updated after review'
+          ELSE 'reviewed'
+        END AS review_state,
+        CASE
+          WHEN last_reviewed_at IS NULL THEN 9999
+          ELSE EXTRACT(DAY FROM NOW() - last_reviewed_at)::int
+        END AS days_since_review
+      FROM articles
+      WHERE is_published = true
+    `;
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    if (status) {
+      query += ` AND review_status = $${paramIdx++}`;
+      params.push(status);
+    } else {
+      // Default: show articles that haven't been reviewed in `days` days
+      query += ` AND (last_reviewed_at IS NULL OR last_reviewed_at < NOW() - INTERVAL '1 day' * $${paramIdx++})`;
+      params.push(days);
+    }
+
+    query += ` ORDER BY days_since_review DESC, updated_at DESC LIMIT $${paramIdx++}`;
+    params.push(limit);
+
+    const result = await pool.query(query, params);
+
+    // Auto-update stale statuses
+    const updateQuery = `
+      UPDATE articles SET review_status = CASE
+        WHEN last_reviewed_at IS NULL OR last_reviewed_at < NOW() - INTERVAL '180 days' THEN 'stale'
+        WHEN last_reviewed_at < NOW() - INTERVAL '90 days' THEN 'due'
+        ELSE 'fresh'
+      END
+      WHERE is_published = true AND review_status IS DISTINCT FROM (
+        CASE
+          WHEN last_reviewed_at IS NULL OR last_reviewed_at < NOW() - INTERVAL '180 days' THEN 'stale'
+          WHEN last_reviewed_at < NOW() - INTERVAL '90 days' THEN 'due'
+          ELSE 'fresh'
+        END
+      )
+    `;
+    await pool.query(updateQuery);
+
+    const articles = result.rows.map((row) => ({
+      id: row.id,
+      slug: row.slug,
+      title: row.title,
+      category: row.category,
+      publishedAt: row.published_at,
+      updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at,
+      reviewStatus: row.review_status || "fresh",
+      reviewState: row.review_state,
+      daysSinceReview: row.days_since_review,
+      editUrl: `/guides/${row.slug}`,
+    }));
+
+    // Summary stats
+    const statsResult = await pool.query(`
+      SELECT
+        COUNT(*) AS total,
+        COUNT(*) FILTER (WHERE review_status = 'fresh') AS fresh,
+        COUNT(*) FILTER (WHERE review_status = 'due') AS due,
+        COUNT(*) FILTER (WHERE review_status = 'stale') AS stale,
+        COUNT(*) FILTER (WHERE last_reviewed_at IS NULL) AS never_reviewed
+      FROM articles WHERE is_published = true
+    `);
+
+    return NextResponse.json({
+      articles,
+      stats: statsResult.rows[0],
+      threshold: { days },
+    });
+  } catch (error) {
+    console.error("Error fetching content freshness:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch content freshness report" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PUT /api/content-freshness
+ * Mark an article as reviewed.
+ *
+ * Body: { articleId: number }
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { articleId } = body;
+
+    if (!articleId) {
+      return NextResponse.json(
+        { error: "articleId is required" },
+        { status: 400 }
+      );
+    }
+
+    await pool.query(
+      `UPDATE articles SET last_reviewed_at = NOW(), review_status = 'fresh' WHERE id = $1`,
+      [articleId]
+    );
+
+    return NextResponse.json({ success: true, articleId });
+  } catch (error) {
+    console.error("Error marking article as reviewed:", error);
+    return NextResponse.json(
+      { error: "Failed to update review status" },
+      { status: 500 }
+    );
+  }
+}

--- a/drizzle/migrations/0003_content_freshness.sql
+++ b/drizzle/migrations/0003_content_freshness.sql
@@ -1,0 +1,5 @@
+-- Add content freshness tracking columns to articles table
+-- last_reviewed_at tracks when an article was last editorially reviewed
+-- review_status tracks whether review is needed (fresh, due, stale)
+ALTER TABLE "articles" ADD COLUMN IF NOT EXISTS "last_reviewed_at" timestamp without time zone;
+ALTER TABLE "articles" ADD COLUMN IF NOT EXISTS "review_status" varchar(20) DEFAULT 'fresh';

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -25,6 +25,8 @@ export interface Article {
   publishedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  lastReviewedAt: Date | null;
+  reviewStatus: string | null;
 }
 
 export interface ArticleWithStats extends Article {
@@ -48,6 +50,8 @@ const FALLBACK_ARTICLE: Article = {
   publishedAt: null,
   createdAt: new Date(),
   updatedAt: new Date(),
+  lastReviewedAt: null,
+  reviewStatus: null,
 };
 
 const FALLBACK_ARTICLES: Article[] = [];
@@ -86,6 +90,8 @@ export async function getArticleBySlug(
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     };
   }, null);
 }
@@ -118,6 +124,8 @@ export async function getAllPublishedArticles(): Promise<Article[]> {
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     }));
   }, FALLBACK_ARTICLES);
 }
@@ -153,6 +161,8 @@ export async function getArticlesByCategory(
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     }));
   }, FALLBACK_ARTICLES);
 }
@@ -218,6 +228,8 @@ export async function getRelatedArticles(
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     }));
   }, []);
 }
@@ -250,6 +262,8 @@ export async function getBuyingGuideArticles(): Promise<Article[]> {
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     }));
   }, FALLBACK_ARTICLES);
 }
@@ -312,6 +326,8 @@ export async function createArticle(data: {
       publishedAt: row.published_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at || null,
+      reviewStatus: row.review_status || null,
     };
   }, null);
 }

--- a/tests/content-freshness.spec.ts
+++ b/tests/content-freshness.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Content Freshness API", () => {
+  const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "https://info.sailboats.fr";
+
+  test("should return freshness report", async ({ request }) => {
+    const resp = await request.get(`${BASE_URL}/api/content-freshness`);
+    expect(resp.ok()).toBeTruthy();
+    const data = await resp.json();
+    expect(data.articles).toBeDefined();
+    expect(Array.isArray(data.articles)).toBeTruthy();
+    expect(data.stats).toBeDefined();
+    expect(data.stats.total).toBeDefined();
+  });
+
+  test("should return stats with freshness breakdown", async ({ request }) => {
+    const resp = await request.get(`${BASE_URL}/api/content-freshness`);
+    const data = await resp.json();
+    expect(data.stats.fresh).toBeDefined();
+    expect(data.stats.due).toBeDefined();
+    expect(data.stats.stale).toBeDefined();
+    expect(data.stats.never_reviewed).toBeDefined();
+  });
+
+  test("should respect days threshold", async ({ request }) => {
+    const resp = await request.get(`${BASE_URL}/api/content-freshness?days=30&limit=5`);
+    expect(resp.ok()).toBeTruthy();
+    const data = await resp.json();
+    expect(data.threshold.days).toBe(30);
+  });
+
+  test("should filter by status", async ({ request }) => {
+    const resp = await request.get(`${BASE_URL}/api/content-freshness?status=stale&limit=5`);
+    expect(resp.ok()).toBeTruthy();
+    const data = await resp.json();
+    expect(Array.isArray(data.articles)).toBeTruthy();
+  });
+});
+
+test.describe("Content Freshness on Guide Pages", () => {
+  const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "https://info.sailboats.fr";
+
+  test("guide detail page should load successfully", async ({ page }) => {
+    await page.goto(`${BASE_URL}/guides/how-to-choose-your-first-sailboat`);
+    await page.waitForLoadState("networkidle");
+    // Page should not show application error
+    const body = await page.locator("body").textContent();
+    expect(body).not.toContain("Application error");
+  });
+});


### PR DESCRIPTION
- Add last_reviewed_at and review_status columns to articles table
- Create /api/content-freshness endpoint (GET report + PUT mark reviewed)
- Auto-classify articles as fresh/due/stale based on days since review
- Display 'Reviewed' date on guide detail pages
- Add Playwright tests for freshness API and guide pages
