### PR TITLE
feat: add personalized recommendations (P9.6) (closes #153)

### DIFF
--- a/app/(main)/account/AccountDashboard.tsx
+++ b/app/(main)/account/AccountDashboard.tsx
@@ -120,6 +120,9 @@ export default function AccountDashboard() {
       {activeTab === "searches" && <SearchesTab />}
       {activeTab === "comparisons" && <ComparisonsTab />}
       {activeTab === "alerts" && <AlertsTab />}
+
+      {/* Personalized Recommendations (P9.6) */}
+      <DashboardRecommendations />
     </div>
   );
 }
@@ -381,6 +384,125 @@ function LoadingSkeleton() {
       {[1, 2, 3].map((i) => (
         <div key={i} className="h-20 bg-gray-100 rounded-lg" />
       ))}
+    </div>
+  );
+}
+
+// === Dashboard Recommendations (P9.6) ===
+interface RecommendationItem {
+  id: number;
+  manufacturer: string | null;
+  modelName: string;
+  slug: string | null;
+  year: number;
+  lengthOverall: string | null;
+  rigType: string | null;
+  score?: number;
+  primaryImage: string | null;
+  reason: string;
+}
+
+interface CompareAgainItem {
+  id: number;
+  name: string;
+  yachtIds: number[];
+  createdAt: string;
+}
+
+function DashboardRecommendations() {
+  const [similar, setSimilar] = useState<RecommendationItem[]>([]);
+  const [compareAgain, setCompareAgain] = useState<CompareAgainItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/user/recommendations")
+      .then((r) => {
+        if (r.status === 401) return null;
+        return r.json();
+      })
+      .then((data) => {
+        if (data) {
+          setSimilar(data.similarToFavorites || []);
+          setCompareAgain(data.compareAgain || []);
+        }
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) return null;
+  if (similar.length === 0 && compareAgain.length === 0) return null;
+
+  return (
+    <div className="mt-10 border-t border-gray-200 pt-8" data-testid="dashboard-recommendations">
+      <h2 className="text-xl font-bold text-gray-900 mb-4">Recommended for You</h2>
+
+      {similar.length > 0 && (
+        <div className="mb-8">
+          <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wider mb-3">
+            Yachts You Might Like
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {similar.slice(0, 3).map((yacht) => (
+              <Link
+                key={yacht.id}
+                href={yacht.slug ? `/yachts/${yacht.slug}` : "#"}
+                className="block border border-gray-200 rounded-lg p-3 hover:border-blue-300 hover:shadow-sm transition"
+                data-testid="dashboard-rec-card"
+              >
+                <div className="font-medium text-sm text-gray-900">
+                  {yacht.manufacturer} {yacht.modelName}
+                </div>
+                <div className="text-xs text-gray-500 mt-1">
+                  {yacht.year} {yacht.lengthOverall ? `· LOA ${parseFloat(yacht.lengthOverall).toFixed(1)}m` : ""}
+                </div>
+                {yacht.reason && (
+                  <div className="text-xs text-blue-600 mt-1.5">{yacht.reason}</div>
+                )}
+                {yacht.score != null && (
+                  <div className="mt-2 flex items-center gap-2">
+                    <div className="flex-1 h-1 bg-gray-100 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-blue-600 rounded-full"
+                        style={{ width: `${Math.round(yacht.score * 100)}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-gray-400">{Math.round(yacht.score * 100)}%</span>
+                  </div>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {compareAgain.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wider mb-3">
+            Compare Again
+          </h3>
+          <div className="space-y-2">
+            {compareAgain.slice(0, 3).map((comp) => (
+              <Link
+                key={comp.id}
+                href={`/compare?ids=${comp.yachtIds.join(",")}`}
+                className="flex items-center justify-between border border-gray-200 rounded-lg p-3 hover:border-blue-300 hover:shadow-sm transition"
+                data-testid="dashboard-compare-again"
+              >
+                <div>
+                  <div className="font-medium text-sm text-gray-900">
+                    {comp.name || `Comparison #${comp.id}`}
+                  </div>
+                  <div className="text-xs text-gray-500 mt-0.5">
+                    {comp.yachtIds.length} yachts · Saved {new Date(comp.createdAt).toLocaleDateString()}
+                  </div>
+                </div>
+                <span className="text-sm text-blue-600 font-medium">View →</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { unstable_cache } from "next/cache";
 import NewsletterSignup from "@/components/NewsletterSignup";
+import { PersonalizedRecommendations } from "@/components/PersonalizedRecommendations";
 import { db, yachtModels, manufacturers } from "@/lib/db";
 import { desc, sql } from "drizzle-orm";
 import { generateWebsiteJsonLd, generateFaqJsonLd, getSiteUrl } from "@/lib/seo";
@@ -268,6 +269,8 @@ export default async function Home() {
           </div>
         </section>
 
+        {/* Personalized Recommendations (P9.6) */}
+        <PersonalizedRecommendations />
         {/* Features / Benefits */}
         <section className="py-16 px-4 bg-sky-50">
           <div className="max-w-5xl mx-auto">

--- a/app/api/user/recommendations/route.ts
+++ b/app/api/user/recommendations/route.ts
@@ -1,0 +1,239 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { eq, desc } from "drizzle-orm";
+import { authOptions } from "@/lib/auth";
+import { db, userFavorites, yachtModels, manufacturers, images, savedComparisons } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface ScoredRecommendation {
+  id: number;
+  manufacturer: string | null;
+  modelName: string;
+  slug: string | null;
+  year: number;
+  lengthOverall: string | null;
+  beam: string | null;
+  displacement: string | null;
+  rigType: string | null;
+  score: number;
+  primaryImage: string | null;
+  reason: string;
+}
+
+/**
+ * Weighted similarity score based on dimensional specs.
+ * Reuses the same algorithm as /api/yachts/[slug]/similar.
+ */
+function computeSimilarity(
+  source: { lengthOverall: string | null; beam: string | null; draft: string | null; displacement: string | null; sailAreaMain: string | null },
+  candidate: { lengthOverall: string | null; beam: string | null; draft: string | null; displacement: string | null; sailAreaMain: string | null },
+): number {
+  type DimKey = "lengthOverall" | "beam" | "draft" | "displacement" | "sailAreaMain";
+  const dims: Array<{ key: DimKey; weight: number }> = [
+    { key: "lengthOverall", weight: 0.30 },
+    { key: "displacement", weight: 0.25 },
+    { key: "beam", weight: 0.20 },
+    { key: "draft", weight: 0.15 },
+    { key: "sailAreaMain", weight: 0.10 },
+  ];
+
+  let totalWeight = 0;
+  let weightedDist = 0;
+
+  for (const dim of dims) {
+    const sv = source[dim.key] !== null ? parseFloat(source[dim.key]!) : null;
+    const cv = candidate[dim.key] !== null ? parseFloat(candidate[dim.key]!) : null;
+    if (sv === null || cv === null || sv === 0) continue;
+    weightedDist += dim.weight * (Math.abs(sv - cv) / sv);
+    totalWeight += dim.weight;
+  }
+
+  if (totalWeight === 0) return 0;
+  return Math.max(0, 1 - weightedDist / totalWeight);
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const userId = Number(session.user.id);
+
+    // Fetch user's favorites with full spec data
+    const favorites = await db
+      .select({
+        id: yachtModels.id,
+        modelName: yachtModels.modelName,
+        manufacturer: manufacturers.name,
+        lengthOverall: yachtModels.lengthOverall,
+        beam: yachtModels.beam,
+        draft: yachtModels.draft,
+        displacement: yachtModels.displacement,
+        sailAreaMain: yachtModels.sailAreaMain,
+      })
+      .from(userFavorites)
+      .innerJoin(yachtModels, eq(userFavorites.yachtModelId, yachtModels.id))
+      .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+      .where(eq(userFavorites.userId, userId));
+
+    // Fetch user's saved comparisons for "compare again"
+    const comparisons = await db
+      .select({
+        id: savedComparisons.id,
+        name: savedComparisons.name,
+        yachtIds: savedComparisons.yachtIds,
+        createdAt: savedComparisons.createdAt,
+      })
+      .from(savedComparisons)
+      .where(eq(savedComparisons.userId, userId))
+      .orderBy(desc(savedComparisons.updatedAt))
+      .limit(5);
+
+    // Fetch recently added yachts
+    const recentYachts = await db
+      .select({
+        id: yachtModels.id,
+        modelName: yachtModels.modelName,
+        slug: yachtModels.slug,
+        year: yachtModels.year,
+        lengthOverall: yachtModels.lengthOverall,
+        beam: yachtModels.beam,
+        displacement: yachtModels.displacement,
+        rigType: yachtModels.rigType,
+        manufacturer: manufacturers.name,
+      })
+      .from(yachtModels)
+      .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+      .orderBy(desc(yachtModels.createdAt))
+      .limit(20);
+
+    const favoriteIds = new Set<number>(favorites.map((f: { id: number }) => f.id));
+
+    // Filter out already-favorited yachts from recent
+    type RecentYacht = typeof recentYachts[number];
+    const newSinceVisit: Array<RecentYacht & { reason: "new" }> = [];
+    for (const y of recentYachts) {
+      if (!favoriteIds.has(y.id)) {
+        newSinceVisit.push({ ...y, reason: "new" });
+      }
+      if (newSinceVisit.length >= 6) break;
+    }
+
+    // Compute "similar to favorites" recommendations
+    const similarToFavoriteList: ScoredRecommendation[] = [];
+
+    if (favorites.length > 0) {
+      // Fetch all candidate yachts (exclude favorites)
+      const allYachts = await db
+        .select({
+          id: yachtModels.id,
+          modelName: yachtModels.modelName,
+          slug: yachtModels.slug,
+          year: yachtModels.year,
+          lengthOverall: yachtModels.lengthOverall,
+          beam: yachtModels.beam,
+          draft: yachtModels.draft,
+          displacement: yachtModels.displacement,
+          sailAreaMain: yachtModels.sailAreaMain,
+          rigType: yachtModels.rigType,
+          manufacturer: manufacturers.name,
+        })
+        .from(yachtModels)
+        .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id));
+
+      // Filter out favorites
+      const candidates = allYachts.filter((y: { id: number }) => !favoriteIds.has(y.id));
+
+      // Score each candidate against all favorites, keep best score
+      for (const candidate of candidates) {
+        let bestScore = 0;
+        let bestReason = "";
+
+        for (const fav of favorites) {
+          const score = computeSimilarity(fav, candidate);
+          if (score > bestScore) {
+            bestScore = score;
+            bestReason = `Similar to ${fav.manufacturer || ""} ${fav.modelName}`.trim();
+          }
+        }
+
+        if (bestScore > 0.3) {
+          similarToFavoriteList.push({
+            id: candidate.id,
+            manufacturer: candidate.manufacturer,
+            modelName: candidate.modelName,
+            slug: candidate.slug,
+            year: candidate.year,
+            lengthOverall: candidate.lengthOverall,
+            beam: candidate.beam,
+            displacement: candidate.displacement,
+            rigType: candidate.rigType,
+            score: bestScore,
+            primaryImage: null,
+            reason: bestReason,
+          });
+        }
+      }
+
+      // Sort by score, take top 6
+      similarToFavoriteList.sort((a: ScoredRecommendation, b: ScoredRecommendation) => b.score - a.score);
+      similarToFavoriteList.splice(6); // keep only top 6
+
+      // Fetch primary images for top recommendations
+      for (const yacht of similarToFavoriteList) {
+        try {
+          const yachtImages = await db
+            .select({ url: images.url })
+            .from(images)
+            .where(eq(images.yachtModelId, yacht.id))
+            .limit(1);
+          yacht.primaryImage = yachtImages.length > 0 ? yachtImages[0].url : null;
+        } catch {
+          yacht.primaryImage = null;
+        }
+      }
+    }
+
+    // Fetch primary images for new since visit
+    type NewWithImage = RecentYacht & { reason: "new"; primaryImage: string | null };
+    const newSinceVisitWithImages: NewWithImage[] = [];
+    for (const y of newSinceVisit) {
+      let primaryImage: string | null = null;
+      try {
+        const yachtImages = await db
+          .select({ url: images.url })
+          .from(images)
+          .where(eq(images.yachtModelId, y.id))
+          .limit(1);
+        primaryImage = yachtImages.length > 0 ? yachtImages[0].url : null;
+      } catch { /* no image */ }
+
+      newSinceVisitWithImages.push({
+        ...y,
+        primaryImage,
+      });
+    }
+
+    type ComparisonRow = typeof comparisons[number];
+    return NextResponse.json({
+      similarToFavorites: similarToFavoriteList,
+      newSinceVisit: newSinceVisitWithImages,
+      compareAgain: comparisons.map((c: ComparisonRow) => ({
+        id: c.id,
+        name: c.name,
+        yachtIds: c.yachtIds,
+        createdAt: c.createdAt,
+      })),
+      favoritesCount: favorites.length,
+    });
+  } catch (error) {
+    console.error("[recommendations] GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch recommendations" },
+      { status: 500 },
+    );
+  }
+}

--- a/components/PersonalizedRecommendations.tsx
+++ b/components/PersonalizedRecommendations.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import YachtImage from "@/app/components/yacht/YachtImage";
+
+interface RecommendedYacht {
+  id: number;
+  manufacturer: string | null;
+  modelName: string;
+  slug: string | null;
+  year: number;
+  lengthOverall: string | null;
+  beam: string | null;
+  displacement: string | null;
+  rigType: string | null;
+  score?: number;
+  primaryImage: string | null;
+  reason: string;
+  createdAt?: string | null;
+}
+
+interface Recommendations {
+  similarToFavorites: RecommendedYacht[];
+  newSinceVisit: RecommendedYacht[];
+  favoritesCount: number;
+}
+
+/**
+ * Personalized recommendations component shown on the homepage for logged-in users.
+ * Falls back to nothing for guest users.
+ */
+export function PersonalizedRecommendations() {
+  const [data, setData] = useState<Recommendations | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/user/recommendations")
+      .then((r) => {
+        if (r.status === 401) return null;
+        return r.json();
+      })
+      .then((result) => {
+        setData(result);
+        setLoading(false);
+      })
+      .catch(() => {
+        setData(null);
+        setLoading(false);
+      });
+  }, []);
+
+  // Don't render anything while loading or for guests
+  if (loading) return null;
+  if (!data || data.favoritesCount === 0) return null;
+
+  const hasSimilar = data.similarToFavorites.length > 0;
+  const hasNew = data.newSinceVisit.length > 0;
+
+  if (!hasSimilar && !hasNew) return null;
+
+  return (
+    <section
+      className="py-16 px-4 bg-gradient-to-b from-blue-50 to-white"
+      data-testid="personalized-recommendations"
+    >
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-8">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Recommended for You
+          </h2>
+          <p className="text-gray-600 mt-1">
+            Based on your {data.favoritesCount} saved favorite{data.favoritesCount !== 1 ? "s" : ""}
+          </p>
+        </div>
+
+        {hasSimilar && (
+          <div className="mb-10">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">
+              Similar to Your Favorites
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {data.similarToFavorites.slice(0, 3).map((yacht) => (
+                <YachtRecommendationCard key={yacht.id} yacht={yacht} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {hasNew && (
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">
+              Recently Added
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {data.newSinceVisit.slice(0, 3).map((yacht) => (
+                <YachtRecommendationCard key={yacht.id} yacht={yacht} variant="new" />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function YachtRecommendationCard({
+  yacht,
+  variant = "similar",
+}: {
+  yacht: RecommendedYacht;
+  variant?: "similar" | "new";
+}) {
+  const formatNum = (val: string | null, decimals = 1) => {
+    if (!val) return null;
+    const n = parseFloat(val);
+    return isNaN(n) ? null : n.toFixed(decimals);
+  };
+
+  return (
+    <Link
+      href={`/yachts/${yacht.slug}`}
+      className="group block bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-lg hover:border-blue-200 transition"
+      data-testid="recommendation-card"
+    >
+      {yacht.primaryImage ? (
+        <div className="h-36 bg-gray-100 overflow-hidden">
+          <YachtImage
+            src={yacht.primaryImage}
+            alt={`${yacht.manufacturer} ${yacht.modelName}`}
+            fill
+            className="w-full h-full group-hover:scale-105 transition-transform duration-200"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          />
+        </div>
+      ) : (
+        <div className="h-36 bg-gray-100 flex items-center justify-center text-gray-400 text-sm">
+          No image
+        </div>
+      )}
+
+      <div className="p-4">
+        <h4 className="font-semibold text-sm sm:text-base group-hover:text-blue-600 transition-colors">
+          {yacht.manufacturer} {yacht.modelName}
+        </h4>
+
+        <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-500">
+          {yacht.year && <span className="bg-gray-100 px-2 py-0.5 rounded">{yacht.year}</span>}
+          {formatNum(yacht.lengthOverall) && (
+            <span className="bg-gray-100 px-2 py-0.5 rounded">
+              LOA {formatNum(yacht.lengthOverall)}m
+            </span>
+          )}
+        </div>
+
+        {variant === "similar" && yacht.score != null && (
+          <div className="mt-3 flex items-center gap-2">
+            <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-blue-600 rounded-full transition-all"
+                style={{ width: `${Math.round(yacht.score * 100)}%` }}
+              />
+            </div>
+            <span className="text-xs text-gray-500 whitespace-nowrap">
+              {Math.round(yacht.score * 100)}% match
+            </span>
+          </div>
+        )}
+
+        {variant === "similar" && yacht.reason && (
+          <p className="mt-1.5 text-xs text-gray-400 italic">{yacht.reason}</p>
+        )}
+
+        {variant === "new" && (
+          <span className="mt-2 inline-block text-xs font-medium text-green-700 bg-green-50 px-2 py-0.5 rounded">
+            New
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/tests/personalized-recommendations.spec.ts
+++ b/tests/personalized-recommendations.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Personalized Recommendations (P9.6)", () => {
+  test.describe("Homepage - guest user", () => {
+    test("homepage loads without personalized recommendations for guests", async ({ page }) => {
+      await page.goto("http://localhost:3000/");
+      // Guest users should not see the personalized recommendations section
+      const recSection = page.locator('[data-testid="personalized-recommendations"]');
+      await expect(recSection).not.toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe("Account Dashboard - guest user", () => {
+    test("account page shows login prompt for guests", async ({ page }) => {
+      await page.goto("http://localhost:3000/account");
+      await expect(page.locator("text=Sign in Required")).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe("Recommendations API", () => {
+    test("API returns 401 for unauthenticated users", async ({ request }) => {
+      const response = await request.get("http://localhost:3000/api/user/recommendations");
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBe("Unauthorized");
+    });
+  });
+});


### PR DESCRIPTION
- New API /api/user/recommendations returning similar-to-favorites,
  new-since-visit, and compare-again data for logged-in users
- PersonalizedRecommendations component on homepage (guest-safe)
- DashboardRecommendations in Account Dashboard with compare-again
- Playwright tests for guest users and API auth
- Reuses existing weighted Euclidean similarity engine
