### PR TITLE
feat: Spec completeness scoring (P10.5)

### DIFF
--- a/app/(main)/yachts/YachtsClient.tsx
+++ b/app/(main)/yachts/YachtsClient.tsx
@@ -4,6 +4,8 @@ import { FavoriteButton } from '@/app/components/FavoriteButton';
 import { PriceTierBadge } from '@/app/components/PriceTierBadge';
 import NewsletterSignup from '@/components/NewsletterSignup';
 import { calculatePriceTier } from '@/lib/price-tier';
+import CompletenessBadge from '@/components/CompletenessBadge';
+import { calculateCompletenessScore } from '@/lib/completeness';
 import { FILTER_PRESETS, detectActivePreset, type FilterPreset } from '@/lib/filter-presets';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
@@ -380,6 +382,7 @@ export default function YachtsClient() {
                           keelType: yacht.keelType,
                           rigType: yacht.rigType,
                         })} />
+                        <CompletenessBadge score={calculateCompletenessScore(yacht)} />
                       </div>
                       <dl className="mt-3 text-sm">
                         <div className="flex justify-between py-0.5"><dt className="text-gray-500">Length:</dt><dd className="font-medium">{fmt(yacht.lengthOverall)} m</dd></div>

--- a/app/(main)/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/(main)/yachts/[slug]/YachtDetailClient.tsx
@@ -19,6 +19,8 @@ import { RelatedArticles } from "./RelatedArticles";
 import AffiliateRecommendations from "@/app/components/AffiliateRecommendations";
 import YachtImage from "@/app/components/yacht/YachtImage";
 import { getAffiliateRecommendations } from "@/lib/affiliate-recommendations";
+import CompletenessBadge from "@/components/CompletenessBadge";
+import { calculateCompletenessScore } from "@/lib/completeness";
 
 interface SpecGroup {
   [group: string]: Array<{
@@ -266,6 +268,9 @@ export default function YachtDetailClient() {
             <div className="no-print">
               <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel />
             </div>
+          </div>
+          <div className="flex items-center gap-2 mb-2">
+            <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel />
           </div>
           <p className="text-base sm:text-lg text-muted-foreground mb-4">
             A sailing yacht built by {yacht.manufacturer}.

--- a/app/(main)/yachts/[slug]/page.tsx
+++ b/app/(main)/yachts/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/seo";
 import { getYachtDetailData, getPrimaryImage } from "@/lib/yachts";
 import { getPriceSummary } from "@/lib/price-data";
+import { calculateCompletenessScore, shouldNoindex } from "@/lib/completeness";
 import YachtDetailClient from "./YachtDetailClient";
 
 // ISR: Revalidate yacht detail pages every hour
@@ -122,9 +123,16 @@ export async function generateMetadata({
     primaryImage: primaryImage ?? undefined,
   });
 
+  // P10.5: Calculate completeness score
+  const completenessScore = calculateCompletenessScore(data.yacht);
+  const noindexThin = shouldNoindex(completenessScore);
+
   // Add hreflang alternates
   return {
     ...baseMeta,
+    ...(noindexThin && {
+      robots: { index: false, follow: true },
+    }),
     alternates: {
       canonical: getSiteUrl(`/yachts/${slug}`),
       languages: {

--- a/app/api/completeness/route.ts
+++ b/app/api/completeness/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, sql, and } from "drizzle-orm";
+import { db, yachtModels, manufacturers, images, reviews, specValues } from "@/lib/db";
+import { calculateCompletenessScore, shouldNoindex } from "@/lib/completeness";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const manufacturerSlug = url.searchParams.get("manufacturer");
+    const minScore = parseInt(url.searchParams.get("minScore") || "0", 10);
+    const maxScore = parseInt(url.searchParams.get("maxScore") || "100", 10);
+    const limit = Math.min(parseInt(url.searchParams.get("limit") || "100", 10), 500);
+    const offset = parseInt(url.searchParams.get("offset") || "0", 10);
+
+    // Build query
+    let query = db
+      .select({
+        id: yachtModels.id,
+        modelName: yachtModels.modelName,
+        slug: yachtModels.slug,
+        year: yachtModels.year,
+        manufacturerName: manufacturers.name,
+        manufacturerId: yachtModels.manufacturerId,
+        lengthOverall: yachtModels.lengthOverall,
+        beam: yachtModels.beam,
+        draft: yachtModels.draft,
+        displacement: yachtModels.displacement,
+        ballast: yachtModels.ballast,
+        sailAreaMain: yachtModels.sailAreaMain,
+        rigType: yachtModels.rigType,
+        keelType: yachtModels.keelType,
+        hullMaterial: yachtModels.hullMaterial,
+        cabins: yachtModels.cabins,
+        berths: yachtModels.berths,
+        heads: yachtModels.heads,
+        engineHp: yachtModels.engineHp,
+        engineType: yachtModels.engineType,
+        fuelCapacity: yachtModels.fuelCapacity,
+        waterCapacity: yachtModels.waterCapacity,
+        description: yachtModels.description,
+        designNotes: yachtModels.designNotes,
+      })
+      .from(yachtModels)
+      .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+      .limit(limit)
+      .offset(offset);
+
+    if (manufacturerSlug) {
+      // Filter by manufacturer slug/name
+      query = db
+        .select({
+          id: yachtModels.id,
+          modelName: yachtModels.modelName,
+          slug: yachtModels.slug,
+          year: yachtModels.year,
+          manufacturerName: manufacturers.name,
+          manufacturerId: yachtModels.manufacturerId,
+          lengthOverall: yachtModels.lengthOverall,
+          beam: yachtModels.beam,
+          draft: yachtModels.draft,
+          displacement: yachtModels.displacement,
+          ballast: yachtModels.ballast,
+          sailAreaMain: yachtModels.sailAreaMain,
+          rigType: yachtModels.rigType,
+          keelType: yachtModels.keelType,
+          hullMaterial: yachtModels.hullMaterial,
+          cabins: yachtModels.cabins,
+          berths: yachtModels.berths,
+          heads: yachtModels.heads,
+          engineHp: yachtModels.engineHp,
+          engineType: yachtModels.engineType,
+          fuelCapacity: yachtModels.fuelCapacity,
+          waterCapacity: yachtModels.waterCapacity,
+          description: yachtModels.description,
+          designNotes: yachtModels.designNotes,
+        })
+        .from(yachtModels)
+        .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+        .where(eq(manufacturers.name, manufacturerSlug))
+        .limit(limit)
+        .offset(offset);
+    }
+
+    const yachts = await query;
+
+    // Calculate completeness for each yacht
+    const scored = yachts.map((yacht: Record<string, unknown>) => {
+      const score = calculateCompletenessScore(yacht);
+      return {
+        id: yacht.id,
+        modelName: yacht.modelName,
+        slug: yacht.slug,
+        year: yacht.year,
+        manufacturerName: yacht.manufacturerName,
+        lengthOverall: yacht.lengthOverall,
+        completenessScore: score,
+        noindex: shouldNoindex(score),
+      };
+    });
+
+    // Filter by score range
+    const filtered = scored.filter((y: { completenessScore: number }) =>
+      y.completenessScore >= minScore && y.completenessScore <= maxScore
+    );
+
+    // Calculate aggregate stats
+    const allScores: number[] = scored.map((y: { completenessScore: number }) => y.completenessScore);
+    const avgScore = allScores.length > 0
+      ? Math.round(allScores.reduce((a, b) => a + b, 0) / allScores.length)
+      : 0;
+
+    // Score distribution
+    const distribution = {
+      comprehensive: allScores.filter((s) => s >= 80).length,
+      good: allScores.filter((s) => s >= 60 && s < 80).length,
+      partial: allScores.filter((s) => s >= 40 && s < 60).length,
+      basic: allScores.filter((s) => s >= 20 && s < 40).length,
+      minimal: allScores.filter((s) => s < 20).length,
+    };
+
+    return NextResponse.json({
+      total: scored.length,
+      averageScore: avgScore,
+      distribution,
+      yachts: filtered,
+    });
+  } catch (error) {
+    console.error("[completeness] Error:", error);
+    return NextResponse.json({ error: "Failed to calculate completeness" }, { status: 500 });
+  }
+}

--- a/components/CompletenessBadge.tsx
+++ b/components/CompletenessBadge.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { getCompletenessLevel } from "@/lib/completeness";
+
+interface CompletenessBadgeProps {
+  score: number;
+  size?: "sm" | "md" | "lg";
+  showLabel?: boolean;
+  className?: string;
+}
+
+export default function CompletenessBadge({
+  score,
+  size = "sm",
+  showLabel = false,
+  className = "",
+}: CompletenessBadgeProps) {
+  const level = getCompletenessLevel(score);
+
+  const sizeClasses = {
+    sm: "text-xs px-2 py-0.5",
+    md: "text-sm px-3 py-1",
+    lg: "text-base px-4 py-1.5",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full font-medium ${level.bgColor} ${level.textColor} ${sizeClasses[size]} ${className}`}
+      title={`Data completeness: ${score}% — ${level.label}`}
+      data-testid="completeness-badge"
+    >
+      <span
+        className={`inline-block w-2 h-2 rounded-full ${level.color}`}
+        aria-hidden="true"
+      />
+      {score}%
+      {showLabel && (
+        <span className="hidden sm:inline opacity-75">· {level.label}</span>
+      )}
+    </span>
+  );
+}

--- a/lib/completeness.ts
+++ b/lib/completeness.ts
@@ -1,0 +1,158 @@
+/**
+ * Spec Completeness Scoring (P10.5)
+ * 
+ * Calculates a 0-100% completeness score for yacht models
+ * based on how many spec fields are populated, with weighted categories.
+ */
+
+// Fields that contribute to completeness, grouped by category with weights
+const SPEC_CATEGORIES = {
+  // Core dimensions — most important (weight: 30)
+  dimensions: {
+    weight: 30,
+    fields: ["lengthOverall", "beam", "draft"] as const,
+  },
+  // Performance specs (weight: 20)
+  performance: {
+    weight: 20,
+    fields: ["displacement", "ballast", "sailAreaMain", "rigType", "keelType"] as const,
+  },
+  // Construction (weight: 15)
+  construction: {
+    weight: 15,
+    fields: ["hullMaterial", "engineHp", "engineType"] as const,
+  },
+  // Accommodation (weight: 15)
+  accommodation: {
+    weight: 15,
+    fields: ["cabins", "berths", "heads"] as const,
+  },
+  // Tankage & utility (weight: 10)
+  utility: {
+    weight: 10,
+    fields: ["fuelCapacity", "waterCapacity"] as const,
+  },
+  // Descriptive content (weight: 10)
+  content: {
+    weight: 10,
+    fields: ["description", "designNotes"] as const,
+  },
+} as const;
+
+type YachtModel = Record<string, unknown>;
+
+// Accept any object with string keys for flexibility
+function toRecord(obj: object): Record<string, unknown> {
+  return obj as Record<string, unknown>;
+}
+
+/**
+ * Calculate the completeness score for a single yacht model.
+ * Returns a number between 0 and 100.
+ */
+export function calculateCompletenessScore(yacht: object): number {
+  const record = toRecord(yacht);
+  let totalScore = 0;
+
+  for (const category of Object.values(SPEC_CATEGORIES)) {
+    const populatedCount = category.fields.filter((field) => {
+      const value = record[field];
+      if (value === null || value === undefined) return false;
+      if (typeof value === "string" && value.trim() === "") return false;
+      return true;
+    }).length;
+
+    const categoryScore = populatedCount / category.fields.length;
+    totalScore += categoryScore * category.weight;
+  }
+
+  return Math.round(totalScore);
+}
+
+/**
+ * Get completeness level for display purposes.
+ */
+export function getCompletenessLevel(score: number): {
+  label: string;
+  color: string;
+  bgColor: string;
+  textColor: string;
+} {
+  if (score >= 80) {
+    return {
+      label: "Comprehensive",
+      color: "bg-green-500",
+      bgColor: "bg-green-50",
+      textColor: "text-green-700",
+    };
+  }
+  if (score >= 60) {
+    return {
+      label: "Good",
+      color: "bg-blue-500",
+      bgColor: "bg-blue-50",
+      textColor: "text-blue-700",
+    };
+  }
+  if (score >= 40) {
+    return {
+      label: "Partial",
+      color: "bg-yellow-500",
+      bgColor: "bg-yellow-50",
+      textColor: "text-yellow-700",
+    };
+  }
+  if (score >= 20) {
+    return {
+      label: "Basic",
+      color: "bg-orange-500",
+      bgColor: "bg-orange-50",
+      textColor: "text-orange-700",
+    };
+  }
+  return {
+    label: "Minimal",
+    color: "bg-red-500",
+    bgColor: "bg-red-50",
+    textColor: "text-red-700",
+  };
+}
+
+/**
+ * Check if a yacht should be noindexed based on completeness.
+ * Below 30% completeness → noindex to avoid thin content SEO issues.
+ */
+export function shouldNoindex(score: number, threshold = 30): boolean {
+  return score < threshold;
+}
+
+/**
+ * Calculate average completeness for an array of yachts.
+ */
+export function calculateAverageScore(yachts: YachtModel[]): number {
+  if (yachts.length === 0) return 0;
+  const total = yachts.reduce((sum, y) => sum + calculateCompletenessScore(y), 0);
+  return Math.round(total / yachts.length);
+}
+
+/**
+ * Get the list of missing fields for a yacht model (for improvement suggestions).
+ */
+export function getMissingFields(yacht: object): string[] {
+  const record = toRecord(yacht);
+  const missing: string[] = [];
+
+  for (const category of Object.values(SPEC_CATEGORIES)) {
+    for (const field of category.fields) {
+      const value = record[field];
+      if (value === null || value === undefined || (typeof value === "string" && value.trim() === "")) {
+        missing.push(field);
+      }
+    }
+  }
+
+  return missing;
+}
+
+// Export category info for display
+export { SPEC_CATEGORIES };

--- a/tests/spec-completeness.spec.ts
+++ b/tests/spec-completeness.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { calculateCompletenessScore, getCompletenessLevel, shouldNoindex, calculateAverageScore, getMissingFields } from './completeness';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://info.sailboats.fr';
+
+// Note: The unit tests for completeness scoring are tested indirectly via API/UI tests
+// since Playwright doesn't support direct TS module imports.
+// We test the scoring through the /api/completeness endpoint and UI rendering.
+
+test.describe('Spec Completeness Scoring (P10.5)', () => {
+  test.describe('API - Completeness Endpoint', () => {
+    test('GET /api/completeness returns completeness data', async ({ request }) => {
+      const res = await request.get(`${BASE_URL}/api/completeness?limit=5`);
+      expect(res.status()).toBe(200);
+      const data = await res.json();
+
+      expect(data).toHaveProperty('total');
+      expect(data).toHaveProperty('averageScore');
+      expect(data).toHaveProperty('distribution');
+      expect(data).toHaveProperty('yachts');
+      expect(Array.isArray(data.yachts)).toBe(true);
+      expect(data.total).toBeGreaterThan(0);
+      expect(data.averageScore).toBeGreaterThanOrEqual(0);
+      expect(data.averageScore).toBeLessThanOrEqual(100);
+    });
+
+    test('each yacht has a completeness score between 0 and 100', async ({ request }) => {
+      const res = await request.get(`${BASE_URL}/api/completeness?limit=20`);
+      const data = await res.json();
+
+      for (const yacht of data.yachts) {
+        expect(yacht.completenessScore).toBeGreaterThanOrEqual(0);
+        expect(yacht.completenessScore).toBeLessThanOrEqual(100);
+        expect(yacht).toHaveProperty('id');
+        expect(yacht).toHaveProperty('modelName');
+        expect(yacht).toHaveProperty('noindex');
+        expect(typeof yacht.noindex).toBe('boolean');
+      }
+    });
+
+    test('score distribution sums to total', async ({ request }) => {
+      const res = await request.get(`${BASE_URL}/api/completeness?limit=50`);
+      const data = await res.json();
+
+      const distSum = data.distribution.comprehensive + data.distribution.good +
+        data.distribution.partial + data.distribution.basic + data.distribution.minimal;
+      expect(distSum).toBe(data.total);
+    });
+
+    test('supports minScore and maxScore filtering', async ({ request }) => {
+      const res = await request.get(`${BASE_URL}/api/completeness?minScore=50&maxScore=100&limit=10`);
+      const data = await res.json();
+
+      for (const yacht of data.yachts) {
+        expect(yacht.completenessScore).toBeGreaterThanOrEqual(50);
+        expect(yacht.completenessScore).toBeLessThanOrEqual(100);
+      }
+    });
+
+    test('supports limit parameter', async ({ request }) => {
+      const res = await request.get(`${BASE_URL}/api/completeness?limit=3`);
+      const data = await res.json();
+
+      expect(data.yachts.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  test.describe('Completeness Badge on Yacht Detail', () => {
+    test('completeness badge appears on yacht detail page', async ({ page }) => {
+      // First get a yacht slug from the API
+      const apiRes = await page.request.get(`${BASE_URL}/api/completeness?limit=1`);
+      const apiData = await apiRes.json();
+
+      if (apiData.yachts.length > 0 && apiData.yachts[0].slug) {
+        await page.goto(`${BASE_URL}/yachts/${apiData.yachts[0].slug}`);
+        const badge = page.getByTestId('completeness-badge');
+        await expect(badge.first()).toBeVisible({ timeout: 10000 });
+      }
+    });
+  });
+
+  test.describe('SEO - Noindex for Low Completeness', () => {
+    test('yachts below threshold get noindex meta tag', async ({ request }) => {
+      // Find low-completeness yachts
+      const res = await request.get(`${BASE_URL}/api/completeness?maxScore=29&limit=5`);
+      const data = await res.json();
+
+      for (const yacht of data.yachts) {
+        if (yacht.noindex && yacht.slug) {
+          // Check that the page has noindex meta
+          const pageRes = await request.get(`${BASE_URL}/yachts/${yacht.slug}`);
+          const html = await pageRes.text();
+          // The noindex should be in the rendered HTML meta tag
+          // Note: this may not work for client-rendered pages, but the server-rendered metadata should include it
+          expect(html).toContain('noindex');
+          break; // Just verify one
+        }
+      }
+    });
+  });
+
+  test.describe('Completeness Badge on Yacht Listing', () => {
+    test('completeness badges appear on yacht listing cards', async ({ page }) => {
+      await page.goto(`${BASE_URL}/yachts`);
+
+      // Wait for yacht cards to load
+      const badges = page.getByTestId('completeness-badge');
+      const count = await badges.count();
+      // Should have at least some badges visible
+      expect(count).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements P10.5 — Spec completeness scoring for yacht models.

### Changes
- **`lib/completeness.ts`**: Weighted completeness scoring utility across 6 categories (dimensions 30%, performance 20%, construction 15%, accommodation 15%, utility 10%, content 10%)
- **`/api/completeness`**: API endpoint with score filtering (minScore/maxScore), manufacturer filter, pagination, and score distribution
- **`CompletenessBadge`**: Color-coded badge component (Comprehensive ≥80%, Good ≥60%, Partial ≥40%, Basic ≥20%, Minimal <20%)
- **Yacht detail pages**: Completeness badge shown below the title
- **Yacht listing cards**: Completeness badge shown next to price tier badge
- **SEO**: Yachts below 30% completeness get `noindex` meta tag to prevent thin content issues
- **Playwright tests**: API tests, badge rendering, noindex verification

### Scoring Logic
Each category contributes its weight proportionally to how many fields are populated. For example, if 2 of 3 dimension fields (LOA, beam, draft) are filled, that category scores 2/3 × 30 = 20 points.

Closes #161