### PR TITLE
fix: expose P10.1 source provenance fields in yacht API mapper

### DIFF
--- a/lib/mappers/yacht.ts
+++ b/lib/mappers/yacht.ts
@@ -30,6 +30,10 @@ export function mapYachtToListDto(row: any): {
   sourceUrl?: string | null;
   sourceAttribution?: string | null;
   adminLinks?: any; // JSONB
+  dataSource?: string | null;
+  sourceConfidence?: number | null;
+  lastVerifiedAt?: Date | null;
+  completenessScore?: number | null;
   createdAt?: Date | null;
   updatedAt?: Date | null;
 } {
@@ -61,6 +65,10 @@ export function mapYachtToListDto(row: any): {
     sourceUrl: row.source_url ?? undefined,
     sourceAttribution: row.source_attribution ?? undefined,
     adminLinks: row.admin_links ?? undefined,
+    dataSource: row.data_source ?? undefined,
+    sourceConfidence: row.source_confidence ?? undefined,
+    lastVerifiedAt: row.last_verified_at ?? undefined,
+    completenessScore: row.completeness_score ?? undefined,
     createdAt: row.created_at ?? undefined,
     updatedAt: row.updated_at ?? undefined,
   };


### PR DESCRIPTION
Add dataSource, sourceConfidence, lastVerifiedAt, and completenessScore
to the mapYachtToListDto return type so the API returns source tracking data.
