### PR TITLE
fix: media API route returns empty response

### DIFF
--- a/app/(main)/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/(main)/yachts/[slug]/YachtDetailClient.tsx
@@ -20,6 +20,7 @@ import AffiliateRecommendations from "@/app/components/AffiliateRecommendations"
 import YachtImage from "@/app/components/yacht/YachtImage";
 import { getAffiliateRecommendations } from "@/lib/affiliate-recommendations";
 import CompletenessBadge from "@/components/CompletenessBadge";
+import MediaGallery from "@/components/MediaGallery";
 import { calculateCompletenessScore } from "@/lib/completeness";
 
 interface SpecGroup {
@@ -74,6 +75,22 @@ interface YachtData {
     reviewDate: string | null;
     authorName: string | null;
     sourceUrl: string | null;
+  }>;
+  mediaAssets?: Array<{
+    id: number;
+    mediaType: string;
+    title: string | null;
+    description: string | null;
+    url: string | null;
+    embedUrl: string | null;
+    thumbnailUrl: string | null;
+    sourceUrl: string | null;
+    fileFormat: string | null;
+    fileSize: number | null;
+    caption: string | null;
+    altText: string | null;
+    isPrimary: boolean;
+    sortOrder: number;
   }>;
 }
 
@@ -355,6 +372,11 @@ export default function YachtDetailClient() {
           )}
         </div>
       </div>
+
+      {/* Media Gallery (P10.2) */}
+      {yacht.mediaAssets && yacht.mediaAssets.length > 0 && (
+        <MediaGallery mediaAssets={yacht.mediaAssets} />
+      )}
 
       {/* Specs by Group */}
       <div className="space-y-6 sm:space-y-8">

--- a/app/api/admin/media/[id]/route.ts
+++ b/app/api/admin/media/[id]/route.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { ensureSchema, pool } from '@/lib/db'
+import { revalidateTag } from 'next/cache'
+
+function toNum(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isNaN(n) ? null : n
+}
+
+/** GET /api/admin/media/[id] — get single media asset */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { id: idParam } = await params
+    const id = parseInt(idParam, 10)
+
+    if (isNaN(id)) {
+      return NextResponse.json(
+        { error: 'Invalid media asset ID' },
+        { status: 400 },
+      )
+    }
+
+    const result = await pool.query(
+      `SELECT id, yacht_model_id, media_type, title, description, url, embed_url,
+              thumbnail_url, source_url, file_format, file_size, caption, alt_text,
+              is_primary, sort_order, data_source, source_confidence, last_verified_at,
+              created_at, updated_at
+       FROM media_assets WHERE id = $1`,
+      [id],
+    )
+
+    if (result.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Media asset not found' },
+        { status: 404 },
+      )
+    }
+
+    const asset = result.rows[0]
+    return NextResponse.json({
+      mediaAsset: {
+        ...asset,
+        yacht_model_id: toNum(asset.yacht_model_id),
+        file_size: toNum(asset.file_size),
+        sort_order: toNum(asset.sort_order),
+        source_confidence: toNum(asset.source_confidence),
+      },
+    })
+  } catch (error) {
+    console.error('Failed to fetch media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch media asset' },
+      { status: 500 },
+    )
+  }
+}
+
+/** PATCH /api/admin/media/[id] — update media asset */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { id: idParam } = await params
+    const id = parseInt(idParam, 10)
+
+    if (isNaN(id)) {
+      return NextResponse.json(
+        { error: 'Invalid media asset ID' },
+        { status: 400 },
+      )
+    }
+
+    const body = await request.json()
+
+    const allowedFields = [
+      'media_type', 'title', 'description', 'url', 'embed_url',
+      'thumbnail_url', 'source_url', 'file_format', 'file_size', 'caption',
+      'alt_text', 'is_primary', 'sort_order', 'data_source', 'source_confidence',
+      'last_verified_at',
+    ]
+
+    const setClauses: string[] = []
+    const values: unknown[] = []
+    let paramIdx = 1
+
+    for (const field of allowedFields) {
+      if (field in body) {
+        setClauses.push(`${field} = $${paramIdx++}`)
+        values.push(body[field] ?? null)
+      }
+    }
+
+    setClauses.push(`updated_at = NOW()`)
+
+    if (setClauses.length === 1) {
+      return NextResponse.json(
+        { error: 'No valid fields to update' },
+        { status: 400 },
+      )
+    }
+
+    values.push(id)
+    const result = await pool.query(
+      `UPDATE media_assets SET ${setClauses.join(', ')} WHERE id = $${paramIdx} RETURNING *`,
+      values,
+    )
+
+    if (result.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Media asset not found' },
+        { status: 404 },
+      )
+    }
+
+    const yachtId = toNum(result.rows[0].yacht_model_id)
+    revalidateTag('yachts')
+    if (yachtId) revalidateTag(`yacht:${yachtId}`)
+
+    const asset = result.rows[0]
+    return NextResponse.json({
+      mediaAsset: {
+        ...asset,
+        yacht_model_id: toNum(asset.yacht_model_id),
+        file_size: toNum(asset.file_size),
+        sort_order: toNum(asset.sort_order),
+        source_confidence: toNum(asset.source_confidence),
+      },
+    })
+  } catch (error) {
+    console.error('Failed to update media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to update media asset' },
+      { status: 500 },
+    )
+  }
+}
+
+/** DELETE /api/admin/media/[id] — delete media asset */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { id: idParam } = await params
+    const id = parseInt(idParam, 10)
+
+    if (isNaN(id)) {
+      return NextResponse.json(
+        { error: 'Invalid media asset ID' },
+        { status: 400 },
+      )
+    }
+
+    const existing = await pool.query(
+      'SELECT yacht_model_id FROM media_assets WHERE id = $1',
+      [id],
+    )
+
+    if (existing.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Media asset not found' },
+        { status: 404 },
+      )
+    }
+
+    const yachtId = toNum(existing.rows[0].yacht_model_id)
+
+    await pool.query('DELETE FROM media_assets WHERE id = $1', [id])
+
+    // Update media_count
+    if (yachtId) {
+      await pool.query(
+        `UPDATE yacht_models SET media_count = (
+          SELECT COUNT(*) FROM media_assets WHERE yacht_model_id = $1
+        ) WHERE id = $1`,
+        [yachtId],
+      )
+    }
+
+    revalidateTag('yachts')
+    if (yachtId) revalidateTag(`yacht:${yachtId}`)
+
+    return NextResponse.json({ message: 'Media asset deleted successfully' })
+  } catch (error) {
+    console.error('Failed to delete media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete media asset' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/media/route.ts
+++ b/app/api/admin/media/route.ts
@@ -1,0 +1,359 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { ensureSchema, pool } from '@/lib/db'
+import { revalidateTag } from 'next/cache'
+
+// Numeric DB fields come as strings — normalize them
+function toNum(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isNaN(n) ? null : n
+}
+
+/** GET /api/admin/media?yachtId=N — list media assets for a yacht */
+export async function GET(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { searchParams } = new URL(request.url)
+    const yachtIdParam = searchParams.get('yachtId')
+
+    if (!yachtIdParam) {
+      return NextResponse.json(
+        { error: 'yachtId query parameter is required' },
+        { status: 400 },
+      )
+    }
+
+    const yachtId = parseInt(yachtIdParam, 10)
+    if (isNaN(yachtId)) {
+      return NextResponse.json({ error: 'Invalid yacht ID' }, { status: 400 })
+    }
+
+    const result = await pool.query(
+      `SELECT id, yacht_model_id, media_type, title, description, url, embed_url,
+              thumbnail_url, source_url, file_format, file_size, caption, alt_text,
+              is_primary, sort_order, data_source, source_confidence, last_verified_at,
+              created_at, updated_at
+       FROM media_assets
+       WHERE yacht_model_id = $1
+       ORDER BY sort_order, created_at`,
+      [yachtId],
+    )
+
+    // Normalize numeric fields
+    const assets = result.rows.map((row: Record<string, unknown>) => ({
+      ...row,
+      yacht_model_id: toNum(row.yacht_model_id as string | number | null),
+      file_size: toNum(row.file_size as string | number | null),
+      sort_order: toNum(row.sort_order as string | number | null),
+      source_confidence: toNum(row.source_confidence as string | number | null),
+      is_primary: row.is_primary === true || row.is_primary === 'true',
+    }))
+
+    return NextResponse.json({ mediaAssets: assets })
+  } catch (error) {
+    console.error('Failed to fetch media assets:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch media assets' },
+      { status: 500 },
+    )
+  }
+}
+
+/** POST /api/admin/media — create a new media asset */
+export async function POST(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const body = await request.json()
+
+    const {
+      yachtModelId,
+      mediaType = 'photo',
+      title,
+      description,
+      url,
+      embedUrl,
+      thumbnailUrl,
+      sourceUrl,
+      fileFormat,
+      fileSize,
+      caption,
+      altText,
+      isPrimary = false,
+      sortOrder = 0,
+      dataSource = 'manual',
+      sourceConfidence = 50,
+    } = body
+
+    if (!yachtModelId) {
+      return NextResponse.json(
+        { error: 'yachtModelId is required' },
+        { status: 400 },
+      )
+    }
+
+    const yachtId = Number(yachtModelId)
+    if (isNaN(yachtId)) {
+      return NextResponse.json(
+        { error: 'Invalid yachtModelId' },
+        { status: 400 },
+      )
+    }
+
+    // Verify yacht exists
+    const yachtCheck = await pool.query(
+      'SELECT id FROM yacht_models WHERE id = $1',
+      [yachtId],
+    )
+    if (yachtCheck.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Yacht not found' },
+        { status: 404 },
+      )
+    }
+
+    const result = await pool.query(
+      `INSERT INTO media_assets (
+        yacht_model_id, media_type, title, description, url, embed_url,
+        thumbnail_url, source_url, file_format, file_size, caption, alt_text,
+        is_primary, sort_order, data_source, source_confidence
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+      RETURNING *`,
+      [
+        yachtId,
+        mediaType,
+        title || null,
+        description || null,
+        url || null,
+        embedUrl || null,
+        thumbnailUrl || null,
+        sourceUrl || null,
+        fileFormat || null,
+        fileSize || null,
+        caption || null,
+        altText || null,
+        isPrimary,
+        sortOrder || 0,
+        dataSource,
+        sourceConfidence || 50,
+      ],
+    )
+
+    // Update media_count on the yacht
+    await pool.query(
+      `UPDATE yacht_models SET media_count = (
+        SELECT COUNT(*) FROM media_assets WHERE yacht_model_id = $1
+      ) WHERE id = $1`,
+      [yachtId],
+    )
+
+    revalidateTag('yachts')
+    revalidateTag(`yacht:${yachtId}`)
+
+    const asset = result.rows[0]
+    return NextResponse.json(
+      {
+        mediaAsset: {
+          ...asset,
+          yacht_model_id: toNum(asset.yacht_model_id),
+          file_size: toNum(asset.file_size),
+          sort_order: toNum(asset.sort_order),
+          source_confidence: toNum(asset.source_confidence),
+        },
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    console.error('Failed to create media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to create media asset' },
+      { status: 500 },
+    )
+  }
+}
+
+/** PATCH /api/admin/media?id=N — update a media asset */
+export async function PATCH(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { searchParams } = new URL(request.url)
+    const idParam = searchParams.get('id')
+
+    if (!idParam) {
+      return NextResponse.json(
+        { error: 'id query parameter is required' },
+        { status: 400 },
+      )
+    }
+
+    const id = parseInt(idParam, 10)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: 'Invalid media asset ID' }, { status: 400 })
+    }
+
+    const body = await request.json()
+
+    // Build dynamic SET clause
+    const allowedFields = [
+      'media_type', 'title', 'description', 'url', 'embed_url',
+      'thumbnail_url', 'source_url', 'file_format', 'file_size', 'caption',
+      'alt_text', 'is_primary', 'sort_order', 'data_source', 'source_confidence',
+      'last_verified_at',
+    ]
+
+    const setClauses: string[] = []
+    const values: unknown[] = []
+    let paramIdx = 1
+
+    for (const field of allowedFields) {
+      if (field in body) {
+        setClauses.push(`${field} = $${paramIdx++}`)
+        values.push(body[field] ?? null)
+      }
+    }
+
+    // Always update updated_at
+    setClauses.push(`updated_at = NOW()`)
+
+    if (setClauses.length === 1) {
+      // Only updated_at, nothing to update
+      return NextResponse.json(
+        { error: 'No valid fields to update' },
+        { status: 400 },
+      )
+    }
+
+    values.push(id)
+    const result = await pool.query(
+      `UPDATE media_assets SET ${setClauses.join(', ')} WHERE id = $${paramIdx} RETURNING *`,
+      values,
+    )
+
+    if (result.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Media asset not found' },
+        { status: 404 },
+      )
+    }
+
+    const yachtId = toNum(result.rows[0].yacht_model_id)
+    revalidateTag('yachts')
+    if (yachtId) revalidateTag(`yacht:${yachtId}`)
+
+    const asset = result.rows[0]
+    return NextResponse.json({
+      mediaAsset: {
+        ...asset,
+        yacht_model_id: toNum(asset.yacht_model_id),
+        file_size: toNum(asset.file_size),
+        sort_order: toNum(asset.sort_order),
+        source_confidence: toNum(asset.source_confidence),
+      },
+    })
+  } catch (error) {
+    console.error('Failed to update media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to update media asset' },
+      { status: 500 },
+    )
+  }
+}
+
+/** DELETE /api/admin/media?id=N — delete a media asset */
+export async function DELETE(request: Request) {
+  const cookieStore = cookies()
+  const authCookie = cookieStore.get('auth')?.value
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: 'Unauthorized - Admin access required' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    await ensureSchema()
+    const { searchParams } = new URL(request.url)
+    const idParam = searchParams.get('id')
+
+    if (!idParam) {
+      return NextResponse.json(
+        { error: 'id query parameter is required' },
+        { status: 400 },
+      )
+    }
+
+    const id = parseInt(idParam, 10)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: 'Invalid media asset ID' }, { status: 400 })
+    }
+
+    // Get yacht_model_id before deleting for cache invalidation
+    const existing = await pool.query(
+      'SELECT yacht_model_id FROM media_assets WHERE id = $1',
+      [id],
+    )
+
+    if (existing.rows.length === 0) {
+      return NextResponse.json(
+        { error: 'Media asset not found' },
+        { status: 404 },
+      )
+    }
+
+    const yachtId = toNum(existing.rows[0].yacht_model_id)
+
+    await pool.query('DELETE FROM media_assets WHERE id = $1', [id])
+
+    // Update media_count on the yacht
+    if (yachtId) {
+      await pool.query(
+        `UPDATE yacht_models SET media_count = (
+          SELECT COUNT(*) FROM media_assets WHERE yacht_model_id = $1
+        ) WHERE id = $1`,
+        [yachtId],
+      )
+    }
+
+    revalidateTag('yachts')
+    if (yachtId) revalidateTag(`yacht:${yachtId}`)
+
+    return NextResponse.json({ message: 'Media asset deleted successfully' })
+  } catch (error) {
+    console.error('Failed to delete media asset:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete media asset' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/yachts/[slug]/media/route.ts
+++ b/app/api/yachts/[slug]/media/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server'
+import { unstable_cache } from 'next/cache'
+import { ensureSchema, pool } from '@/lib/db'
+
+// ISR: revalidate every 5 minutes
+export const revalidate = 300
+
+export interface MediaAsset {
+  id: number
+  mediaType: string
+  title: string | null
+  description: string | null
+  url: string | null
+  embedUrl: string | null
+  thumbnailUrl: string | null
+  sourceUrl: string | null
+  fileFormat: string | null
+  fileSize: number | null
+  caption: string | null
+  altText: string | null
+  isPrimary: boolean
+  sortOrder: number
+}
+
+function toNum(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isNaN(n) ? null : n
+}
+
+/** GET /api/yachts/[slug]/media — public media assets for a yacht */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    await ensureSchema()
+    const { slug } = await params
+
+    const data = unstable_cache(
+      async () => {
+        // Resolve yacht id from slug
+        const yachtResult = await pool.query(
+          'SELECT id FROM yacht_models WHERE slug = $1',
+          [slug],
+        )
+
+        if (yachtResult.rows.length === 0) return null
+
+        const yachtId = toNum(yachtResult.rows[0].id as string | number)!
+
+        const result = await pool.query(
+          `SELECT id, media_type, title, description, url, embed_url,
+                  thumbnail_url, source_url, file_format, file_size, caption,
+                  alt_text, is_primary, sort_order
+           FROM media_assets
+           WHERE yacht_model_id = $1
+           ORDER BY sort_order, created_at`,
+          [yachtId],
+        )
+
+        const assets: MediaAsset[] = result.rows.map(
+          (row: Record<string, unknown>) => ({
+            id: toNum(row.id as string | number | null)!,
+            mediaType: String(row.media_type ?? 'photo'),
+            title: (row.title as string) ?? null,
+            description: (row.description as string) ?? null,
+            url: (row.url as string) ?? null,
+            embedUrl: (row.embed_url as string) ?? null,
+            thumbnailUrl: (row.thumbnail_url as string) ?? null,
+            sourceUrl: (row.source_url as string) ?? null,
+            fileFormat: (row.file_format as string) ?? null,
+            fileSize: toNum(row.file_size as string | number | null),
+            caption: (row.caption as string) ?? null,
+            altText: (row.alt_text as string) ?? null,
+            isPrimary: row.is_primary === true || row.is_primary === 'true',
+            sortOrder: toNum(row.sort_order as string | number | null) ?? 0,
+          }),
+        )
+
+        // Group by media type for easier frontend consumption
+        const grouped: Record<string, MediaAsset[]> = {}
+        for (const asset of assets) {
+          const type = asset.mediaType
+          if (!grouped[type]) grouped[type] = []
+          grouped[type].push(asset)
+        }
+
+        return { mediaAssets: assets, grouped, total: assets.length }
+      },
+      [`api:yacht-media:${slug}`],
+      { tags: [`yacht:${slug}`, 'yachts'], revalidate: 300 },
+    )()
+
+    if (!data) {
+      return NextResponse.json({ error: 'Yacht not found' }, { status: 404 })
+    }
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Error fetching yacht media:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch media' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/yachts/[slug]/media/route.ts
+++ b/app/api/yachts/[slug]/media/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server'
-import { unstable_cache } from 'next/cache'
 import { ensureSchema, pool } from '@/lib/db'
 
 // ISR: revalidate every 5 minutes
@@ -37,66 +36,56 @@ export async function GET(
     await ensureSchema()
     const { slug } = await params
 
-    const data = unstable_cache(
-      async () => {
-        // Resolve yacht id from slug
-        const yachtResult = await pool.query(
-          'SELECT id FROM yacht_models WHERE slug = $1',
-          [slug],
-        )
+    // Resolve yacht id from slug
+    const yachtResult = await pool.query(
+      'SELECT id FROM yacht_models WHERE slug = $1',
+      [slug],
+    )
 
-        if (yachtResult.rows.length === 0) return null
-
-        const yachtId = toNum(yachtResult.rows[0].id as string | number)!
-
-        const result = await pool.query(
-          `SELECT id, media_type, title, description, url, embed_url,
-                  thumbnail_url, source_url, file_format, file_size, caption,
-                  alt_text, is_primary, sort_order
-           FROM media_assets
-           WHERE yacht_model_id = $1
-           ORDER BY sort_order, created_at`,
-          [yachtId],
-        )
-
-        const assets: MediaAsset[] = result.rows.map(
-          (row: Record<string, unknown>) => ({
-            id: toNum(row.id as string | number | null)!,
-            mediaType: String(row.media_type ?? 'photo'),
-            title: (row.title as string) ?? null,
-            description: (row.description as string) ?? null,
-            url: (row.url as string) ?? null,
-            embedUrl: (row.embed_url as string) ?? null,
-            thumbnailUrl: (row.thumbnail_url as string) ?? null,
-            sourceUrl: (row.source_url as string) ?? null,
-            fileFormat: (row.file_format as string) ?? null,
-            fileSize: toNum(row.file_size as string | number | null),
-            caption: (row.caption as string) ?? null,
-            altText: (row.alt_text as string) ?? null,
-            isPrimary: row.is_primary === true || row.is_primary === 'true',
-            sortOrder: toNum(row.sort_order as string | number | null) ?? 0,
-          }),
-        )
-
-        // Group by media type for easier frontend consumption
-        const grouped: Record<string, MediaAsset[]> = {}
-        for (const asset of assets) {
-          const type = asset.mediaType
-          if (!grouped[type]) grouped[type] = []
-          grouped[type].push(asset)
-        }
-
-        return { mediaAssets: assets, grouped, total: assets.length }
-      },
-      [`api:yacht-media:${slug}`],
-      { tags: [`yacht:${slug}`, 'yachts'], revalidate: 300 },
-    )()
-
-    if (!data) {
+    if (yachtResult.rows.length === 0) {
       return NextResponse.json({ error: 'Yacht not found' }, { status: 404 })
     }
 
-    return NextResponse.json(data)
+    const yachtId = toNum(yachtResult.rows[0].id as string | number)!
+
+    const result = await pool.query(
+      `SELECT id, media_type, title, description, url, embed_url,
+              thumbnail_url, source_url, file_format, file_size, caption,
+              alt_text, is_primary, sort_order
+       FROM media_assets
+       WHERE yacht_model_id = $1
+       ORDER BY sort_order, created_at`,
+      [yachtId],
+    )
+
+    const assets: MediaAsset[] = result.rows.map(
+      (row: Record<string, unknown>) => ({
+        id: toNum(row.id as string | number | null)!,
+        mediaType: String(row.media_type ?? 'photo'),
+        title: (row.title as string) ?? null,
+        description: (row.description as string) ?? null,
+        url: (row.url as string) ?? null,
+        embedUrl: (row.embed_url as string) ?? null,
+        thumbnailUrl: (row.thumbnail_url as string) ?? null,
+        sourceUrl: (row.source_url as string) ?? null,
+        fileFormat: (row.file_format as string) ?? null,
+        fileSize: toNum(row.file_size as string | number | null),
+        caption: (row.caption as string) ?? null,
+        altText: (row.alt_text as string) ?? null,
+        isPrimary: row.is_primary === true || row.is_primary === 'true',
+        sortOrder: toNum(row.sort_order as string | number | null) ?? 0,
+      }),
+    )
+
+    // Group by media type for easier frontend consumption
+    const grouped: Record<string, MediaAsset[]> = {}
+    for (const asset of assets) {
+      const type = asset.mediaType
+      if (!grouped[type]) grouped[type] = []
+      grouped[type].push(asset)
+    }
+
+    return NextResponse.json({ mediaAssets: assets, grouped, total: assets.length })
   } catch (error) {
     console.error('Error fetching yacht media:', error)
     return NextResponse.json(

--- a/app/api/yachts/[slug]/route.ts
+++ b/app/api/yachts/[slug]/route.ts
@@ -9,6 +9,7 @@ import {
   specCategories,
   images,
   reviews,
+  pool,
 } from "@/lib/db";
 import { eq } from "drizzle-orm";
 import { getYachtDetailData } from "@/lib/yachts";
@@ -55,6 +56,33 @@ export async function GET(
           });
         }
 
+        // Fetch media assets (P10.2)
+        const mediaResult = await pool.query(
+          `SELECT id, media_type, title, description, url, embed_url, thumbnail_url,
+                  source_url, file_format, file_size, caption, alt_text, is_primary, sort_order
+           FROM media_assets
+           WHERE yacht_model_id = $1
+           ORDER BY sort_order, created_at`,
+          [yacht.id],
+        );
+
+        const mediaAssets = mediaResult.rows.map((row: Record<string, unknown>) => ({
+          id: toNum(row.id as string | number | null),
+          mediaType: String(row.media_type ?? "photo"),
+          title: (row.title as string) ?? null,
+          description: (row.description as string) ?? null,
+          url: (row.url as string) ?? null,
+          embedUrl: (row.embed_url as string) ?? null,
+          thumbnailUrl: (row.thumbnail_url as string) ?? null,
+          sourceUrl: (row.source_url as string) ?? null,
+          fileFormat: (row.file_format as string) ?? null,
+          fileSize: toNum(row.file_size as string | number | null),
+          caption: (row.caption as string) ?? null,
+          altText: (row.alt_text as string) ?? null,
+          isPrimary: row.is_primary === true || row.is_primary === "true",
+          sortOrder: toNum(row.sort_order as string | number | null) ?? 0,
+        }));
+
         const response = {
           id: yacht.id,
           manufacturerId: yacht.manufacturerId,
@@ -88,6 +116,7 @@ export async function GET(
           specsByGroup: parsedSpecsByGroup,
           images,
           reviews,
+          mediaAssets,
         };
 
         return response;

--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Image as ImageIcon,
+  PlayCircle,
+  FileText,
+  Layout,
+  Map,
+  RotateCcw,
+  Box,
+  ChevronLeft,
+  ChevronRight,
+  X,
+  ExternalLink,
+  Download,
+  Video,
+} from "lucide-react";
+
+export interface MediaAsset {
+  id: number;
+  mediaType: string;
+  title: string | null;
+  description: string | null;
+  url: string | null;
+  embedUrl: string | null;
+  thumbnailUrl: string | null;
+  sourceUrl: string | null;
+  fileFormat: string | null;
+  fileSize: number | null;
+  caption: string | null;
+  altText: string | null;
+  isPrimary: boolean;
+  sortOrder: number;
+}
+
+interface MediaGalleryProps {
+  mediaAssets: MediaAsset[];
+}
+
+type TabKey = "photos" | "videos" | "brochures" | "more";
+
+const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+  { key: "photos", label: "Photos", icon: <ImageIcon className="h-4 w-4" /> },
+  { key: "videos", label: "Videos", icon: <PlayCircle className="h-4 w-4" /> },
+  {
+    key: "brochures",
+    label: "Brochures & Plans",
+    icon: <FileText className="h-4 w-4" />,
+  },
+  { key: "more", label: "More", icon: <Box className="h-4 w-4" /> },
+];
+
+function groupByType(assets: MediaAsset[]) {
+  const groups: Record<string, MediaAsset[]> = {};
+  for (const a of assets) {
+    const key = a.mediaType;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(a);
+  }
+  return groups;
+}
+
+function formatFileSize(bytes: number | null): string {
+  if (!bytes) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>("photos");
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  if (!mediaAssets || mediaAssets.length === 0) return null;
+
+  const grouped = groupByType(mediaAssets);
+
+  const photos = [
+    ...(grouped["photo"] || []),
+  ];
+  const videos = [...(grouped["video"] || [])];
+  const brochures = [
+    ...(grouped["brochure"] || []),
+    ...(grouped["deck_plan"] || []),
+    ...(grouped["interior_layout"] || []),
+  ];
+  const more = [
+    ...(grouped["360_tour"] || []),
+    ...(grouped["3d_model"] || []),
+  ];
+
+  const tabCounts: Record<TabKey, number> = {
+    photos: photos.length,
+    videos: videos.length,
+    brochures: brochures.length,
+    more: more.length,
+  };
+
+  const currentLightboxPhotos = photos;
+  const currentPhoto =
+    lightboxIndex !== null ? currentLightboxPhotos[lightboxIndex] : null;
+
+  return (
+    <section className="mt-10 sm:mt-12" data-testid="media-gallery">
+      <h2 className="text-lg sm:text-xl font-bold mb-4">Media Gallery</h2>
+
+      {/* Tabs */}
+      <div
+        className="flex gap-1 border-b border-border mb-6 overflow-x-auto"
+        role="tablist"
+        data-testid="media-gallery-tabs"
+      >
+        {TABS.filter((tab) => tabCounts[tab.key] > 0 || tab.key === activeTab).map(
+          (tab) => (
+            <button
+              key={tab.key}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              data-testid={`tab-${tab.key}`}
+              onClick={() => setActiveTab(tab.key)}
+              className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                activeTab === tab.key
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+              {tabCounts[tab.key] > 0 && (
+                <span className="ml-1 text-xs bg-muted rounded-full px-2 py-0.5">
+                  {tabCounts[tab.key]}
+                </span>
+              )}
+            </button>
+          ),
+        )}
+      </div>
+
+      {/* Tab Content */}
+      <div data-testid={`tab-content-${activeTab}`}>
+        {activeTab === "photos" && (
+          <PhotoGrid
+            photos={photos}
+            onPhotoClick={(idx) => setLightboxIndex(idx)}
+          />
+        )}
+        {activeTab === "videos" && <VideoList videos={videos} />}
+        {activeTab === "brochures" && <BrochureList items={brochures} />}
+        {activeTab === "more" && <MoreList items={more} />}
+      </div>
+
+      {/* Lightbox */}
+      {currentPhoto && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
+          onClick={() => setLightboxIndex(null)}
+          data-testid="lightbox"
+        >
+          <button
+            className="absolute top-4 right-4 text-white hover:text-gray-300"
+            onClick={() => setLightboxIndex(null)}
+            aria-label="Close lightbox"
+          >
+            <X className="h-8 w-8" />
+          </button>
+          {lightboxIndex != null && lightboxIndex > 0 && (
+            <button
+              className="absolute left-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300"
+              onClick={(e) => {
+                e.stopPropagation();
+                setLightboxIndex(lightboxIndex! - 1);
+              }}
+              aria-label="Previous photo"
+            >
+              <ChevronLeft className="h-10 w-10" />
+            </button>
+          )}
+          {lightboxIndex != null && lightboxIndex < currentLightboxPhotos.length - 1 && (
+            <button
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300"
+              onClick={(e) => {
+                e.stopPropagation();
+                setLightboxIndex(lightboxIndex! + 1);
+              }}
+              aria-label="Next photo"
+            >
+              <ChevronRight className="h-10 w-10" />
+            </button>
+          )}
+          <div
+            className="max-w-4xl max-h-[80vh] relative"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={currentPhoto.url || currentPhoto.thumbnailUrl || ""}
+              alt={
+                currentPhoto.altText ||
+                currentPhoto.title ||
+                currentPhoto.caption ||
+                "Yacht photo"
+              }
+              className="max-w-full max-h-[80vh] object-contain rounded-lg"
+            />
+            {(currentPhoto.title || currentPhoto.caption) && (
+              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 rounded-b-lg">
+                <p className="text-white text-sm">
+                  {currentPhoto.title || currentPhoto.caption}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PhotoGrid({
+  photos,
+  onPhotoClick,
+}: {
+  photos: MediaAsset[];
+  onPhotoClick: (idx: number) => void;
+}) {
+  if (photos.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm" data-testid="no-photos">
+        No photos available yet
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+      {photos.map((photo, idx) => (
+        <button
+          key={photo.id}
+          onClick={() => onPhotoClick(idx)}
+          className="relative aspect-[4/3] rounded-lg overflow-hidden bg-muted group cursor-pointer border border-border hover:border-primary transition-colors"
+          data-testid="media-photo-thumb"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={photo.thumbnailUrl || photo.url || ""}
+            alt={
+              photo.altText || photo.title || photo.caption || "Yacht photo"
+            }
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+            loading="lazy"
+          />
+          {photo.isPrimary && (
+            <span className="absolute top-1 left-1 bg-primary text-primary-foreground text-xs px-2 py-0.5 rounded-full">
+              Primary
+            </span>
+          )}
+          {photo.title && (
+            <span className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+              <span className="text-white text-xs truncate block">
+                {photo.title}
+              </span>
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function VideoList({ videos }: { videos: MediaAsset[] }) {
+  if (videos.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm" data-testid="no-videos">
+        No videos available yet
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {videos.map((video) => (
+        <div
+          key={video.id}
+          className="border border-border rounded-lg overflow-hidden"
+          data-testid="media-video-card"
+        >
+          {video.embedUrl ? (
+            <div className="aspect-video">
+              <iframe
+                src={video.embedUrl}
+                title={video.title || "Video"}
+                className="w-full h-full"
+                allowFullScreen
+                loading="lazy"
+              />
+            </div>
+          ) : video.thumbnailUrl ? (
+            <div className="aspect-video relative bg-muted">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={video.thumbnailUrl}
+                alt={video.altText || video.title || "Video thumbnail"}
+                className="w-full h-full object-cover"
+                loading="lazy"
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                {video.url ? (
+                  <a
+                    href={video.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="bg-black/50 rounded-full p-3 hover:bg-black/70 transition-colors"
+                  >
+                    <PlayCircle className="h-10 w-10 text-white" />
+                  </a>
+                ) : (
+                  <Video className="h-10 w-10 text-white/50" />
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="aspect-video bg-muted flex items-center justify-center">
+              <Video className="h-10 w-10 text-muted-foreground" />
+            </div>
+          )}
+          <div className="p-3">
+            {video.title && (
+              <h4 className="font-medium text-sm">{video.title}</h4>
+            )}
+            {video.caption && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {video.caption}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BrochureList({ items }: { items: MediaAsset[] }) {
+  if (items.length === 0) {
+    return (
+      <p
+        className="text-muted-foreground text-sm"
+        data-testid="no-brochures"
+      >
+        No brochures or plans available yet
+      </p>
+    );
+  }
+
+  const typeIcons: Record<string, React.ReactNode> = {
+    brochure: <FileText className="h-6 w-6" />,
+    deck_plan: <Map className="h-6 w-6" />,
+    interior_layout: <Layout className="h-6 w-6" />,
+  };
+
+  const typeLabels: Record<string, string> = {
+    brochure: "Brochure",
+    deck_plan: "Deck Plan",
+    interior_layout: "Interior Layout",
+  };
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="border border-border rounded-lg p-4 flex gap-4 items-start hover:bg-muted/50 transition-colors"
+          data-testid="media-brochure-card"
+        >
+          <div className="shrink-0 text-primary">
+            {typeIcons[item.mediaType] || <FileText className="h-6 w-6" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h4 className="font-medium text-sm truncate">
+              {item.title || typeLabels[item.mediaType] || item.mediaType}
+            </h4>
+            {item.description && (
+              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                {item.description}
+              </p>
+            )}
+            {item.fileFormat && (
+              <span className="inline-block text-xs bg-muted rounded px-2 py-0.5 mt-1">
+                {item.fileFormat.toUpperCase()}
+                {item.fileSize ? ` • ${formatFileSize(item.fileSize)}` : ""}
+              </span>
+            )}
+            {item.url && (
+              <a
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
+              >
+                <Download className="h-3 w-3" />
+                Download
+              </a>
+            )}
+            {item.sourceUrl && !item.url && (
+              <a
+                href={item.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
+              >
+                <ExternalLink className="h-3 w-3" />
+                View Source
+              </a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MoreList({ items }: { items: MediaAsset[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm" data-testid="no-more">
+        No 360° tours or 3D models available yet
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="border border-border rounded-lg overflow-hidden"
+          data-testid={`media-${item.mediaType}-card`}
+        >
+          {item.embedUrl ? (
+            <div className="aspect-video">
+              <iframe
+                src={item.embedUrl}
+                title={item.title || item.mediaType}
+                className="w-full h-full"
+                allowFullScreen
+                loading="lazy"
+              />
+            </div>
+          ) : (
+            <div className="aspect-video bg-muted flex flex-col items-center justify-center gap-2">
+              {item.mediaType === "360_tour" ? (
+                <RotateCcw className="h-8 w-8 text-muted-foreground" />
+              ) : (
+                <Box className="h-8 w-8 text-muted-foreground" />
+              )}
+              <span className="text-sm text-muted-foreground">
+                {item.mediaType === "360_tour"
+                  ? "360° Tour"
+                  : "3D Model Viewer"}
+              </span>
+            </div>
+          )}
+          <div className="p-3">
+            <h4 className="font-medium text-sm">
+              {item.title ||
+                (item.mediaType === "360_tour"
+                  ? "360° Virtual Tour"
+                  : "3D Model")}
+            </h4>
+            {item.caption && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {item.caption}
+              </p>
+            )}
+            {item.url && (
+              <a
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
+              >
+                <ExternalLink className="h-3 w-3" />
+                Open
+              </a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -81,6 +81,7 @@ export const yachtModels = pgTable(
     sourceConfidence: integer("source_confidence").default(50),
     lastVerifiedAt: timestamp("last_verified_at", { withTimezone: true }),
     completenessScore: integer("completeness_score"),
+    mediaCount: integer("media_count").default(0),
 
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow(),
@@ -336,6 +337,44 @@ export const leads = pgTable(
   }),
 );
 
+
+
+// Media assets (P10.2 — Rich media support)
+export const mediaAssets = pgTable(
+  "media_assets",
+  {
+    id: serial("id").primaryKey(),
+    yachtModelId: integer("yacht_model_id")
+      .notNull()
+      .references(() => yachtModels.id, { onDelete: "cascade" }),
+    mediaType: text("media_type").$type<"photo" | "brochure" | "deck_plan" | "interior_layout" | "video" | "360_tour" | "3d_model">().notNull().default("photo"),
+    title: varchar("title", { length: 500 }),
+    description: text("description"),
+    url: varchar("url", { length: 1000 }),
+    embedUrl: varchar("embed_url", { length: 1000 }),
+    thumbnailUrl: varchar("thumbnail_url", { length: 1000 }),
+    sourceUrl: varchar("source_url", { length: 1000 }),
+    fileFormat: varchar("file_format", { length: 50 }),
+    fileSize: integer("file_size"),
+    caption: text("caption"),
+    altText: varchar("alt_text", { length: 500 }),
+    isPrimary: boolean("is_primary").default(false),
+    sortOrder: integer("sort_order").default(0),
+    dataSource: varchar("data_source", { length: 100 }).default("manual"),
+    sourceConfidence: integer("source_confidence").default(50),
+    lastVerifiedAt: timestamp("last_verified_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    idxYacht: index("idx_media_assets_yacht").on(table.yachtModelId),
+    idxType: index("idx_media_assets_type").on(table.mediaType),
+    idxPrimary: index("idx_media_assets_primary").on(table.yachtModelId),
+  }),
+);
+
+export const insertMediaAssetSchema = createInsertSchema(mediaAssets);
+export const selectMediaAssetSchema = createSelectSchema(mediaAssets);
 // ---------- Zod Schemas for validation ----------
 
 export const insertManufacturerSchema = createInsertSchema(manufacturers);

--- a/e2e/media-assets.spec.ts
+++ b/e2e/media-assets.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "@playwright/test";
+
+// Use a known yacht slug that exists in the test DB
+const TEST_SLUG = "beneteau-oceanis-30-1";
+const BASE_URL = process.env.PLAYWRIGHT_TEST_URL || "http://localhost:3000";
+
+test.describe("Media Assets API", () => {
+  test.describe("Admin API - Auth Guard", () => {
+    test("GET /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.get(`${BASE_URL}/api/admin/media?yachtId=1`);
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body.error).toContain("Unauthorized");
+    });
+
+    test("POST /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.post(`${BASE_URL}/api/admin/media`, {
+        data: { yachtModelId: 1, mediaType: "photo" },
+      });
+      expect(response.status()).toBe(401);
+    });
+
+    test("PATCH /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.patch(`${BASE_URL}/api/admin/media?id=1`, {
+        data: { title: "Test" },
+      });
+      expect(response.status()).toBe(401);
+    });
+
+    test("DELETE /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.delete(
+        `${BASE_URL}/api/admin/media?id=999`,
+      );
+      expect(response.status()).toBe(401);
+    });
+  });
+
+  test.describe("Admin API - CRUD with auth", () => {
+    // These tests require auth cookie — skip if no test auth available
+    test.skip(
+      () => !process.env.TEST_AUTH_COOKIE,
+      "No TEST_AUTH_COOKIE set — skipping authenticated CRUD tests",
+    );
+
+    const authCookie = process.env.TEST_AUTH_COOKIE || "";
+    const headers = { Cookie: `auth=${authCookie}` };
+
+    test("should create a media asset", async ({ request }) => {
+      // First get a valid yacht ID
+      const yachtResponse = await request.get(
+        `${BASE_URL}/api/yachts/${TEST_SLUG}`,
+      );
+      if (yachtResponse.status() !== 200) {
+        test.skip();
+        return;
+      }
+      const yacht = await yachtResponse.json();
+
+      const response = await request.post(`${BASE_URL}/api/admin/media`, {
+        headers,
+        data: {
+          yachtModelId: yacht.id,
+          mediaType: "photo",
+          title: "Test Photo",
+          caption: "A test photo",
+          url: "https://example.com/test.jpg",
+          dataSource: "test",
+        },
+      });
+
+      expect([201, 200]).toContain(response.status());
+      const body = await response.json();
+      expect(body.mediaAsset).toBeDefined();
+      expect(body.mediaAsset.title).toBe("Test Photo");
+    });
+  });
+
+  test.describe("Public API", () => {
+    test("GET /api/yachts/[slug]/media returns data", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/yachts/${TEST_SLUG}/media`,
+      );
+      // May be 200 with empty array or 404 if yacht doesn't exist
+      if (response.status() === 200) {
+        const body = await response.json();
+        expect(body.mediaAssets).toBeDefined();
+        expect(body.grouped).toBeDefined();
+        expect(typeof body.total).toBe("number");
+      } else {
+        // Yacht might not exist in test DB — that's OK
+        expect([200, 404, 500]).toContain(response.status());
+      }
+    });
+
+    test("media response is grouped by type", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/yachts/${TEST_SLUG}/media`,
+      );
+      if (response.status() === 200) {
+        const body = await response.json();
+        // grouped should be an object with media type keys
+        expect(typeof body.grouped).toBe("object");
+      }
+    });
+  });
+});
+
+test.describe("Media Gallery Component", () => {
+  test("gallery renders when media exists on yacht page", async ({ page }) => {
+    // Navigate to a yacht detail page
+    await page.goto(`${BASE_URL}/yachts/${TEST_SLUG}`);
+
+    // Wait for page to load (client-side fetch)
+    await page.waitForTimeout(3000);
+
+    // If media gallery exists, check it renders
+    const gallery = page.locator('[data-testid="media-gallery"]');
+    if ((await gallery.count()) > 0) {
+      await expect(gallery).toBeVisible();
+    }
+    // It's OK if there's no gallery — yacht may have no media assets
+  });
+
+  test("gallery tabs switch content correctly", async ({ page }) => {
+    await page.goto(`${BASE_URL}/yachts/${TEST_SLUG}`);
+    await page.waitForTimeout(3000);
+
+    const gallery = page.locator('[data-testid="media-gallery"]');
+    if ((await gallery.count()) === 0) {
+      // No media — skip tab tests
+      test.info().annotations.push({
+        type: "skip",
+        description: "No media assets on test yacht",
+      });
+      return;
+    }
+
+    // Check that tab bar exists
+    const tabBar = page.locator('[data-testid="media-gallery-tabs"]');
+    if ((await tabBar.count()) > 0) {
+      await expect(tabBar).toBeVisible();
+
+      // Find visible tabs and click through them
+      const tabs = tabBar.locator("button[role='tab']");
+      const tabCount = await tabs.count();
+      for (let i = 0; i < tabCount; i++) {
+        await tabs.nth(i).click();
+        await page.waitForTimeout(300);
+      }
+    }
+  });
+});

--- a/lib/completeness.ts
+++ b/lib/completeness.ts
@@ -70,6 +70,24 @@ export function calculateCompletenessScore(yacht: object): number {
 }
 
 /**
+ * Calculate media richness bonus points (P10.2).
+ * Returns up to 15 bonus points for having media assets of different types.
+ */
+export function calculateMediaRichnessBonus(mediaTypes: string[]): number {
+  const uniqueTypes = new Set(mediaTypes);
+  let bonus = 0;
+
+  if (uniqueTypes.has("photo")) bonus += 5;
+  if (uniqueTypes.has("brochure")) bonus += 3;
+  if (uniqueTypes.has("video")) bonus += 3;
+  if (uniqueTypes.has("deck_plan")) bonus += 2;
+  if (uniqueTypes.has("interior_layout")) bonus += 2;
+
+  // Cap at 15
+  return Math.min(bonus, 15);
+}
+
+/**
  * Get completeness level for display purposes.
  */
 export function getCompletenessLevel(score: number): {

--- a/tests/media-assets.spec.ts
+++ b/tests/media-assets.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+// Use a known yacht slug that exists in production
+const TEST_SLUG = "beneteau-oceanis-30-1";
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || "https://info.sailboats.fr";
+
+test.describe("Media Assets API", () => {
+  test.describe("Admin API - Auth Guard", () => {
+    test("GET /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/admin/media?yachtId=1`,
+      );
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body.error).toContain("Unauthorized");
+    });
+
+    test("POST /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.post(`${BASE_URL}/api/admin/media`, {
+        data: { yachtModelId: 1, mediaType: "photo" },
+      });
+      expect(response.status()).toBe(401);
+    });
+
+    test("PATCH /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.patch(
+        `${BASE_URL}/api/admin/media?id=1`,
+        { data: { title: "Test" } },
+      );
+      expect(response.status()).toBe(401);
+    });
+
+    test("DELETE /api/admin/media returns 401 without auth cookie", async ({
+      request,
+    }) => {
+      const response = await request.delete(
+        `${BASE_URL}/api/admin/media?id=999`,
+      );
+      expect(response.status()).toBe(401);
+    });
+  });
+
+  test.describe("Public API", () => {
+    test("GET /api/yachts/[slug]/media returns data", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/yachts/${TEST_SLUG}/media`,
+      );
+      // May be 200 with empty array or 404 if yacht doesn't exist
+      if (response.status() === 200) {
+        const body = await response.json();
+        expect(body.mediaAssets).toBeDefined();
+        expect(body.grouped).toBeDefined();
+        expect(typeof body.total).toBe("number");
+      } else {
+        // Yacht might not exist in test DB — that's OK
+        expect([200, 404]).toContain(response.status());
+      }
+    });
+
+    test("media response is grouped by type", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/yachts/${TEST_SLUG}/media`,
+      );
+      if (response.status() === 200) {
+        const body = await response.json();
+        expect(typeof body.grouped).toBe("object");
+      }
+    });
+  });
+});
+
+test.describe("Media Gallery Component", () => {
+  test("gallery renders when media exists on yacht page", async ({ page }) => {
+    await page.goto(`${BASE_URL}/yachts/${TEST_SLUG}`, {
+      waitUntil: "networkidle",
+    });
+
+    // If media gallery exists, check it renders
+    const gallery = page.locator('[data-testid="media-gallery"]');
+    if ((await gallery.count()) > 0) {
+      await expect(gallery).toBeVisible();
+    }
+    // It's OK if there's no gallery — yacht may have no media assets
+  });
+
+  test("gallery tabs switch content correctly", async ({ page }) => {
+    await page.goto(`${BASE_URL}/yachts/${TEST_SLUG}`, {
+      waitUntil: "networkidle",
+    });
+
+    const gallery = page.locator('[data-testid="media-gallery"]');
+    if ((await gallery.count()) === 0) {
+      // No media — skip tab tests
+      return;
+    }
+
+    // Check that tab bar exists
+    const tabBar = page.locator('[data-testid="media-gallery-tabs"]');
+    if ((await tabBar.count()) > 0) {
+      await expect(tabBar).toBeVisible();
+
+      // Find visible tabs and click through them
+      const tabs = tabBar.locator("button[role='tab']");
+      const tabCount = await tabs.count();
+      for (let i = 0; i < tabCount; i++) {
+        await tabs.nth(i).click();
+        await page.waitForTimeout(300);
+      }
+    }
+  });
+});


### PR DESCRIPTION
The `unstable_cache` wrapper in the public media API was causing it to return an empty object `{}` instead of the expected `{mediaAssets, grouped, total}` response. Removed the cache wrapper and kept the simpler direct query pattern consistent with other API routes.

Fixes live verification issue found after merging #167.