### PR TITLE
P10.7: User-submitted corrections with admin moderation

### DIFF
--- a/app/(main)/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/(main)/yachts/[slug]/YachtDetailClient.tsx
@@ -25,6 +25,7 @@ import { calculateCompletenessScore } from "@/lib/completeness";
 import SourceProvenance from "@/components/SourceProvenance";
 import { ReviewSummary } from "@/components/ReviewSummary";
 import { ReviewSubmissionForm } from "@/components/ReviewSubmissionForm";
+import { CorrectionForm } from "@/components/CorrectionForm";
 
 interface SpecGroup {
   [group: string]: Array<{
@@ -438,6 +439,32 @@ export default function YachtDetailClient() {
         lastVerifiedAt={yacht.lastVerifiedAt}
         completenessScore={yacht.completenessScore}
       />
+
+      {/* User Correction (P10.7) */}
+      <CorrectionForm
+        yachtId={yacht.id}
+        yachtSlug={yacht.slug}
+        specFields={[
+          { name: "lengthOverall", label: "Length Overall", currentValue: yacht.lengthOverall },
+          { name: "beam", label: "Beam", currentValue: yacht.beam },
+          { name: "draft", label: "Draft", currentValue: yacht.draft },
+          { name: "displacement", label: "Displacement", currentValue: yacht.displacement },
+          { name: "ballast", label: "Ballast", currentValue: yacht.ballast },
+          { name: "sailAreaMain", label: "Sail Area (Main)", currentValue: yacht.sailAreaMain },
+          { name: "rigType", label: "Rig Type", currentValue: yacht.rigType },
+          { name: "keelType", label: "Keel Type", currentValue: yacht.keelType },
+          { name: "hullMaterial", label: "Hull Material", currentValue: yacht.hullMaterial },
+          { name: "cabins", label: "Cabins", currentValue: yacht.cabins },
+          { name: "berths", label: "Berths", currentValue: yacht.berths },
+          { name: "heads", label: "Heads", currentValue: yacht.heads },
+          { name: "maxOccupancy", label: "Max Occupancy", currentValue: yacht.maxOccupancy },
+          { name: "engineHp", label: "Engine HP", currentValue: yacht.engineHp },
+          { name: "engineType", label: "Engine Type", currentValue: yacht.engineType },
+          { name: "fuelCapacity", label: "Fuel Capacity", currentValue: yacht.fuelCapacity },
+          { name: "waterCapacity", label: "Water Capacity", currentValue: yacht.waterCapacity },
+        ].filter(f => f.currentValue !== null && f.currentValue !== undefined)}
+      />
+
       {/* Performance Ratios Section */}
       {(() => {
         const ratios = calculatePerformanceRatios(yacht);

--- a/app/api/admin/corrections/[id]/route.ts
+++ b/app/api/admin/corrections/[id]/route.ts
@@ -1,0 +1,261 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { pool } from "@/lib/db";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+function toNum(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+function mapCorrection(row: Record<string, unknown>) {
+  return {
+    id: toNum(row.id as string | number | null),
+    yachtModelId: toNum(row.yacht_model_id as string | number | null),
+    modelName: (row.model_name as string) ?? null,
+    yachtSlug: (row.yacht_slug as string) ?? null,
+    manufacturerName: (row.manufacturer_name as string) ?? null,
+    submitterName: (row.submitter_name as string) ?? null,
+    submitterEmail: (row.submitter_email as string) ?? null,
+    correctionType: (row.correction_type as string) ?? "incorrect_value",
+    fieldName: (row.field_name as string) ?? null,
+    currentValue: (row.current_value as string) ?? null,
+    suggestedValue: (row.suggested_value as string) ?? null,
+    notes: (row.notes as string) ?? null,
+    sourceUrl: (row.source_url as string) ?? null,
+    status: (row.status as string) ?? "pending",
+    adminNotes: (row.admin_notes as string) ?? null,
+    createdAt: (row.created_at as string) ?? null,
+    reviewedAt: (row.reviewed_at as string) ?? null,
+  };
+}
+
+const patchSchema = z.object({
+  status: z.enum(["accepted", "rejected"]),
+  adminNotes: z.string().max(2000).optional(),
+});
+
+/**
+ * GET /api/admin/corrections/[id]
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies();
+  const authCookie = cookieStore.get("auth")?.value;
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const correctionId = Number(id);
+    if (Number.isNaN(correctionId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const result = await pool.query(
+      `SELECT uc.*, ym.model_name, ym.slug as yacht_slug, m.name as manufacturer_name
+       FROM user_corrections uc
+       LEFT JOIN yacht_models ym ON uc.yacht_model_id = ym.id
+       LEFT JOIN manufacturers m ON ym.manufacturer_id = m.id
+       WHERE uc.id = $1`,
+      [correctionId],
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Correction not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(mapCorrection(result.rows[0]));
+  } catch (error: any) {
+    console.error("[admin/corrections/[id]] GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/admin/corrections/[id]
+ * Accept or reject a correction. When accepted, auto-updates the yacht_model field.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies();
+  const authCookie = cookieStore.get("auth")?.value;
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const correctionId = Number(id);
+    if (Number.isNaN(correctionId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const parsed = patchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const { status, adminNotes } = parsed.data;
+
+    // Fetch the correction
+    const correctionResult = await pool.query(
+      "SELECT * FROM user_corrections WHERE id = $1",
+      [correctionId],
+    );
+    if (correctionResult.rows.length === 0) {
+      return NextResponse.json({ error: "Correction not found" }, { status: 404 });
+    }
+
+    const correction = correctionResult.rows[0];
+
+    // If already reviewed, prevent re-review
+    if (correction.status !== "pending") {
+      return NextResponse.json(
+        { error: `Correction already ${correction.status}` },
+        { status: 409 },
+      );
+    }
+
+    // If accepted, apply the correction to the yacht model
+    if (status === "accepted") {
+      const fieldName = correction.field_name;
+      const suggestedValue = correction.suggested_value;
+      const yachtModelId = correction.yacht_model_id;
+
+      // Map frontend field names to DB column names
+      const fieldToColumn: Record<string, string> = {
+        lengthOverall: "length_overall",
+        beam: "beam",
+        draft: "draft",
+        displacement: "displacement",
+        ballast: "ballast",
+        sailAreaMain: "sail_area_main",
+        rigType: "rig_type",
+        keelType: "keel_type",
+        hullMaterial: "hull_material",
+        cabins: "cabins",
+        berths: "berths",
+        heads: "heads",
+        maxOccupancy: "max_occupancy",
+        engineHp: "engine_hp",
+        engineType: "engine_type",
+        fuelCapacity: "fuel_capacity",
+        waterCapacity: "water_capacity",
+        designNotes: "design_notes",
+        description: "description",
+      };
+
+      const columnName = fieldToColumn[fieldName] || fieldName;
+
+      // Use parameterized query — can't parameterize column names, so whitelist it
+      const allowedColumns = new Set(Object.values(fieldToColumn));
+      if (!allowedColumns.has(columnName)) {
+        return NextResponse.json(
+          { error: `Cannot update field: ${fieldName}` },
+          { status: 400 },
+        );
+      }
+
+      // Determine if numeric field for casting
+      const numericFields = new Set([
+        "length_overall", "beam", "draft", "displacement", "ballast",
+        "sail_area_main", "cabins", "berths", "heads", "max_occupancy",
+        "engine_hp", "fuel_capacity", "water_capacity",
+      ]);
+
+      if (numericFields.has(columnName)) {
+        const numValue = Number(suggestedValue);
+        if (Number.isNaN(numValue)) {
+          return NextResponse.json(
+            { error: `Invalid numeric value for ${fieldName}` },
+            { status: 400 },
+          );
+        }
+        await pool.query(
+          `UPDATE yacht_models SET ${columnName} = $1, updated_at = NOW() WHERE id = $2`,
+          [numValue, yachtModelId],
+        );
+      } else {
+        await pool.query(
+          `UPDATE yacht_models SET ${columnName} = $1, updated_at = NOW() WHERE id = $2`,
+          [suggestedValue, yachtModelId],
+        );
+      }
+    }
+
+    // Update the correction status
+    const updateResult = await pool.query(
+      `UPDATE user_corrections
+       SET status = $1, admin_notes = $2, reviewed_at = NOW()
+       WHERE id = $3
+       RETURNING *`,
+      [status, adminNotes || null, correctionId],
+    );
+
+    return NextResponse.json(mapCorrection(updateResult.rows[0]));
+  } catch (error: any) {
+    console.error("[admin/corrections/[id]] PATCH error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/admin/corrections/[id]
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const cookieStore = cookies();
+  const authCookie = cookieStore.get("auth")?.value;
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const correctionId = Number(id);
+    if (Number.isNaN(correctionId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const result = await pool.query(
+      "DELETE FROM user_corrections WHERE id = $1 RETURNING id",
+      [correctionId],
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Correction not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ deleted: true, id: correctionId });
+  } catch (error: any) {
+    console.error("[admin/corrections/[id]] DELETE error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/admin/corrections/route.ts
+++ b/app/api/admin/corrections/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { pool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+function toNum(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * GET /api/admin/corrections?status=pending&yachtId=123&limit=20&offset=0
+ * List user corrections with optional filters.
+ */
+export async function GET(request: NextRequest) {
+  const cookieStore = cookies();
+  const authCookie = cookieStore.get("auth")?.value;
+
+  if (!authCookie) {
+    return NextResponse.json(
+      { error: "Unauthorized - Admin access required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status");
+    const yachtId = searchParams.get("yachtId");
+    const limit = Math.min(100, Math.max(1, Number(searchParams.get("limit")) || 20));
+    const offset = Math.max(0, Number(searchParams.get("offset")) || 0);
+
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    if (status && ["pending", "accepted", "rejected"].includes(status)) {
+      conditions.push(`uc.status = $${paramIdx++}`);
+      params.push(status);
+    }
+
+    if (yachtId) {
+      conditions.push(`uc.yacht_model_id = $${paramIdx++}`);
+      params.push(Number(yachtId));
+    }
+
+    const whereClause = conditions.length > 0
+      ? "WHERE " + conditions.join(" AND ")
+      : "";
+
+    params.push(limit, offset);
+
+    const result = await pool.query(
+      `SELECT uc.*, ym.model_name, ym.slug as yacht_slug, m.name as manufacturer_name
+       FROM user_corrections uc
+       LEFT JOIN yacht_models ym ON uc.yacht_model_id = ym.id
+       LEFT JOIN manufacturers m ON ym.manufacturer_id = m.id
+       ${whereClause}
+       ORDER BY uc.created_at DESC
+       LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+      params,
+    );
+
+    // Get total count
+    const countResult = await pool.query(
+      `SELECT COUNT(*)::int as total FROM user_corrections uc ${whereClause}`,
+      params.slice(0, -2), // exclude limit/offset
+    );
+
+    const corrections = result.rows.map((row: Record<string, unknown>) => ({
+      id: toNum(row.id as string | number | null),
+      yachtModelId: toNum(row.yacht_model_id as string | number | null),
+      modelName: (row.model_name as string) ?? null,
+      yachtSlug: (row.yacht_slug as string) ?? null,
+      manufacturerName: (row.manufacturer_name as string) ?? null,
+      submitterName: (row.submitter_name as string) ?? null,
+      submitterEmail: (row.submitter_email as string) ?? null,
+      correctionType: (row.correction_type as string) ?? "incorrect_value",
+      fieldName: (row.field_name as string) ?? null,
+      currentValue: (row.current_value as string) ?? null,
+      suggestedValue: (row.suggested_value as string) ?? null,
+      notes: (row.notes as string) ?? null,
+      sourceUrl: (row.source_url as string) ?? null,
+      status: (row.status as string) ?? "pending",
+      adminNotes: (row.admin_notes as string) ?? null,
+      createdAt: (row.created_at as string) ?? null,
+      reviewedAt: (row.reviewed_at as string) ?? null,
+    }));
+
+    return NextResponse.json({
+      corrections,
+      total: countResult.rows[0]?.total ?? 0,
+      limit,
+      offset,
+    });
+  } catch (error: any) {
+    console.error("[admin/corrections] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/corrections/route.ts
+++ b/app/api/corrections/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pool } from "@/lib/db";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+// --- Rate limiting (in-memory, per IP) ---
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + 60 * 60 * 1000 }); // 1 hour window
+    return false;
+  }
+  entry.count++;
+  return entry.count > 3; // max 3 per hour
+}
+
+// Periodically prune stale entries (every 10 minutes)
+if (typeof setInterval !== "undefined") {
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of rateLimitMap) {
+      if (now > entry.resetAt) rateLimitMap.delete(key);
+    }
+  }, 10 * 60 * 1000);
+}
+
+// --- Validation ---
+const correctionSchema = z.object({
+  yachtModelId: z.number().int().positive("Yacht ID is required"),
+  correctionType: z.enum([
+    "missing_specification",
+    "incorrect_value",
+    "outdated_information",
+    "wrong_image",
+    "other",
+  ]).default("incorrect_value"),
+  fieldName: z.string().min(1, "Field name is required").max(200),
+  currentValue: z.string().max(500).optional(),
+  suggestedValue: z.string().min(1, "Suggested value is required").max(1000),
+  notes: z.string().max(2000).optional(),
+  sourceUrl: z.string().url("Invalid URL").max(500).optional().or(z.literal("")),
+  submitterName: z.string().max(200).optional(),
+  submitterEmail: z.string().email("Invalid email").max(255).optional().or(z.literal("")),
+  // honeypot — must be empty
+  website: z.string().max(0).optional(),
+});
+
+/**
+ * POST /api/corrections
+ * Submit a user correction for a yacht spec.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Rate limit by IP
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
+    if (isRateLimited(ip)) {
+      return NextResponse.json(
+        { error: "Too many submissions. Please try again later." },
+        { status: 429 },
+      );
+    }
+
+    const body = await request.json();
+
+    // Honeypot check
+    if (body.website) {
+      // Silently accept but don't insert (anti-spam)
+      return NextResponse.json({ id: 0, status: "pending" }, { status: 201 });
+    }
+
+    const parsed = correctionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const data = parsed.data;
+
+    // Verify the yacht exists
+    const yachtCheck = await pool.query(
+      "SELECT id FROM yacht_models WHERE id = $1",
+      [data.yachtModelId],
+    );
+    if (yachtCheck.rows.length === 0) {
+      return NextResponse.json(
+        { error: "Yacht not found" },
+        { status: 404 },
+      );
+    }
+
+    const result = await pool.query(
+      `INSERT INTO user_corrections
+        (yacht_model_id, submitter_name, submitter_email, correction_type, field_name, current_value, suggested_value, notes, source_url, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending')
+       RETURNING id`,
+      [
+        data.yachtModelId,
+        data.submitterName || null,
+        data.submitterEmail || null,
+        data.correctionType,
+        data.fieldName,
+        data.currentValue || null,
+        data.suggestedValue,
+        data.notes || null,
+        data.sourceUrl || null,
+      ],
+    );
+
+    return NextResponse.json(
+      { id: result.rows[0].id, status: "pending" },
+      { status: 201 },
+    );
+  } catch (error: any) {
+    console.error("[corrections] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/components/CorrectionForm.tsx
+++ b/components/CorrectionForm.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { AlertTriangle, Send, X } from "lucide-react";
+
+interface SpecField {
+  name: string;
+  label: string;
+  currentValue: string | number | null;
+}
+
+interface CorrectionFormProps {
+  yachtId: number;
+  yachtSlug: string;
+  specFields: SpecField[];
+}
+
+const CORRECTION_TYPES = [
+  { value: "missing_specification", label: "Missing specification" },
+  { value: "incorrect_value", label: "Incorrect value" },
+  { value: "outdated_information", label: "Outdated information" },
+  { value: "wrong_image", label: "Wrong image" },
+  { value: "other", label: "Other" },
+];
+
+type FormStatus = "idle" | "submitting" | "success" | "error";
+
+export function CorrectionForm({ yachtId, yachtSlug, specFields }: CorrectionFormProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const [correctionType, setCorrectionType] = useState("incorrect_value");
+  const [fieldName, setFieldName] = useState("");
+  const [suggestedValue, setSuggestedValue] = useState("");
+  const [notes, setNotes] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [submitterName, setSubmitterName] = useState("");
+  const [submitterEmail, setSubmitterEmail] = useState("");
+  // Honeypot
+  const [honeypot, setHoneypot] = useState("");
+
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const selectedField = specFields.find((f) => f.name === fieldName);
+
+  function resetForm() {
+    setCorrectionType("incorrect_value");
+    setFieldName("");
+    setSuggestedValue("");
+    setNotes("");
+    setSourceUrl("");
+    setSubmitterName("");
+    setSubmitterEmail("");
+    setHoneypot("");
+    setStatus("idle");
+    setErrorMessage("");
+  }
+
+  function handleClose() {
+    setIsOpen(false);
+    resetForm();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("submitting");
+    setErrorMessage("");
+
+    try {
+      const res = await fetch("/api/corrections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          yachtModelId: yachtId,
+          correctionType,
+          fieldName,
+          currentValue: selectedField?.currentValue ?? null,
+          suggestedValue,
+          notes: notes || undefined,
+          sourceUrl: sourceUrl || undefined,
+          submitterName: submitterName || undefined,
+          submitterEmail: submitterEmail || undefined,
+          website: honeypot,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Submission failed");
+      }
+
+      setStatus("success");
+    } catch (err: any) {
+      setStatus("error");
+      setErrorMessage(err.message || "Something went wrong");
+    }
+  }
+
+  return (
+    <>
+      {/* Trigger button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        data-testid="suggest-correction-btn"
+      >
+        <AlertTriangle className="h-3.5 w-3.5" />
+        Suggest a Correction
+      </button>
+
+      {/* Modal overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleClose();
+          }}
+        >
+          <div
+            className="bg-background border border-border rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto"
+            data-testid="correction-form-modal"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                Suggest a Correction
+              </h3>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="p-1 rounded-md hover:bg-muted transition-colors"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* Body */}
+            {status === "success" ? (
+              <div className="px-5 py-8 text-center">
+                <div className="text-green-600 text-3xl mb-3">✓</div>
+                <p className="font-semibold text-lg">Thank you!</p>
+                <p className="text-muted-foreground mt-1">
+                  Your correction has been submitted and will be reviewed by our team.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:bg-primary/90 transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <form
+                ref={formRef}
+                onSubmit={handleSubmit}
+                className="px-5 py-4 space-y-4"
+              >
+                {/* Honeypot */}
+                <input
+                  type="text"
+                  name="website"
+                  value={honeypot}
+                  onChange={(e) => setHoneypot(e.target.value)}
+                  className="hidden"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  aria-hidden="true"
+                />
+
+                {/* Correction type */}
+                <div>
+                  <label htmlFor="correction-type" className="block text-sm font-medium mb-1">
+                    Correction type <span className="text-red-500">*</span>
+                  </label>
+                  <select
+                    id="correction-type"
+                    value={correctionType}
+                    onChange={(e) => setCorrectionType(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    required
+                    data-testid="correction-type-select"
+                  >
+                    {CORRECTION_TYPES.map((t) => (
+                      <option key={t.value} value={t.value}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Field name */}
+                <div>
+                  <label htmlFor="field-name" className="block text-sm font-medium mb-1">
+                    Field <span className="text-red-500">*</span>
+                  </label>
+                  <select
+                    id="field-name"
+                    value={fieldName}
+                    onChange={(e) => setFieldName(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    required
+                    data-testid="field-name-select"
+                  >
+                    <option value="">Select a field…</option>
+                    {specFields.map((f) => (
+                      <option key={f.name} value={f.name}>
+                        {f.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Current value (read-only) */}
+                {selectedField && selectedField.currentValue !== null && (
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      Current value
+                    </label>
+                    <div className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground">
+                      {String(selectedField.currentValue)}
+                    </div>
+                  </div>
+                )}
+
+                {/* Suggested value */}
+                <div>
+                  <label htmlFor="suggested-value" className="block text-sm font-medium mb-1">
+                    Suggested value <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="suggested-value"
+                    type="text"
+                    value={suggestedValue}
+                    onChange={(e) => setSuggestedValue(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="Enter the correct value"
+                    required
+                    data-testid="suggested-value-input"
+                  />
+                </div>
+
+                {/* Notes */}
+                <div>
+                  <label htmlFor="correction-notes" className="block text-sm font-medium mb-1">
+                    Notes
+                  </label>
+                  <textarea
+                    id="correction-notes"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-[80px] resize-y"
+                    placeholder="Any additional context…"
+                    rows={3}
+                  />
+                </div>
+
+                {/* Source URL */}
+                <div>
+                  <label htmlFor="correction-source" className="block text-sm font-medium mb-1">
+                    Source URL
+                  </label>
+                  <input
+                    id="correction-source"
+                    type="url"
+                    value={sourceUrl}
+                    onChange={(e) => setSourceUrl(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="https://…"
+                  />
+                </div>
+
+                {/* Submitter name */}
+                <div>
+                  <label htmlFor="submitter-name" className="block text-sm font-medium mb-1">
+                    Your name <span className="text-muted-foreground text-xs">(optional)</span>
+                  </label>
+                  <input
+                    id="submitter-name"
+                    type="text"
+                    value={submitterName}
+                    onChange={(e) => setSubmitterName(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="John Doe"
+                  />
+                </div>
+
+                {/* Submitter email */}
+                <div>
+                  <label htmlFor="submitter-email" className="block text-sm font-medium mb-1">
+                    Your email <span className="text-muted-foreground text-xs">(optional)</span>
+                  </label>
+                  <input
+                    id="submitter-email"
+                    type="email"
+                    value={submitterEmail}
+                    onChange={(e) => setSubmitterEmail(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="john@example.com"
+                  />
+                </div>
+
+                {/* Error message */}
+                {status === "error" && errorMessage && (
+                  <div className="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-700">
+                    {errorMessage}
+                  </div>
+                )}
+
+                {/* Submit */}
+                <div className="flex items-center justify-end gap-3 pt-2">
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={status === "submitting"}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                    data-testid="correction-submit-btn"
+                  >
+                    <Send className="h-3.5 w-3.5" />
+                    {status === "submitting" ? "Submitting…" : "Submit Correction"}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/drizzle/migrations/0015_user_corrections.sql
+++ b/drizzle/migrations/0015_user_corrections.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS user_corrections (
+  id SERIAL PRIMARY KEY,
+  yacht_model_id INTEGER NOT NULL REFERENCES yacht_models(id) ON DELETE CASCADE,
+  submitter_name TEXT,
+  submitter_email TEXT,
+  correction_type TEXT NOT NULL DEFAULT 'incorrect_value',
+  field_name TEXT NOT NULL,
+  current_value TEXT,
+  suggested_value TEXT NOT NULL,
+  notes TEXT,
+  source_url TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  admin_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_corrections_yacht ON user_corrections(yacht_model_id);
+CREATE INDEX IF NOT EXISTS idx_corrections_status ON user_corrections(status);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -791,3 +791,33 @@ export const pushSubscriptions = pgTable(
 
 export const insertPushSubscriptionSchema = createInsertSchema(pushSubscriptions);
 export const selectPushSubscriptionSchema = createSelectSchema(pushSubscriptions);
+
+// User corrections (P10.7 — User-submitted corrections)
+export const userCorrections = pgTable(
+  "user_corrections",
+  {
+    id: serial("id").primaryKey(),
+    yachtModelId: integer("yacht_model_id")
+      .notNull()
+      .references(() => yachtModels.id, { onDelete: "cascade" }),
+    submitterName: text("submitter_name"),
+    submitterEmail: text("submitter_email"),
+    correctionType: text("correction_type").notNull().default("incorrect_value"),
+    fieldName: text("field_name").notNull(),
+    currentValue: text("current_value"),
+    suggestedValue: text("suggested_value").notNull(),
+    notes: text("notes"),
+    sourceUrl: text("source_url"),
+    status: text("status").notNull().default("pending"),
+    adminNotes: text("admin_notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+  },
+  (table) => ({
+    idxYacht: index("idx_corrections_yacht").on(table.yachtModelId),
+    idxStatus: index("idx_corrections_status").on(table.status),
+  }),
+);
+
+export const insertUserCorrectionSchema = createInsertSchema(userCorrections);
+export const selectUserCorrectionSchema = createSelectSchema(userCorrections);

--- a/tests/user-corrections.spec.ts
+++ b/tests/user-corrections.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("User Corrections (P10.7)", () => {
+  test.describe("Correction form on yacht detail", () => {
+    test("correction form button is visible on yacht detail page", async ({ page }) => {
+      await page.goto("/yachts");
+      await page.waitForLoadState("domcontentloaded");
+
+      const yachtLink = page.locator('a[href^="/yachts/"]').first();
+      if ((await yachtLink.count()) === 0) {
+        test.skip();
+        return;
+      }
+
+      await yachtLink.click();
+      await page.waitForLoadState("domcontentloaded");
+
+      const btn = page.locator('[data-testid="suggest-correction-btn"]');
+      await expect(btn).toBeVisible({ timeout: 10000 });
+    });
+
+    test("form opens and has required fields", async ({ page }) => {
+      await page.goto("/yachts");
+      await page.waitForLoadState("domcontentloaded");
+
+      const link = page.locator('a[href^="/yachts/"]').first();
+      if ((await link.count()) === 0) {
+        test.skip();
+        return;
+      }
+
+      await link.click();
+      await page.waitForLoadState("domcontentloaded");
+
+      const btn = page.locator('[data-testid="suggest-correction-btn"]');
+      await expect(btn).toBeVisible({ timeout: 10000 });
+      await btn.click();
+
+      const modal = page.locator('[data-testid="correction-form-modal"]');
+      await expect(modal).toBeVisible();
+
+      await expect(page.locator('[data-testid="correction-type-select"]')).toBeVisible();
+      await expect(page.locator('[data-testid="field-name-select"]')).toBeVisible();
+      await expect(page.locator('[data-testid="suggested-value-input"]')).toBeVisible();
+      await expect(page.locator('[data-testid="correction-submit-btn"]')).toBeVisible();
+    });
+  });
+
+  test.describe("API validation", () => {
+    test("submission API validates input (returns error for empty body)", async ({ request }) => {
+      const response = await request.post("/api/corrections", {
+        data: {},
+      });
+      // Should return client error: 400 (validation), 404 (not found), or 500 (server error)
+      // Exact code depends on deployment state; key is it's not 200/201
+      expect(response.status()).toBeGreaterThanOrEqual(400);
+      expect(response.status()).toBeLessThan(500);
+    });
+
+    test("submission API returns error for invalid data", async ({ request }) => {
+      const response = await request.post("/api/corrections", {
+        data: {
+          yachtModelId: 999999,
+        },
+      });
+      expect(response.status()).toBeGreaterThanOrEqual(400);
+    });
+
+    test("submission API returns 404 for non-existent yacht", async ({ request }) => {
+      const response = await request.post("/api/corrections", {
+        data: {
+          yachtModelId: 999999,
+          fieldName: "lengthOverall",
+          suggestedValue: "10.5",
+        },
+      });
+      expect(response.status()).toBe(404);
+    });
+  });
+
+  test.describe("Admin corrections API auth", () => {
+    test("GET /api/admin/corrections requires auth (401)", async ({ request }) => {
+      const response = await request.get("/api/admin/corrections");
+      expect(response.status()).toBe(401);
+    });
+
+    test("GET /api/admin/corrections/[id] requires auth (401)", async ({ request }) => {
+      const response = await request.get("/api/admin/corrections/1");
+      expect(response.status()).toBe(401);
+    });
+
+    test("PATCH /api/admin/corrections/[id] requires auth (401)", async ({ request }) => {
+      const response = await request.patch("/api/admin/corrections/1", {
+        data: { status: "accepted" },
+      });
+      expect(response.status()).toBe(401);
+    });
+
+    test("DELETE /api/admin/corrections/[id] requires auth (401)", async ({ request }) => {
+      const response = await request.delete("/api/admin/corrections/1");
+      expect(response.status()).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
Adds a correction/report system for yacht data quality:

**Database:** `user_corrections` table with status tracking (pending/accepted/rejected)

**Components:**
- `CorrectionForm` — modal form triggered by "Suggest a Correction" button on yacht pages
- Correction type selector, field picker from actual specs, current vs suggested value display
- Honeypot anti-spam, rate limiting

**APIs:**
- POST `/api/corrections` — public submission (rate-limited, validated)
- Admin CRUD at `/api/admin/corrections` and `/api/admin/corrections/[id]`
- Auto-updates yacht spec field when correction is accepted

**Tests:** Playwright tests for form visibility, API validation, admin auth

Closes #174