### PR TITLE
fix: guard best-value pages against missing DATABASE_URL + upgrade CI to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 
@@ -61,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 
@@ -82,12 +82,12 @@ jobs:
     needs: [typecheck, build]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 

--- a/app/(main)/best-value/[slug]/page.tsx
+++ b/app/(main)/best-value/[slug]/page.tsx
@@ -182,6 +182,11 @@ export function calculateValueScore(yacht: {
 export async function getBestValueYachts(
   pageDef: BestValuePageDef
 ): Promise<BestValueYacht[]> {
+  if (!process.env.DATABASE_URL) {
+    console.warn(`[build-safe] Returning fallback data during build (no DATABASE_URL)`);
+    return [];
+  }
+
   const query = `
     SELECT
       y.id,


### PR DESCRIPTION
## Problem
- 23 consecutive CI failures since commit \`a04bbbe\` added best-value pages
- \`getBestValueYachts()\` calls \`pool.query()\` during build-time prerendering, but CI has no \`DATABASE_URL\`
- GitHub deprecating Node.js 20 on runners (Sep 2026)

## Changes
1. **Build-safe DB guard** — Returns \`[]\` when \`DATABASE_URL\` is not set, matching existing \`[build-safe]\` pattern used across the codebase
2. **CI upgrades** — \`actions/checkout@v5\`, \`actions/setup-node@v5\`, Node.js 22