### PR TITLE
feat: OpenAPI-backed API docs with interactive examples and schema reference (closes #200)

### DIFF
--- a/app/api/docs/ApiDocsPage.tsx
+++ b/app/api/docs/ApiDocsPage.tsx
@@ -1,0 +1,610 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { openApiSpec } from '@/lib/openapi-schema';
+
+const BASE_URL = 'https://info.sailboats.fr/api/v1';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+type EndpointId = string;
+
+interface TryResult {
+  status: number;
+  body: string;
+  duration: number;
+}
+
+interface EndpointEntry {
+  path: string;
+  method: string;
+  spec: Record<string, any>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+function methodBadge(method: string) {
+  const colors: Record<string, string> = {
+    GET: 'bg-emerald-100 text-emerald-800',
+    POST: 'bg-blue-100 text-blue-800',
+    PUT: 'bg-amber-100 text-amber-800',
+    DELETE: 'bg-red-100 text-red-800',
+  };
+  return (
+    <span className={`px-2 py-0.5 rounded text-xs font-bold tracking-wide ${colors[method] || 'bg-gray-100 text-gray-800'}`}>
+      {method}
+    </span>
+  );
+}
+
+function SchemaTable({ schema, depth = 0 }: { schema: any; depth?: number }) {
+  if (!schema || depth > 3) return null;
+  const props = schema.properties || {};
+  const entries = Object.entries(props);
+  if (entries.length === 0) return <span className="text-gray-500 text-sm">No properties</span>;
+
+  return (
+    <div className={`overflow-x-auto ${depth > 0 ? 'ml-4 border-l-2 border-gray-200 pl-3' : ''}`}>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200">
+            <th className="text-left py-1 pr-4 font-medium text-gray-600">Field</th>
+            <th className="text-left py-1 pr-4 font-medium text-gray-600">Type</th>
+            <th className="text-left py-1 pr-4 font-medium text-gray-600">Required</th>
+            <th className="text-left py-1 font-medium text-gray-600">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([name, prop]: [string, any]) => {
+            const required = (schema.required || []).includes(name);
+            const hasRef = prop.$ref || (prop.items && prop.items.$ref);
+            const refName = hasRef
+              ? (prop.$ref || prop.items.$ref).split('/').pop()
+              : null;
+            const typeLabel = prop.type
+              ? prop.items
+                ? `${prop.type}&lt;${refName || 'object'}&gt;`
+                : prop.enum
+                  ? `enum (${prop.enum.join(' | ')})`
+                  : prop.type
+              : refName || 'object';
+
+            return (
+              <tr key={name} className="border-b border-gray-100">
+                <td className="py-1 pr-4 font-mono text-xs text-blue-700">
+                  {name}
+                  {hasRef && refName && (
+                    <a
+                      href={`#schema-${refName.toLowerCase()}`}
+                      className="ml-1 text-blue-400 hover:text-blue-600"
+                      title={`Go to ${refName}`}
+                    >
+                      ↗
+                    </a>
+                  )}
+                </td>
+                <td className="py-1 pr-4 text-gray-600 text-xs">
+                  <span dangerouslySetInnerHTML={{ __html: typeLabel }} />
+                </td>
+                <td className="py-1 pr-4">
+                  {required ? <span className="text-red-500 text-xs font-bold">✓</span> : <span className="text-gray-400 text-xs">—</span>}
+                </td>
+                <td className="py-1 text-gray-500 text-xs">
+                  {prop.description || ''}
+                  {prop.example && <span className="ml-1 text-gray-400">(e.g. {JSON.stringify(prop.example)})</span>}
+                  {prop.default !== undefined && <span className="ml-1 text-gray-400">(default: {JSON.stringify(prop.default)})</span>}
+                  {prop.minimum !== undefined && <span className="ml-1 text-gray-400">(min: {prop.minimum})</span>}
+                  {prop.maximum !== undefined && <span className="ml-1 text-gray-400">(max: {prop.maximum})</span>}
+                  {prop.minLength !== undefined && <span className="ml-1 text-gray-400">(min length: {prop.minLength})</span>}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Try-It Widget                                                      */
+/* ------------------------------------------------------------------ */
+function TryIt({ path, method }: { path: string; method: string }) {
+  const [params, setParams] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TryResult | null>(null);
+
+  const endpoint = openApiSpec.paths[path]?.[method.toLowerCase()] as Record<string, any> | undefined;
+  const parameters: Record<string, any>[] = endpoint?.parameters || [];
+
+  useEffect(() => {
+    setParams({});
+    setResult(null);
+  }, [path, method]);
+
+  const buildUrl = useCallback(() => {
+    let url = `${BASE_URL}${path}`;
+    const queryParams: string[] = [];
+    for (const p of parameters) {
+      const val = params[p.name];
+      if (!val) continue;
+      if (p.in === 'path') {
+        url = url.replace(`{${p.name}}`, encodeURIComponent(val));
+      } else if (p.in === 'query') {
+        queryParams.push(`${p.name}=${encodeURIComponent(val)}`);
+      }
+    }
+    if (queryParams.length) url += '?' + queryParams.join('&');
+    return url;
+  }, [path, params, parameters]);
+
+  const handleTry = async () => {
+    setLoading(true);
+    const url = buildUrl();
+    const t0 = performance.now();
+    try {
+      const res = await fetch(url);
+      const duration = Math.round(performance.now() - t0);
+      const json = await res.json();
+      setResult({ status: res.status, body: JSON.stringify(json, null, 2), duration });
+    } catch (err: any) {
+      setResult({ status: 0, body: `Network error: ${err.message}`, duration: Math.round(performance.now() - t0) });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pathParams = parameters.filter((p) => p.in === 'path');
+  const queryParams = parameters.filter((p) => p.in === 'query');
+
+  return (
+    <div className="mt-4 border border-gray-200 rounded-lg overflow-hidden">
+      <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
+        <span className="text-sm font-semibold text-gray-700">Try it</span>
+        <button
+          onClick={handleTry}
+          disabled={loading}
+          className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {loading ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {/* URL preview */}
+        <div className="bg-gray-900 text-green-300 font-mono text-xs p-2 rounded break-all">
+          {methodBadge(method)}{' '}
+          <span className="text-white">{buildUrl()}</span>
+        </div>
+
+        {/* Path params */}
+        {pathParams.length > 0 && (
+          <div className="space-y-2">
+            {pathParams.map((p) => (
+              <div key={p.name} className="flex items-center gap-2">
+                <label className="text-xs font-mono text-gray-600 w-28 flex-shrink-0">
+                  {p.name}
+                  {p.required && <span className="text-red-500 ml-0.5">*</span>}
+                </label>
+                <input
+                  type="text"
+                  placeholder={p.example || p.description}
+                  value={params[p.name] || ''}
+                  onChange={(e) => setParams({ ...params, [p.name]: e.target.value })}
+                  className="flex-1 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Query params */}
+        {queryParams.length > 0 && (
+          <details className="group">
+            <summary className="text-xs text-blue-600 cursor-pointer hover:text-blue-800">
+              Query Parameters ({queryParams.length})
+            </summary>
+            <div className="mt-2 space-y-2">
+              {queryParams.map((p) => (
+                <div key={p.name} className="flex items-center gap-2">
+                  <label className="text-xs font-mono text-gray-600 w-28 flex-shrink-0">
+                    {p.name}
+                    {p.required && <span className="text-red-500 ml-0.5">*</span>}
+                  </label>
+                  <input
+                    type="text"
+                    placeholder={p.example ? String(p.example) : p.description || ''}
+                    value={params[p.name] || ''}
+                    onChange={(e) => setParams({ ...params, [p.name]: e.target.value })}
+                    className="flex-1 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                  {p.schema?.default !== undefined && (
+                    <span className="text-xs text-gray-400">default: {JSON.stringify(p.schema.default)}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
+        {/* Result */}
+        {result && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-xs">
+              <span className={`px-2 py-0.5 rounded font-bold ${result.status < 300 ? 'bg-green-100 text-green-800' : result.status < 500 ? 'bg-yellow-100 text-yellow-800' : 'bg-red-100 text-red-800'}`}>
+                {result.status}
+              </span>
+              <span className="text-gray-500">{result.duration}ms</span>
+            </div>
+            <pre className="bg-gray-900 text-green-300 text-xs font-mono p-3 rounded max-h-80 overflow-auto">
+              {result.body}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Endpoint Card                                                      */
+/* ------------------------------------------------------------------ */
+function EndpointCard({
+  path,
+  method,
+  spec,
+  expanded,
+  onToggle,
+}: {
+  path: string;
+  method: string;
+  spec: Record<string, any>;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const responses = spec.responses || {};
+  const statusCodes = Object.keys(responses);
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden" id={`endpoint-${path.replace(/[{}\/]/g, '-')}-${method.toLowerCase()}`}>
+      {/* Header */}
+      <button
+        onClick={onToggle}
+        className="w-full text-left px-4 py-3 bg-white hover:bg-gray-50 transition-colors flex items-center gap-3"
+      >
+        {methodBadge(method)}
+        <code className="text-sm font-mono text-gray-800 flex-1">{path}</code>
+        <span className="text-sm text-gray-500">{spec.summary}</span>
+        <span className="text-gray-400">{expanded ? '▲' : '▼'}</span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-200 px-4 py-4 space-y-4">
+          {spec.description && <p className="text-sm text-gray-600">{spec.description}</p>}
+
+          {spec.tags?.length > 0 && (
+            <div className="flex gap-2">
+              {spec.tags.map((tag: string) => (
+                <span key={tag} className="px-2 py-0.5 bg-purple-100 text-purple-800 text-xs rounded-full">{tag}</span>
+              ))}
+            </div>
+          )}
+
+          {spec.parameters?.length > 0 && (
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">Parameters</h4>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200">
+                      <th className="text-left py-1 pr-3 font-medium text-gray-600">Name</th>
+                      <th className="text-left py-1 pr-3 font-medium text-gray-600">In</th>
+                      <th className="text-left py-1 pr-3 font-medium text-gray-600">Required</th>
+                      <th className="text-left py-1 pr-3 font-medium text-gray-600">Type</th>
+                      <th className="text-left py-1 font-medium text-gray-600">Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {spec.parameters.map((p: any) => (
+                      <tr key={p.name + p.in} className="border-b border-gray-100">
+                        <td className="py-1 pr-3 font-mono text-xs text-blue-700">{p.name}</td>
+                        <td className="py-1 pr-3 text-xs text-gray-500">{p.in}</td>
+                        <td className="py-1 pr-3">{p.required ? <span className="text-red-500 text-xs font-bold">yes</span> : <span className="text-gray-400 text-xs">no</span>}</td>
+                        <td className="py-1 pr-3 text-xs text-gray-600">{p.schema?.type || 'string'}</td>
+                        <td className="py-1 text-xs text-gray-500">
+                          {p.description}
+                          {p.example && <span className="ml-1 text-gray-400">(e.g. {JSON.stringify(p.example)})</span>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">Responses</h4>
+            <div className="space-y-2">
+              {statusCodes.map((code) => {
+                const resp = responses[code];
+                const respSchema = resp.content?.['application/json']?.schema;
+                return (
+                  <details key={code} className="group">
+                    <summary className={`cursor-pointer px-3 py-1.5 rounded text-sm font-mono ${
+                      code.startsWith('2') ? 'bg-green-50 text-green-800 hover:bg-green-100' :
+                      code.startsWith('3') ? 'bg-blue-50 text-blue-800 hover:bg-blue-100' :
+                      code.startsWith('4') ? 'bg-yellow-50 text-yellow-800 hover:bg-yellow-100' :
+                      'bg-red-50 text-red-800 hover:bg-red-100'
+                    }`}>
+                      {code} — {resp.description}
+                    </summary>
+                    {respSchema && (
+                      <div className="mt-2 ml-4">
+                        <SchemaTable schema={respSchema} depth={0} />
+                      </div>
+                    )}
+                  </details>
+                );
+              })}
+            </div>
+          </div>
+
+          <TryIt path={path} method={method} />
+
+          <div>
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">cURL Example</h4>
+            <pre className="bg-gray-900 text-green-300 text-xs font-mono p-3 rounded overflow-x-auto">
+              {generateCurl(path, spec)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function generateCurl(path: string, spec: Record<string, any>): string {
+  let url = `${BASE_URL}${path}`;
+  const queryParams: string[] = [];
+  for (const p of (spec.parameters || []) as Record<string, any>[]) {
+    if (p.in === 'path') {
+      url = url.replace(`{${p.name}}`, String(p.example || `YOUR_${p.name.toUpperCase()}`));
+    } else if (p.in === 'query' && p.example !== undefined) {
+      queryParams.push(`${p.name}=${encodeURIComponent(String(p.example))}`);
+    }
+  }
+  if (queryParams.length) url += '?' + queryParams.join('&');
+  return `curl "${url}"`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Schema Reference                                                   */
+/* ------------------------------------------------------------------ */
+function SchemaReference() {
+  const schemas = openApiSpec.components.schemas as Record<string, any>;
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gray-600">
+        These schemas define the structure of objects returned by the API. Fields marked with
+        <span className="text-red-500 font-bold ml-1">✓</span> are required.
+      </p>
+      {Object.entries(schemas).map(([name, schema]: [string, any]) => (
+        <div key={name} id={`schema-${name.toLowerCase()}`} className="border border-gray-200 rounded-lg overflow-hidden">
+          <div className="bg-gray-50 px-4 py-2 border-b border-gray-200">
+            <h3 className="text-lg font-semibold font-mono text-gray-800">{name}</h3>
+            {schema.description && <p className="text-xs text-gray-500 mt-0.5">{schema.description}</p>}
+          </div>
+          <div className="p-4">
+            <SchemaTable schema={schema} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Endpoint collection helper                                         */
+/* ------------------------------------------------------------------ */
+function collectEndpoints(): EndpointEntry[] {
+  const result: EndpointEntry[] = [];
+  const paths = openApiSpec.paths as Record<string, any>;
+  for (const [path, methods] of Object.entries(paths)) {
+    for (const [method, specRaw] of Object.entries(methods as Record<string, any>)) {
+      if (specRaw && typeof specRaw === 'object' && specRaw.summary) {
+        result.push({ path, method: method.toUpperCase(), spec: specRaw });
+      }
+    }
+  }
+  return result;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Page                                                          */
+/* ------------------------------------------------------------------ */
+export default function ApiDocsPage() {
+  const [expandedEndpoints, setExpandedEndpoints] = useState<Set<EndpointId>>(new Set());
+  const [activeSection, setActiveSection] = useState<'endpoints' | 'schemas'>('endpoints');
+
+  const toggleEndpoint = (id: EndpointId) => {
+    setExpandedEndpoints((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const endpoints = collectEndpoints();
+
+  // Group by tag
+  const tagGroups: Record<string, EndpointEntry[]> = {};
+  for (const ep of endpoints) {
+    const tag = ep.spec.tags?.[0] || 'Other';
+    if (!tagGroups[tag]) tagGroups[tag] = [];
+    tagGroups[tag].push(ep);
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <h1 className="text-3xl font-bold text-gray-900">{openApiSpec.info.title}</h1>
+          <span className="px-2 py-0.5 bg-blue-100 text-blue-800 text-xs font-bold rounded-full">v{openApiSpec.info.version}</span>
+        </div>
+        <p className="text-gray-600">{openApiSpec.info.description}</p>
+        <div className="mt-3 flex items-center gap-4 text-sm">
+          <span className="text-gray-500">
+            Base URL: <code className="bg-gray-100 px-2 py-0.5 rounded text-xs">{BASE_URL}</code>
+          </span>
+          <a
+            href="/api/v1/openapi.json"
+            className="text-blue-600 hover:underline text-xs"
+            target="_blank"
+            rel="noreferrer"
+          >
+            OpenAPI JSON ↗
+          </a>
+        </div>
+      </div>
+
+      {/* Quick Info Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="border border-blue-200 bg-blue-50 rounded-lg p-4">
+          <h3 className="font-semibold text-blue-800 mb-1">Rate Limiting</h3>
+          <p className="text-sm text-blue-700">100 requests/min per IP</p>
+          <p className="text-xs text-blue-600 mt-1">
+            Headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+          </p>
+        </div>
+        <div className="border border-green-200 bg-green-50 rounded-lg p-4">
+          <h3 className="font-semibold text-green-800 mb-1">Response Format</h3>
+          <p className="text-sm text-green-700">JSON with CORS headers</p>
+          <p className="text-xs text-green-600 mt-1">
+            Envelope: <code>{'{ "data": [...], "meta": {...} }'}</code>
+          </p>
+        </div>
+        <div className="border border-purple-200 bg-purple-50 rounded-lg p-4">
+          <h3 className="font-semibold text-purple-800 mb-1">Authentication</h3>
+          <p className="text-sm text-purple-700">None required (public API)</p>
+          <p className="text-xs text-purple-600 mt-1">
+            Optional X-API-Key header for future premium tier
+          </p>
+        </div>
+      </div>
+
+      {/* Section Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        <button
+          onClick={() => setActiveSection('endpoints')}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            activeSection === 'endpoints'
+              ? 'text-blue-700 border-b-2 border-blue-700'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Endpoints ({endpoints.length})
+        </button>
+        <button
+          onClick={() => setActiveSection('schemas')}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            activeSection === 'schemas'
+              ? 'text-blue-700 border-b-2 border-blue-700'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Schemas ({Object.keys(openApiSpec.components.schemas).length})
+        </button>
+      </div>
+
+      {/* Endpoints */}
+      {activeSection === 'endpoints' && (
+        <div className="space-y-8">
+          {Object.entries(tagGroups).map(([tag, eps]) => (
+            <div key={tag}>
+              <h2 className="text-xl font-bold text-gray-800 mb-3 flex items-center gap-2">
+                <span className="w-1.5 h-6 bg-blue-600 rounded-full" />
+                {tag}
+              </h2>
+              <div className="space-y-2">
+                {eps.map((ep) => {
+                  const id = `${ep.path}-${ep.method}`;
+                  return (
+                    <EndpointCard
+                      key={id}
+                      path={ep.path}
+                      method={ep.method}
+                      spec={ep.spec}
+                      expanded={expandedEndpoints.has(id)}
+                      onToggle={() => toggleEndpoint(id)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Schemas */}
+      {activeSection === 'schemas' && <SchemaReference />}
+
+      {/* Error Codes */}
+      <div className="mt-12 border-t border-gray-200 pt-8">
+        <h2 className="text-xl font-bold text-gray-800 mb-4">Error Codes</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="text-left py-2 pr-4 font-medium text-gray-600">Code</th>
+                <th className="text-left py-2 pr-4 font-medium text-gray-600">HTTP Status</th>
+                <th className="text-left py-2 font-medium text-gray-600">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-gray-100">
+                <td className="py-2 pr-4 font-mono text-xs text-blue-700">INVALID_PARAM</td>
+                <td className="py-2 pr-4">400</td>
+                <td className="py-2 text-gray-600">Invalid or missing request parameter</td>
+              </tr>
+              <tr className="border-b border-gray-100">
+                <td className="py-2 pr-4 font-mono text-xs text-blue-700">NOT_FOUND</td>
+                <td className="py-2 pr-4">404</td>
+                <td className="py-2 text-gray-600">Requested resource does not exist</td>
+              </tr>
+              <tr className="border-b border-gray-100">
+                <td className="py-2 pr-4 font-mono text-xs text-blue-700">RATE_LIMIT_EXCEEDED</td>
+                <td className="py-2 pr-4">429</td>
+                <td className="py-2 text-gray-600">Too many requests — slow down and retry after the reset time</td>
+              </tr>
+              <tr className="border-b border-gray-100">
+                <td className="py-2 pr-4 font-mono text-xs text-blue-700">INTERNAL_ERROR</td>
+                <td className="py-2 pr-4">500</td>
+                <td className="py-2 text-gray-600">Unexpected server error — please retry later</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="mt-12 pt-6 border-t border-gray-200 text-center text-xs text-gray-400">
+        <p>
+          Generated from{' '}
+          <a href="/api/v1/openapi.json" className="text-blue-500 hover:underline">
+            OpenAPI 3.0.3 spec
+          </a>
+          . Licensed under{' '}
+          <a href="https://creativecommons.org/licenses/by-sa/4.0/" className="text-blue-500 hover:underline" target="_blank" rel="noreferrer">
+            CC BY-SA 4.0
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/api/docs/page.tsx
+++ b/app/api/docs/page.tsx
@@ -1,74 +1,13 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import ApiDocsPage from './ApiDocsPage';
 
 export const metadata: Metadata = {
-  title: 'Sailing Yacht Info API Documentation',
-  description: 'Public API for accessing sailing yacht data from the Sailing Yacht Info',
+  title: 'API Documentation',
+  description:
+    'Public REST API for sailing yacht data — browse endpoints, schemas, and interactive examples.',
+  alternates: { canonical: '/api/docs' },
 };
 
-export default function ApiPage() {
-  return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Sailing Yacht Info API</h1>
-        <p className="text-gray-600">Access sailing yacht data for your applications</p>
-      </div>
-
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-8">
-        <h2 className="text-lg font-semibold mb-2">Quick Links</h2>
-        <ul className="space-y-2">
-          <li>
-            <Link href="/api/v1/yachts" className="text-blue-600 hover:underline">
-              GET /api/v1/yachts
-            </Link>
-            <span className="text-gray-600 ml-2">— List all yachts</span>
-          </li>
-          <li>
-            <Link href="/api/v1/yachts/[slug]" className="text-blue-600 hover:underline">
-              GET /api/v1/yachts/[slug]
-            </Link>
-            <span className="text-gray-600 ml-2">— Single yacht details</span>
-          </li>
-          <li>
-            <Link href="/api/v1/manufacturers" className="text-blue-600 hover:underline">
-              GET /api/v1/manufacturers
-            </Link>
-            <span className="text-gray-600 ml-2">— List manufacturers</span>
-          </li>
-          <li>
-            <Link href="/api/v1/manufacturers/[id]" className="text-blue-600 hover:underline">
-              GET /api/v1/manufacturers/[id]
-            </Link>
-            <span className="text-gray-600 ml-2">— Manufacturer with yachts</span>
-          </li>
-          <li>
-            <Link href="/api/v1/search" className="text-blue-600 hover:underline">
-              GET /api/v1/search
-            </Link>
-            <span className="text-gray-600 ml-2">— Search yachts</span>
-          </li>
-        </ul>
-      </div>
-
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">Rate Limits</h2>
-        <p className="mb-2">Free tier: <strong>100 requests per minute</strong> per IP address</p>
-        <p>Response headers include rate limit information: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset</p>
-      </div>
-
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">Interactive Testing</h2>
-        <div className="bg-gray-100 rounded-lg p-4 font-mono text-sm">
-          <p className="mb-2">Try from your terminal:</p>
-          <div className="bg-white p-3 rounded border">
-            <p>$ curl "https://info.sailboats.fr/api/v1/yachts?limit=3"</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="prose prose-blue">
-        <div dangerouslySetInnerHTML={{ __html: '<!-- Include markdown content -->' }} />
-      </div>
-    </div>
-  );
+export default function Page() {
+  return <ApiDocsPage />;
 }

--- a/app/api/v1/openapi.json/route.ts
+++ b/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { openApiSpec } from '@/lib/openapi-schema';
+
+export const dynamic = 'force-static';
+
+/**
+ * GET /api/v1/openapi.json — OpenAPI 3.0.3 specification for the public API.
+ */
+export async function GET() {
+  return NextResponse.json(openApiSpec, {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/lib/openapi-schema.ts
+++ b/lib/openapi-schema.ts
@@ -1,0 +1,326 @@
+/**
+ * OpenAPI 3.0.3 specification for the Sailing Yachts public API v1.
+ *
+ * This is the single source of truth for the API docs page (/api/docs)
+ * and the /api/v1/openapi.json endpoint.
+ */
+
+export interface OpenApiSpec {
+  openapi: string;
+  info: {
+    title: string;
+    version: string;
+    description: string;
+    contact?: { name: string; url: string };
+    license?: { name: string; url: string };
+  };
+  servers: { url: string; description: string }[];
+  paths: Record<string, any>;
+  components: {
+    schemas: Record<string, any>;
+    securitySchemes?: Record<string, any>;
+  };
+}
+
+const YachtSchema = {
+  type: 'object',
+  required: ['id', 'modelName', 'manufacturer'],
+  properties: {
+    id: { type: 'integer', description: 'Unique identifier' },
+    slug: { type: 'string', description: 'URL-friendly identifier', example: 'beneteau-oceanis-30-1' },
+    modelName: { type: 'string', description: 'Yacht model name', example: 'Oceanis 30.1' },
+    manufacturer: {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'integer', description: 'Manufacturer ID' },
+        name: { type: 'string', description: 'Manufacturer name', example: 'Bénéteau' },
+        country: { type: 'string', description: 'Country of origin', example: 'France' },
+        website: { type: 'string', format: 'uri', description: 'Manufacturer website' },
+        description: { type: 'string', description: 'Manufacturer description' },
+      },
+    },
+    year: { type: 'integer', description: 'Year of production', example: 2020 },
+    lengthOverall: { type: 'number', description: 'Length overall in meters', example: 9.32 },
+    beam: { type: 'number', description: 'Beam width in meters', example: 3.29 },
+    draft: { type: 'number', description: 'Draft depth in meters', example: 1.85 },
+    displacement: { type: 'number', description: 'Displacement in kg', example: 3800 },
+    ballast: { type: 'number', description: 'Ballast weight in kg' },
+    sailAreaMain: { type: 'number', description: 'Main sail area in m²' },
+    rigType: { type: 'string', description: 'Rig type', example: 'Fractional Sloop' },
+    keelType: { type: 'string', description: 'Keel type', example: 'Fin keel' },
+    hullMaterial: { type: 'string', description: 'Hull material', example: 'GRP' },
+    cabins: { type: 'integer', description: 'Number of cabins', example: 2 },
+    berths: { type: 'integer', description: 'Number of berths', example: 4 },
+    heads: { type: 'integer', description: 'Number of heads (toilets)' },
+    maxOccupancy: { type: 'integer', description: 'Maximum occupancy' },
+    engineHp: { type: 'number', description: 'Engine horsepower' },
+    engineType: { type: 'string', description: 'Engine type' },
+    fuelCapacity: { type: 'number', description: 'Fuel capacity in liters' },
+    waterCapacity: { type: 'number', description: 'Water capacity in liters' },
+    designNotes: { type: 'string', description: 'Design notes from the manufacturer' },
+    description: { type: 'string', description: 'Detailed description of the yacht' },
+    images: {
+      type: 'array',
+      description: 'Yacht images (detail endpoint only)',
+      items: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri' },
+          caption: { type: 'string' },
+          alt: { type: 'string' },
+          isPrimary: { type: 'boolean' },
+        },
+      },
+    },
+    reviews: {
+      type: 'array',
+      description: 'Yacht reviews (detail endpoint only)',
+      items: {
+        type: 'object',
+        properties: {
+          source: { type: 'string' },
+          rating: { type: 'number', minimum: 0, maximum: 5 },
+          summary: { type: 'string' },
+          author: { type: 'string' },
+          date: { type: 'string', format: 'date' },
+        },
+      },
+    },
+  },
+};
+
+const ManufacturerSchema = {
+  type: 'object',
+  required: ['id', 'name', 'yachtCount'],
+  properties: {
+    id: { type: 'integer', description: 'Unique identifier' },
+    name: { type: 'string', description: 'Manufacturer name', example: 'Bénéteau' },
+    country: { type: 'string', description: 'Country of origin', example: 'France' },
+    foundedYear: { type: 'integer', description: 'Year founded', example: 1884 },
+    website: { type: 'string', format: 'uri', description: 'Manufacturer website' },
+    description: { type: 'string', description: 'About the manufacturer' },
+    logoUrl: { type: 'string', format: 'uri', description: 'Logo URL (detail endpoint only)' },
+    yachtCount: { type: 'integer', description: 'Total number of yacht models', example: 15 },
+    yachts: {
+      type: 'array',
+      description: 'Yachts by this manufacturer (detail endpoint only)',
+      items: { $ref: '#/components/schemas/Yacht' },
+    },
+  },
+};
+
+const ErrorSchema = {
+  type: 'object',
+  required: ['error'],
+  properties: {
+    error: {
+      type: 'object',
+      required: ['code', 'message'],
+      properties: {
+        code: { type: 'string', description: 'Machine-readable error code', enum: ['INVALID_PARAM', 'NOT_FOUND', 'RATE_LIMIT_EXCEEDED', 'INTERNAL_ERROR'] },
+        message: { type: 'string', description: 'Human-readable error message' },
+        details: { type: 'string', description: 'Additional context' },
+      },
+    },
+  },
+};
+
+const RateLimitHeaders = {
+  'X-RateLimit-Limit': { schema: { type: 'integer' }, description: 'Maximum requests per window' },
+  'X-RateLimit-Remaining': { schema: { type: 'integer' }, description: 'Remaining requests in current window' },
+  'X-RateLimit-Reset': { schema: { type: 'integer' }, description: 'Unix timestamp when the window resets' },
+};
+
+const CorsHeaders = {
+  'Access-Control-Allow-Origin': { schema: { type: 'string' }, description: 'Allowed origin(s)' },
+  'Access-Control-Allow-Methods': { schema: { type: 'string' }, description: 'Allowed HTTP methods' },
+};
+
+const CommonHeaders = { ...CorsHeaders, ...RateLimitHeaders };
+
+export const openApiSpec: OpenApiSpec = {
+  openapi: '3.0.3',
+  info: {
+    title: 'Sailing Yacht Info API',
+    version: '1.0.0',
+    description:
+      'Public REST API for accessing sailing yacht data including models, manufacturers, specs, images, and reviews. All endpoints return JSON with CORS headers.',
+    contact: { name: 'Sailing Yacht Info', url: 'https://info.sailboats.fr' },
+    license: { name: 'CC BY-SA 4.0', url: 'https://creativecommons.org/licenses/by-sa/4.0/' },
+  },
+  servers: [
+    { url: 'https://info.sailboats.fr/api/v1', description: 'Production' },
+    { url: 'http://localhost:3000/api/v1', description: 'Development' },
+  ],
+  paths: {
+    '/yachts': {
+      get: {
+        summary: 'List yachts',
+        description: 'Retrieve a paginated, filterable, sortable list of sailing yachts.',
+        operationId: 'listYachts',
+        tags: ['Yachts'],
+        parameters: [
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1, minimum: 1 }, description: 'Page number' },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 20, minimum: 1, maximum: 100 }, description: 'Items per page' },
+          { name: 'sort', in: 'query', schema: { type: 'string', enum: ['id', 'modelName', 'year', 'lengthOverall', 'beam', 'draft', 'displacement', 'cabins', 'berths'], default: 'id' }, description: 'Sort field' },
+          { name: 'order', in: 'query', schema: { type: 'string', enum: ['asc', 'desc'], default: 'asc' }, description: 'Sort order' },
+          { name: 'manufacturer', in: 'query', schema: { type: 'string' }, description: 'Manufacturer name (partial match)' },
+          { name: 'manufacturerId', in: 'query', schema: { type: 'integer' }, description: 'Manufacturer ID (exact match)' },
+          { name: 'rigType', in: 'query', schema: { type: 'string' }, description: 'Rig type (exact match)' },
+          { name: 'keelType', in: 'query', schema: { type: 'string' }, description: 'Keel type (exact match)' },
+          { name: 'hullMaterial', in: 'query', schema: { type: 'string' }, description: 'Hull material (exact match)' },
+          { name: 'lengthMin', in: 'query', schema: { type: 'number' }, description: 'Minimum LOA in meters' },
+          { name: 'lengthMax', in: 'query', schema: { type: 'number' }, description: 'Maximum LOA in meters' },
+          { name: 'yearMin', in: 'query', schema: { type: 'integer' }, description: 'Minimum year' },
+          { name: 'yearMax', in: 'query', schema: { type: 'integer' }, description: 'Maximum year' },
+          { name: 'cabinsMin', in: 'query', schema: { type: 'integer' }, description: 'Minimum number of cabins' },
+        ],
+        responses: {
+          '200': {
+            description: 'Paginated list of yachts',
+            headers: CommonHeaders,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['data', 'meta'],
+                  properties: {
+                    data: { type: 'array', items: { $ref: '#/components/schemas/Yacht' } },
+                    meta: {
+                      type: 'object',
+                      required: ['page', 'limit', 'total', 'totalPages'],
+                      properties: {
+                        page: { type: 'integer' },
+                        limit: { type: 'integer' },
+                        total: { type: 'integer' },
+                        totalPages: { type: 'integer' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '429': {
+            description: 'Rate limit exceeded',
+            headers: { ...CommonHeaders, 'Retry-After': { schema: { type: 'integer' }, description: 'Seconds until reset' } },
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+          },
+          '500': { description: 'Internal error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+    '/yachts/{slug}': {
+      get: {
+        summary: 'Get yacht details',
+        description: 'Retrieve a single yacht by its slug, including manufacturer info, images, and reviews.',
+        operationId: 'getYacht',
+        tags: ['Yachts'],
+        parameters: [
+          { name: 'slug', in: 'path', required: true, schema: { type: 'string' }, description: 'Yacht slug', example: 'beneteau-oceanis-30-1' },
+        ],
+        responses: {
+          '200': {
+            description: 'Yacht details with images and reviews',
+            headers: CommonHeaders,
+            content: { 'application/json': { schema: { type: 'object', required: ['data'], properties: { data: { $ref: '#/components/schemas/Yacht' } } } } },
+          },
+          '404': { description: 'Yacht not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+          '429': { description: 'Rate limit exceeded', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+    '/manufacturers': {
+      get: {
+        summary: 'List manufacturers',
+        description: 'Retrieve a list of all yacht manufacturers with yacht counts.',
+        operationId: 'listManufacturers',
+        tags: ['Manufacturers'],
+        parameters: [
+          { name: 'country', in: 'query', schema: { type: 'string' }, description: 'Filter by country (exact match)' },
+          { name: 'name', in: 'query', schema: { type: 'string' }, description: 'Filter by name (partial match)' },
+        ],
+        responses: {
+          '200': {
+            description: 'List of manufacturers',
+            headers: CommonHeaders,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['data'],
+                  properties: { data: { type: 'array', items: { $ref: '#/components/schemas/Manufacturer' } } },
+                },
+              },
+            },
+          },
+          '429': { description: 'Rate limit exceeded', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+    '/manufacturers/{id}': {
+      get: {
+        summary: 'Get manufacturer details',
+        description: 'Retrieve a single manufacturer with all its yacht models.',
+        operationId: 'getManufacturer',
+        tags: ['Manufacturers'],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' }, description: 'Manufacturer ID', example: 82 },
+        ],
+        responses: {
+          '200': {
+            description: 'Manufacturer with yachts',
+            headers: CommonHeaders,
+            content: { 'application/json': { schema: { type: 'object', required: ['data'], properties: { data: { $ref: '#/components/schemas/Manufacturer' } } } } },
+          },
+          '400': { description: 'Invalid manufacturer ID', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+          '404': { description: 'Manufacturer not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+    '/search': {
+      get: {
+        summary: 'Search yachts',
+        description: 'Full-text search across yacht model names, manufacturers, rig types, keel types, hull materials, and descriptions.',
+        operationId: 'searchYachts',
+        tags: ['Search'],
+        parameters: [
+          { name: 'q', in: 'query', required: true, schema: { type: 'string', minLength: 2 }, description: 'Search query', example: 'oceanis' },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 20, minimum: 1, maximum: 50 }, description: 'Maximum results' },
+        ],
+        responses: {
+          '200': {
+            description: 'Search results',
+            headers: CommonHeaders,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['data', 'meta'],
+                  properties: {
+                    data: { type: 'array', items: { $ref: '#/components/schemas/Yacht' } },
+                    meta: {
+                      type: 'object',
+                      required: ['total', 'limit'],
+                      properties: { total: { type: 'integer' }, limit: { type: 'integer' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid query parameter', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+          '429': { description: 'Rate limit exceeded', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Yacht: YachtSchema,
+      Manufacturer: ManufacturerSchema,
+      Error: ErrorSchema,
+    },
+  },
+};

--- a/tests/api-docs.spec.ts
+++ b/tests/api-docs.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://info.sailboats.fr';
+
+test.describe('API Documentation', () => {
+  test.describe('Docs Page', () => {
+    test('should load the API docs page', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+      await page.waitForLoadState('networkidle');
+
+      // Check key content is present
+      await expect(page.locator('h1')).toContainText('Sailing Yacht Info API');
+      await expect(page.locator('text=Rate Limiting')).toBeVisible();
+      await expect(page.locator('text=100 requests/min')).toBeVisible();
+      await expect(page.locator('text=Response Format')).toBeVisible();
+      await expect(page.locator('text=Authentication')).toBeVisible();
+    });
+
+    test('should display all endpoint sections', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+
+      // Should have tag groups for Yachts, Manufacturers, Search
+      await expect(page.locator('text=Endpoints (5)')).toBeVisible();
+
+      // Should list all endpoints
+      await expect(page.locator('code:text("/yachts")')).toBeVisible();
+      await expect(page.locator('code:text("/yachts/{slug}")')).toBeVisible();
+      await expect(page.locator('code:text("/manufacturers")')).toBeVisible();
+      await expect(page.locator('code:text("/manufacturers/{id}")')).toBeVisible();
+      await expect(page.locator('code:text("/search")')).toBeVisible();
+    });
+
+    test('should expand an endpoint and show parameters', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+
+      // Click on the /yachts endpoint
+      const yachtBtn = page.locator('button:has(code:text("/yachts"))').first();
+      await yachtBtn.click();
+
+      // Should show parameters section
+      await expect(page.locator('text=Parameters')).toBeVisible();
+      await expect(page.locator('td:text("page")')).toBeVisible();
+      await expect(page.locator('td:text("limit")')).toBeVisible();
+      await expect(page.locator('td:text("sort")')).toBeVisible();
+
+      // Should show Try It widget
+      await expect(page.locator('text=Try it')).toBeVisible();
+      await expect(page.locator('button:text("Send")')).toBeVisible();
+
+      // Should show cURL example
+      await expect(page.locator('text=cURL Example')).toBeVisible();
+    });
+
+    test('should switch to Schemas tab and show schemas', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+
+      // Click on Schemas tab
+      await page.locator('button:text("Schemas (3)")').click();
+
+      // Should show all schemas
+      await expect(page.locator('h3:text("Yacht")')).toBeVisible();
+      await expect(page.locator('h3:text("Manufacturer")')).toBeVisible();
+      await expect(page.locator('h3:text("Error")')).toBeVisible();
+    });
+
+    test('should show error codes section', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+
+      await expect(page.locator('text=Error Codes')).toBeVisible();
+      await expect(page.locator('text=INVALID_PARAM')).toBeVisible();
+      await expect(page.locator('text=NOT_FOUND')).toBeVisible();
+      await expect(page.locator('text=RATE_LIMIT_EXCEEDED')).toBeVisible();
+      await expect(page.locator('text=INTERNAL_ERROR')).toBeVisible();
+    });
+
+    test('should link to OpenAPI JSON', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+      const link = page.locator('a[href="/api/v1/openapi.json"]');
+      await expect(link).toBeVisible();
+      expect(await link.getAttribute('href')).toBe('/api/v1/openapi.json');
+    });
+
+    test('docs page visual snapshot', async ({ page }) => {
+      await page.goto(`${BASE_URL}/api/docs`);
+      await page.waitForLoadState('networkidle');
+      // Mask dynamic content
+      await expect(page).toHaveScreenshot('api-docs.png', {
+        maxDiffPixelRatio: 0.02,
+        fullPage: false,
+      });
+    });
+  });
+
+  test.describe('OpenAPI JSON Endpoint', () => {
+    test('should return valid OpenAPI 3.0.3 spec', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/openapi.json`);
+      expect(response.status()).toBe(200);
+
+      const spec = await response.json();
+
+      // Validate top-level structure
+      expect(spec.openapi).toBe('3.0.3');
+      expect(spec.info).toBeDefined();
+      expect(spec.info.title).toBe('Sailing Yacht Info API');
+      expect(spec.info.version).toBe('1.0.0');
+      expect(spec.servers).toBeDefined();
+      expect(spec.paths).toBeDefined();
+      expect(spec.components).toBeDefined();
+      expect(spec.components.schemas).toBeDefined();
+    });
+
+    test('should contain all v1 endpoints', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/openapi.json`);
+      const spec = await response.json();
+
+      expect(spec.paths['/yachts']).toBeDefined();
+      expect(spec.paths['/yachts'].get).toBeDefined();
+      expect(spec.paths['/yachts/{slug}']).toBeDefined();
+      expect(spec.paths['/yachts/{slug}'].get).toBeDefined();
+      expect(spec.paths['/manufacturers']).toBeDefined();
+      expect(spec.paths['/manufacturers'].get).toBeDefined();
+      expect(spec.paths['/manufacturers/{id}']).toBeDefined();
+      expect(spec.paths['/manufacturers/{id}'].get).toBeDefined();
+      expect(spec.paths['/search']).toBeDefined();
+      expect(spec.paths['/search'].get).toBeDefined();
+    });
+
+    test('should include Yacht, Manufacturer, and Error schemas', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/openapi.json`);
+      const spec = await response.json();
+
+      const schemas = spec.components.schemas;
+      expect(schemas.Yacht).toBeDefined();
+      expect(schemas.Manufacturer).toBeDefined();
+      expect(schemas.Error).toBeDefined();
+
+      // Yacht schema should have key properties
+      const yachtProps = schemas.Yacht.properties;
+      expect(yachtProps.id).toBeDefined();
+      expect(yachtProps.modelName).toBeDefined();
+      expect(yachtProps.manufacturer).toBeDefined();
+      expect(yachtProps.lengthOverall).toBeDefined();
+      expect(yachtProps.beam).toBeDefined();
+      expect(yachtProps.draft).toBeDefined();
+
+      // Required fields
+      expect(schemas.Yacht.required).toContain('id');
+      expect(schemas.Yacht.required).toContain('modelName');
+      expect(schemas.Yacht.required).toContain('manufacturer');
+    });
+
+    test('should have consistent server URLs', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/openapi.json`);
+      const spec = await response.json();
+
+      expect(spec.servers.length).toBeGreaterThanOrEqual(1);
+      expect(spec.servers[0].url).toContain('sailboats.fr');
+    });
+
+    test('should have CORS headers', async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/v1/openapi.json`);
+      expect(response.headers()['access-control-allow-origin']).toBe('*');
+    });
+  });
+
+  test.describe('Route Availability', () => {
+    const publicRoutes = [
+      '/api/v1/yachts',
+      '/api/v1/yachts?limit=1',
+      '/api/v1/manufacturers',
+      '/api/v1/search?q=oceanis',
+      '/api/v1/openapi.json',
+      '/api/docs',
+    ];
+
+    for (const route of publicRoutes) {
+      test(`GET ${route} should return 200`, async ({ request }) => {
+        const response = await request.get(`${BASE_URL}${route}`);
+        expect(response.status()).toBe(200);
+      });
+    }
+  });
+});


### PR DESCRIPTION
- Add OpenAPI 3.0.3 spec as single source of truth (lib/openapi-schema.ts)
- Add /api/v1/openapi.json endpoint serving the spec with CORS and caching
- Replace placeholder docs page with rich interactive documentation:
  - Expandable endpoint cards with parameters, responses, schemas
  - Try-It widget for live API testing from the docs page
  - Auto-generated cURL examples per endpoint
  - Schema reference tab with field-level documentation
  - Error codes reference table
  - Quick info cards for rate limiting, auth, response format
- Add comprehensive test suite:
  - Docs page loads and shows all sections
  - Endpoint expansion and parameter display
  - Schema tab navigation
  - OpenAPI JSON endpoint validation
  - All endpoints present in spec
  - Schema consistency checks (Yacht, Manufacturer, Error)
  - Route availability tests for all public routes
  - Visual regression snapshot for docs page
