### PR TITLE
fix: OpenAPI route 404 — use /api/v1/openapi with .json rewrite

### DIFF
--- a/app/api/v1/openapi/route.ts
+++ b/app/api/v1/openapi/route.ts
@@ -4,7 +4,7 @@ import { openApiSpec } from '@/lib/openapi-schema';
 export const dynamic = 'force-static';
 
 /**
- * GET /api/v1/openapi.json — OpenAPI 3.0.3 specification for the public API.
+ * GET /api/v1/openapi — OpenAPI 3.0.3 specification for the public API.
  */
 export async function GET() {
   return NextResponse.json(openApiSpec, {

--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,15 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      // OpenAPI spec: serve /api/v1/openapi.json via the route at /api/v1/openapi
+      {
+        source: '/api/v1/openapi.json',
+        destination: '/api/v1/openapi',
+      },
+    ];
+  },
 };
 
 // Sentry wrapper — only applies when Sentry env vars are set


### PR DESCRIPTION
Fixes the 404 on /api/v1/openapi.json — Next.js App Router doesn't handle dots in folder names. Moved the route handler to /api/v1/openapi and added a rewrite rule.