### PR TITLE
fix: remove DB imports from middleware to fix Edge runtime crash

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,15 +2,12 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { checkLoginRateLimit, getClientIp } from '@/lib/rate-limit'
-import { logAudit, getUserAgent } from '@/lib/admin-audit'
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
   const clientIp = getClientIp(request)
-  const userAgent = getUserAgent(request)
 
   // ── Rate limiting for admin login attempts ──
-  // Intercept the NextAuth credentials callback to enforce lockout
   if (pathname === '/api/auth/callback/credentials' && request.method === 'POST') {
     const rateLimit = checkLoginRateLimit(clientIp)
     if (!rateLimit.allowed) {
@@ -25,22 +22,19 @@ export async function middleware(request: NextRequest) {
   if (pathname.startsWith('/api/admin/') && 
       !pathname.startsWith('/api/auth/') &&
       pathname !== '/api/admin/login' && 
-      pathname !== '/api/admin/logout') {
+      pathname !== '/api/admin/logout' &&
+      pathname !== '/api/admin/audit-logs') {
     const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
     
     if (!token || token.role !== 'admin') {
-      // Log unauthorized access attempt
-      await logAudit({
-        userId: token?.sub ? Number(token.sub) : null,
-        userEmail: (token?.email as string) ?? null,
-        action: 'unauthorized_access',
-        resourceType: 'admin_api',
-        resourceId: pathname,
-        ipAddress: clientIp,
-        userAgent,
-        statusCode: 401,
-      }).catch(() => {})
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+  }
 
+  // ── Protect audit-logs endpoint (admin only) ──
+  if (pathname === '/api/admin/audit-logs') {
+    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+    if (!token || token.role !== 'admin') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
   }


### PR DESCRIPTION
The middleware was importing admin-audit.ts → lib/db → Neon serverless client, which is incompatible with Vercel's Edge runtime. This caused `MIDDLEWARE_INVOCATION_FAILED` 500 errors on all admin routes.

Fix: Remove audit logging from middleware. Middleware now only does auth checks + rate limiting. Audit logging will be done in individual route handlers (Node.js runtime).