### PR TITLE
fix: resolve remaining WCAG 2.1 AA color contrast violations

### DIFF
--- a/app/(main)/account/AccountDashboard.tsx
+++ b/app/(main)/account/AccountDashboard.tsx
@@ -473,7 +473,7 @@ function DashboardRecommendations() {
                         style={{ width: `${Math.round(yacht.score * 100)}%` }}
                       />
                     </div>
-                    <span className="text-xs text-gray-400">{Math.round(yacht.score * 100)}%</span>
+                    <span className="text-xs text-gray-500">{Math.round(yacht.score * 100)}%</span>
                   </div>
                 )}
               </Link>

--- a/app/(main)/admin/leads/page.tsx
+++ b/app/(main)/admin/leads/page.tsx
@@ -57,7 +57,7 @@ export default async function AdminLeadsPage() {
           </thead>
           <tbody className="divide-y">
             {allLeads.length === 0 && (
-              <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-400">No leads yet</td></tr>
+              <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-500">No leads yet</td></tr>
             )}
             {allLeads.map((lead: any) => (
               <tr key={lead.id} className="hover:bg-gray-50">
@@ -73,7 +73,7 @@ export default async function AdminLeadsPage() {
                   {(lead.metadata as any)?.yachtNames?.join(", ") || "—"}
                 </td>
                 <td className="px-4 py-3 text-xs text-gray-500">{lead.source || "—"}</td>
-                <td className="px-4 py-3 text-xs text-gray-400">
+                <td className="px-4 py-3 text-xs text-gray-500">
                   {lead.utmSource ? `${lead.utmSource}${lead.utmMedium ? ` / ${lead.utmMedium}` : ""}` : "—"}
                 </td>
                 <td className="px-4 py-3">

--- a/app/(main)/admin/prices/page.tsx
+++ b/app/(main)/admin/prices/page.tsx
@@ -131,7 +131,7 @@ export default async function AdminPricesPage() {
                 </td>
                 <td className="px-4 py-3 text-sm">
                   <div className="text-gray-900">{p.source}</div>
-                  <div className="text-gray-400 text-xs">{p.source_type}</div>
+                  <div className="text-gray-500 text-xs">{p.source_type}</div>
                 </td>
                 <td className="px-4 py-3 text-sm"><ConfidenceBadge score={p.confidence_score} /></td>
                 <td className="px-4 py-3 text-sm"><StatusBadge active={p.is_active} /></td>

--- a/app/(main)/best-value/[slug]/page.tsx
+++ b/app/(main)/best-value/[slug]/page.tsx
@@ -397,7 +397,7 @@ export default async function BestValuePage({
                               ? "bg-gray-100 text-gray-600"
                               : index === 2
                                 ? "bg-amber-100 text-amber-700"
-                                : "bg-gray-50 text-gray-400"
+                                : "bg-gray-50 text-gray-600"
                         }`}
                       >
                         {index + 1}
@@ -413,7 +413,7 @@ export default async function BestValuePage({
                           />
                         </div>
                       ) : (
-                        <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center text-gray-400 text-2xl flex-shrink-0">
+                        <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center text-gray-500 text-2xl flex-shrink-0">
                           ⛵
                         </div>
                       )}
@@ -526,7 +526,7 @@ export default async function BestValuePage({
                             )}
                           </span>
                           {yacht.lengthOverall && yacht.priceMin && (
-                            <span className="text-gray-400 ml-2">
+                            <span className="text-gray-500 ml-2">
                               (~
                               {new Intl.NumberFormat("en-US", {
                                 style: "currency",

--- a/app/(main)/best-value/page.tsx
+++ b/app/(main)/best-value/page.tsx
@@ -84,7 +84,7 @@ export default function BestValueIndexPage() {
                 <p className="text-sm text-gray-600 mb-3">
                   {cat.description}
                 </p>
-                <span className="text-xs text-emerald-600 font-medium">
+                <span className="text-xs text-emerald-700 font-medium">
                   View {cat.yachtCount} yachts →
                 </span>
               </Link>

--- a/app/(main)/cheaper-alternatives-to/[slug]/page.tsx
+++ b/app/(main)/cheaper-alternatives-to/[slug]/page.tsx
@@ -297,7 +297,7 @@ export default async function CheaperAlternativesPage({
                         />
                       </div>
                     ) : (
-                      <div className="ml-4 w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center text-gray-400 text-2xl flex-shrink-0">
+                      <div className="ml-4 w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center text-gray-500 text-2xl flex-shrink-0">
                         ⛵
                       </div>
                     )}

--- a/app/(main)/compare/CompareClient.tsx
+++ b/app/(main)/compare/CompareClient.tsx
@@ -470,7 +470,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
             <h3 className="text-sm font-semibold text-gray-700">Saved Comparisons</h3>
             <button
               onClick={() => setSavedPanelOpen(false)}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-500 hover:text-gray-700 transition-colors"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -478,7 +478,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
             </button>
           </div>
           {savedList.length === 0 ? (
-            <div className="px-4 py-6 text-center text-gray-400 text-sm">
+            <div className="px-4 py-6 text-center text-gray-500 text-sm">
               No saved comparisons yet. Select 2+ yachts and click Save.
             </div>
           ) : (
@@ -552,7 +552,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                     </div>
                     <button
                       onClick={() => removeYacht(id)}
-                      className="text-gray-400 hover:text-red-500 transition-colors p-1"
+                      className="text-gray-500 hover:text-red-600 transition-colors p-1"
                       title="Remove"
                     >
                       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -596,7 +596,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
           {/* Search */}
           <div className="p-3 border-b border-gray-100 bg-gray-50">
             <div className="relative">
-              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
               </svg>
               <input

--- a/app/(main)/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/(main)/compare/[slugA]-vs-[slugB]/page.tsx
@@ -196,7 +196,7 @@ export default async function CanonicalComparePage({
                     <th className="px-6 py-4 text-left min-w-[200px]">
                       <Link
                         href={`/yachts/${yachtB.slug}`}
-                        className="font-semibold text-emerald-600 hover:underline"
+                        className="font-semibold text-emerald-700 hover:underline"
                       >
                         {fullNameB}
                       </Link>
@@ -505,7 +505,7 @@ export default async function CanonicalComparePage({
             </div>
 
             {/* Footer */}
-            <div className="px-6 py-4 bg-gray-50 border-t text-xs text-gray-400">
+            <div className="px-6 py-4 bg-gray-50 border-t text-xs text-gray-600">
               Compare more yachts with our{" "}
               <Link href="/compare" className="text-blue-600 hover:underline font-medium">
                 comparison tool
@@ -554,7 +554,7 @@ export default async function CanonicalComparePage({
                 </p>
                 <Link
                   href={`/yachts/${yachtB.slug}`}
-                  className="inline-flex items-center gap-2 text-emerald-600 hover:underline font-medium"
+                  className="inline-flex items-center gap-2 text-emerald-700 hover:underline font-medium"
                 >
                   View Full Details
                   <svg

--- a/app/(main)/links/page.tsx
+++ b/app/(main)/links/page.tsx
@@ -44,7 +44,7 @@ export default function LinksPage() {
           >
             <h2 className="text-xl font-semibold text-blue-600 hover:underline">{p.name}</h2>
             <p className="text-gray-600 mt-2">{p.description}</p>
-            <span className="text-sm text-gray-400 mt-2 block">{p.url}</span>
+            <span className="text-sm text-gray-500 mt-2 block">{p.url}</span>
           </a>
         ))}
       </div>

--- a/app/(main)/yachts/YachtsClient.tsx
+++ b/app/(main)/yachts/YachtsClient.tsx
@@ -413,7 +413,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
           <div className="bg-white rounded-lg p-5 sm:p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
             <div className="flex justify-between items-start">
               <h2 className="text-xl sm:text-2xl font-bold pr-4">{selectedYacht.manufacturer} {selectedYacht.modelName}</h2>
-              <button onClick={closeModal} className="text-gray-400 hover:text-gray-700 text-2xl leading-none flex-shrink-0">&times;</button>
+              <button onClick={closeModal} className="text-gray-500 hover:text-gray-700 text-2xl leading-none flex-shrink-0">&times;</button>
             </div>
             <p className="text-gray-600 mb-4">{selectedYacht.year ?? ''}</p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">

--- a/app/api/docs/ApiDocsPage.tsx
+++ b/app/api/docs/ApiDocsPage.tsx
@@ -595,11 +595,11 @@ export default function ApiDocsPage() {
       <div className="mt-12 pt-6 border-t border-gray-200 text-center text-xs text-gray-500">
         <p>
           Generated from{' '}
-          <a href="/api/v1/openapi.json" className="text-blue-500 hover:underline">
+          <a href="/api/v1/openapi.json" className="text-blue-600 hover:underline">
             OpenAPI 3.0.3 spec
           </a>
           . Licensed under{' '}
-          <a href="https://creativecommons.org/licenses/by-sa/4.0/" className="text-blue-500 hover:underline" target="_blank" rel="noreferrer">
+          <a href="https://creativecommons.org/licenses/by-sa/4.0/" className="text-blue-600 hover:underline" target="_blank" rel="noreferrer">
             CC BY-SA 4.0
           </a>
           .

--- a/app/components/AffiliateRecommendations.tsx
+++ b/app/components/AffiliateRecommendations.tsx
@@ -76,7 +76,7 @@ export default function AffiliateRecommendations({ categories }: AffiliateRecomm
                       <h4 className="font-semibold text-gray-900 group-hover:text-blue-700 transition-colors text-sm sm:text-base">
                         {product.name}
                       </h4>
-                      <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-blue-600 flex-shrink-0 ml-2" />
+                      <ExternalLink className="h-4 w-4 text-gray-500 group-hover:text-blue-600 flex-shrink-0 ml-2" />
                     </div>
 
                     <p className="text-xs sm:text-sm text-gray-600 mb-2">

--- a/app/components/BuyerChecklist.tsx
+++ b/app/components/BuyerChecklist.tsx
@@ -115,7 +115,7 @@ export function BuyerChecklist({ yachtIds, yachtNames }: BuyerChecklistProps) {
             </button>
             <button
               onClick={() => setShowAuthHint(false)}
-              className="text-sm text-gray-400 hover:text-gray-600"
+              className="text-sm text-gray-500 hover:text-gray-700"
             >
               Dismiss
             </button>
@@ -170,7 +170,7 @@ export function BuyerChecklist({ yachtIds, yachtNames }: BuyerChecklistProps) {
                       <span
                         className={`text-sm ${
                           item.checked
-                            ? "text-gray-400 line-through"
+                            ? "text-gray-500 line-through"
                             : "text-gray-700"
                         }`}
                       >

--- a/app/components/CompareExport.tsx
+++ b/app/components/CompareExport.tsx
@@ -133,7 +133,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
             </svg>
             <span>Export</span>
             <svg
-              className="w-3 h-3 text-gray-400"
+              className="w-3 h-3 text-gray-500"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -184,7 +184,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
               </svg>
               <div>
                 <div className="font-medium">Download CSV</div>
-                <div className="text-xs text-gray-400">Spreadsheet-friendly</div>
+                <div className="text-xs text-gray-500">Spreadsheet-friendly</div>
               </div>
             </button>
             <div className="border-t border-gray-100" />
@@ -207,7 +207,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
               </svg>
               <div>
                 <div className="font-medium">Save as PDF</div>
-                <div className="text-xs text-gray-400">Print-optimized report</div>
+                <div className="text-xs text-gray-500">Print-optimized report</div>
               </div>
             </button>
           </div>

--- a/app/components/CompareMonetization.tsx
+++ b/app/components/CompareMonetization.tsx
@@ -280,7 +280,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
                   setInquirySubmitted(false);
                   setInquiryError(null);
                 }}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
+                className="text-gray-500 hover:text-gray-700 transition-colors"
               >
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />

--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -44,7 +44,7 @@ export function FavoriteButton({
       className={`inline-flex items-center justify-center rounded-full transition-all duration-200 ${
         active
           ? "bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600"
-          : "bg-gray-100 text-gray-400 hover:bg-gray-200 hover:text-gray-500"
+          : "bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-600"
       } ${sizeClasses[size]} ${className}`}
       aria-label={active ? `Remove ${modelName || slug} from favorites` : `Add ${modelName || slug} to favorites`}
       title={active ? "Remove from favorites" : "Add to favorites"}

--- a/app/components/PriceInsightBlock.tsx
+++ b/app/components/PriceInsightBlock.tsx
@@ -91,7 +91,7 @@ function PriceUnavailableFallback({ status }: { status: "contact" | "unavailable
           <PhoneIcon />
           <span className="font-medium">Contact for price</span>
         </div>
-        <p className="mt-1 text-xs text-gray-400">Pricing available upon request from dealers</p>
+        <p className="mt-1 text-xs text-gray-500">Pricing available upon request from dealers</p>
       </div>
     );
   }
@@ -102,7 +102,7 @@ function PriceUnavailableFallback({ status }: { status: "contact" | "unavailable
         <DashIcon />
         <span className="font-medium">Price not available</span>
       </div>
-      <p className="mt-1 text-xs text-gray-400">No pricing data found for this model</p>
+      <p className="mt-1 text-xs text-gray-500">No pricing data found for this model</p>
     </div>
   );
 }
@@ -169,7 +169,7 @@ function PriceTrendSparkline({ data }: { data: PriceTrendPoint[] }) {
     <div className="mt-3" data-testid="price-trend-chart">
       <div className="flex items-center justify-between mb-1">
         <span className="text-xs text-gray-500">Price History</span>
-        <span className="text-xs text-gray-400">{data.length} data points</span>
+        <span className="text-xs text-gray-500">{data.length} data points</span>
       </div>
       <svg
         viewBox={`0 0 ${width} ${height}`}
@@ -182,7 +182,7 @@ function PriceTrendSparkline({ data }: { data: PriceTrendPoint[] }) {
         <polyline points={lineMin} fill="none" stroke="currentColor" className="text-primary" strokeWidth="1.5" />
         <polyline points={lineMax} fill="none" stroke="currentColor" className="text-primary/50" strokeWidth="1" strokeDasharray="2,2" />
       </svg>
-      <div className="flex justify-between text-xs text-gray-400 mt-0.5">
+      <div className="flex justify-between text-xs text-gray-500 mt-0.5">
         <span>{data[0]?.date}</span>
         <span>{data[data.length - 1]?.date}</span>
       </div>
@@ -211,7 +211,7 @@ function PriceRow({
         <span className="text-sm font-bold text-gray-900">
           {formatPriceRange(priceRange.min, priceRange.max, priceRange.currency)}
         </span>
-        <div className="text-xs text-gray-400">
+        <div className="text-xs text-gray-500">
           {priceRange.sources} source{priceRange.sources !== 1 ? "s" : ""}
         </div>
       </div>
@@ -420,10 +420,10 @@ export function PriceInsightBlock({
 
       {/* Footer */}
       <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-100">
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-gray-500">
           Prices normalized to {currency}
         </span>
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-gray-500">
           {displayInfo.confidenceLabel}
         </span>
       </div>

--- a/app/components/PriceTierBadge.tsx
+++ b/app/components/PriceTierBadge.tsx
@@ -41,12 +41,12 @@ export function PriceTierDetail({ info }: PriceTierDetailProps) {
       <ul className="space-y-1">
         {info.reasons.map((reason, i) => (
           <li key={i} className="text-sm text-gray-600 flex items-start gap-1.5">
-            <span className="text-gray-400 mt-0.5">•</span>
+            <span className="text-gray-500 mt-0.5">•</span>
             {reason}
           </li>
         ))}
       </ul>
-      <p className="text-xs text-gray-400 mt-3 italic">
+      <p className="text-xs text-gray-500 mt-3 italic">
         Estimate based on yacht specifications. Actual prices vary by market, condition, and equipment.
       </p>
     </div>


### PR DESCRIPTION
## Summary
Follow-up to PR #208 — fixes remaining `text-gray-400` and `text-emerald-600` contrast violations identified during live-site axe-core testing.

## Changes
- **18 files** updated: all `text-gray-400` visible-text instances → `text-gray-500` (~4.6:1 contrast on white)
- `text-emerald-600` on visible small text → `text-emerald-700` (~5.2:1 contrast)
- `text-blue-500` in API docs footer → `text-blue-600`
- Admin pages, account dashboard, and all component files included

## Files affected
`CompareClient.tsx`, `best-value/page.tsx`, `best-value/[slug]/page.tsx`, `compare/[slugA]-vs-[slugB]/page.tsx`, `YachtsClient.tsx`, `ApiDocsPage.tsx`, `BuyerChecklist.tsx`, `FavoriteButton.tsx`, `CompareExport.tsx`, `CompareMonetization.tsx`, `PriceInsightBlock.tsx`, `PriceTierBadge.tsx`, `AffiliateRecommendations.tsx`, `AccountDashboard.tsx`, `leads/page.tsx`, `prices/page.tsx`, `links/page.tsx`, `cheaper-alternatives-to/[slug]/page.tsx`

## Testing
- ✅ Typecheck passes
- ✅ Build passes
- ⬜ Live verification pending

Refs #207