### PR TITLE
fix: simplify API caching — use parallel queries and Cache-Control headers instead of per-request unstable_cache

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,108 +1,7 @@
 import { NextResponse } from 'next/server';
 import { pool } from '@/lib/db';
-import { cached, CACHE_TTL, CACHE_TAGS } from '@/lib/api-cache';
 
 export const dynamic = 'force-dynamic';
-
-// ─── Cached autocomplete ─────────────────────────────────────────────
-function getCachedAutocomplete(query: string, limit: number) {
-  return cached(
-    async (q: string, l: number) => {
-      const escapedQ = q.replace(/[%;_]/g, '\\$&');
-      const sqlQuery = `
-        SELECT y.id, y.model_name, y.slug, y.length_overall, y.year, m.name AS manufacturer_name
-        FROM yacht_models y
-        LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
-        WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1)
-        ORDER BY
-          CASE WHEN y.model_name ILIKE $2 THEN 0 WHEN m.name ILIKE $2 THEN 1 ELSE 2 END,
-          y.length_overall DESC NULLS LAST
-        LIMIT $3
-      `;
-      const result = await pool.query(sqlQuery, [`%${escapedQ}%`, `${escapedQ}%`, l]);
-      return result.rows.map((row: any) => ({
-        id: row.id,
-        modelName: row.model_name,
-        manufacturer: row.manufacturer_name ?? '',
-        slug: row.slug,
-        year: row.year,
-        lengthOverall: row.length_overall,
-        display: row.manufacturer_name ? `${row.manufacturer_name} ${row.model_name}` : row.model_name,
-      }));
-    },
-    [`search-autocomplete-${query}-${limit}`],
-    [CACHE_TAGS.SEARCH, CACHE_TAGS.YACHTS],
-    CACHE_TTL.SEARCH_AUTOCOMPLETE,
-  )(query, limit);
-}
-
-// ─── Cached full search ──────────────────────────────────────────────
-function getCachedSearch(query: string, limit: number) {
-  return cached(
-    async (q: string, l: number) => {
-      const escapedQ = q.replace(/[%;_]/g, '\\$&');
-      const like = `%${escapedQ}%`;
-      const prefixLike = `${escapedQ}%`;
-
-      const [countResult, dataResult] = await Promise.all([
-        pool.query(
-          `SELECT COUNT(*) as total FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
-           WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
-             OR y.rig_type ILIKE $1 OR y.keel_type ILIKE $1 OR y.hull_material ILIKE $1
-             OR y.design_notes ILIKE $1 OR y.description ILIKE $1)`,
-          [like],
-        ),
-        pool.query(
-          `SELECT y.id, y.model_name, y.manufacturer_id, y.year, y.slug, y.length_overall, y.beam, y.draft,
-             y.displacement, y.ballast, y.sail_area_main, y.rig_type, y.keel_type, y.hull_material,
-             y.cabins, y.berths, y.heads, y.max_occupancy, y.engine_hp, y.engine_type,
-             y.fuel_capacity, y.water_capacity, y.design_notes, y.description, m.name AS manufacturer_name
-           FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
-           WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
-             OR y.rig_type ILIKE $1 OR y.keel_type ILIKE $1 OR y.hull_material ILIKE $1
-             OR y.design_notes ILIKE $1 OR y.description ILIKE $1)
-           ORDER BY CASE WHEN y.model_name ILIKE $2 THEN 0 WHEN m.name ILIKE $2 THEN 1 ELSE 2 END,
-             y.length_overall DESC NULLS LAST
-           LIMIT $3`,
-          [like, prefixLike, l],
-        ),
-      ]);
-
-      const total = parseInt(countResult.rows[0]?.total || '0', 10);
-      const yachts = dataResult.rows.map((row: any) => ({
-        id: row.id,
-        manufacturer: row.manufacturer_name ?? '',
-        modelName: row.model_name,
-        year: row.year ?? undefined,
-        slug: row.slug ?? undefined,
-        lengthOverall: row.length_overall ?? undefined,
-        beam: row.beam ?? undefined,
-        draft: row.draft ?? undefined,
-        displacement: row.displacement ?? undefined,
-        ballast: row.ballast ?? undefined,
-        sailAreaMain: row.sail_area_main ?? undefined,
-        rigType: row.rig_type ?? undefined,
-        keelType: row.keel_type ?? undefined,
-        hullMaterial: row.hull_material ?? undefined,
-        cabins: row.cabins ?? undefined,
-        berths: row.berths ?? undefined,
-        heads: row.heads ?? undefined,
-        maxOccupancy: row.max_occupancy ?? undefined,
-        engineHp: row.engine_hp ?? undefined,
-        engineType: row.engine_type ?? undefined,
-        fuelCapacity: row.fuel_capacity ?? undefined,
-        waterCapacity: row.water_capacity ?? undefined,
-        designNotes: row.design_notes ?? undefined,
-        description: row.description ?? undefined,
-      }));
-
-      return { yachts, total };
-    },
-    [`search-full-${query}-${limit}`],
-    [CACHE_TAGS.SEARCH, CACHE_TAGS.YACHTS],
-    CACHE_TTL.SEARCH_AUTOCOMPLETE,
-  )(query, limit);
-}
 
 export async function GET(request: Request) {
   try {
@@ -115,11 +14,90 @@ export async function GET(request: Request) {
       return NextResponse.json({ yachts: [], total: 0 });
     }
 
-    const response = NextResponse.json(
-      mode === 'autocomplete'
-        ? { suggestions: await getCachedAutocomplete(q, limit), query: q }
-        : { ...(await getCachedSearch(q, limit)), query: q }
-    );
+    const escapedQ = q.replace(/[%;_]/g, '\\$&');
+    const like = `%${escapedQ}%`;
+    const prefixLike = `${escapedQ}%`;
+
+    if (mode === 'autocomplete') {
+      const result = await pool.query(
+        `SELECT y.id, y.model_name, y.slug, y.length_overall, y.year, m.name AS manufacturer_name
+         FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+         WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1)
+         ORDER BY CASE WHEN y.model_name ILIKE $2 THEN 0 WHEN m.name ILIKE $2 THEN 1 ELSE 2 END,
+           y.length_overall DESC NULLS LAST
+         LIMIT $3`,
+        [like, prefixLike, limit],
+      );
+
+      const suggestions = result.rows.map((row: any) => ({
+        id: row.id,
+        modelName: row.model_name,
+        manufacturer: row.manufacturer_name ?? '',
+        slug: row.slug,
+        year: row.year,
+        lengthOverall: row.length_overall,
+        display: row.manufacturer_name ? `${row.manufacturer_name} ${row.model_name}` : row.model_name,
+      }));
+
+      const response = NextResponse.json({ suggestions, query: q });
+      response.headers.set('Cache-Control', 'public, s-maxage=30, stale-while-revalidate=60');
+      return response;
+    }
+
+    // Full search — run count + data in parallel
+    const [countResult, dataResult] = await Promise.all([
+      pool.query(
+        `SELECT COUNT(*) as total FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+         WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
+           OR y.rig_type ILIKE $1 OR y.keel_type ILIKE $1 OR y.hull_material ILIKE $1
+           OR y.design_notes ILIKE $1 OR y.description ILIKE $1)`,
+        [like],
+      ),
+      pool.query(
+        `SELECT y.id, y.model_name, y.year, y.slug, y.length_overall, y.beam, y.draft,
+           y.displacement, y.ballast, y.sail_area_main, y.rig_type, y.keel_type, y.hull_material,
+           y.cabins, y.berths, y.heads, y.max_occupancy, y.engine_hp, y.engine_type,
+           y.fuel_capacity, y.water_capacity, y.design_notes, y.description, m.name AS manufacturer_name
+         FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+         WHERE (y.model_name ILIKE $1 OR m.name ILIKE $1 OR CONCAT(m.name, ' ', y.model_name) ILIKE $1
+           OR y.rig_type ILIKE $1 OR y.keel_type ILIKE $1 OR y.hull_material ILIKE $1
+           OR y.design_notes ILIKE $1 OR y.description ILIKE $1)
+         ORDER BY CASE WHEN y.model_name ILIKE $2 THEN 0 WHEN m.name ILIKE $2 THEN 1 ELSE 2 END,
+           y.length_overall DESC NULLS LAST
+         LIMIT $3`,
+        [like, prefixLike, limit],
+      ),
+    ]);
+
+    const total = parseInt(countResult.rows[0]?.total || '0', 10);
+    const yachts = dataResult.rows.map((row: any) => ({
+      id: row.id,
+      manufacturer: row.manufacturer_name ?? '',
+      modelName: row.model_name,
+      year: row.year ?? undefined,
+      slug: row.slug ?? undefined,
+      lengthOverall: row.length_overall ?? undefined,
+      beam: row.beam ?? undefined,
+      draft: row.draft ?? undefined,
+      displacement: row.displacement ?? undefined,
+      ballast: row.ballast ?? undefined,
+      sailAreaMain: row.sail_area_main ?? undefined,
+      rigType: row.rig_type ?? undefined,
+      keelType: row.keel_type ?? undefined,
+      hullMaterial: row.hull_material ?? undefined,
+      cabins: row.cabins ?? undefined,
+      berths: row.berths ?? undefined,
+      heads: row.heads ?? undefined,
+      maxOccupancy: row.max_occupancy ?? undefined,
+      engineHp: row.engine_hp ?? undefined,
+      engineType: row.engine_type ?? undefined,
+      fuelCapacity: row.fuel_capacity ?? undefined,
+      waterCapacity: row.water_capacity ?? undefined,
+      designNotes: row.design_notes ?? undefined,
+      description: row.description ?? undefined,
+    }));
+
+    const response = NextResponse.json({ yachts, total, query: q });
     response.headers.set('Cache-Control', 'public, s-maxage=30, stale-while-revalidate=60');
     return response;
   } catch (error: any) {

--- a/app/api/yachts/route.ts
+++ b/app/api/yachts/route.ts
@@ -25,44 +25,6 @@ const getCachedFilterOptions = cached(
   CACHE_TTL.FILTER_OPTIONS,
 );
 
-// ─── Cached: yacht list query ────────────────────────────────────────
-function getCachedYachts(
-  whereClause: string,
-  params: any[],
-  safeSort: string,
-  sortOrder: string,
-  limit: number,
-  offset: number,
-  fields: string,
-  cacheKey: string,
-) {
-  return cached(
-    async (
-      _where: string,
-      _params: any[],
-      _sort: string,
-      _order: string,
-      _limit: number,
-      _offset: number,
-      _fields: string,
-    ) => {
-      const [countResult, dataResult] = await Promise.all([
-        pool.query(`SELECT COUNT(*)::int as count FROM yacht_models y ${_where}`, _params),
-        pool.query(
-          `SELECT ${_fields} FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id ${_where} ORDER BY y.${_sort} ${_order} LIMIT $${_params.length + 1} OFFSET $${_params.length + 2}`,
-          [..._params, _limit, _offset],
-        ),
-      ]);
-
-      const total = countResult.rows[0]?.count || 0;
-      return { rows: dataResult.rows, total };
-    },
-    [cacheKey],
-    [CACHE_TAGS.YACHTS],
-    CACHE_TTL.YACHT_LIST,
-  )(whereClause, params, safeSort, sortOrder, limit, offset, fields);
-}
-
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -132,19 +94,20 @@ export async function GET(request: Request) {
     const offset = (page - 1) * limit;
     const fields = view === 'list' ? LIST_FIELDS : ALL_FIELDS;
 
-    // Generate deterministic cache key from all inputs
-    const cacheKey = `yachts-${whereClause}-${params.join(',')}-${safeSort}-${sortOrder}-${limit}-${offset}-${view}`;
-
-    // Run data query + filter options in parallel (both cached)
-    const [dataResult, distinct] = await Promise.all([
-      getCachedYachts(whereClause, params, safeSort, sortOrder, limit, offset, fields, cacheKey),
+    // Run count + data + filter options in parallel
+    const [countResult, dataResult, distinct] = await Promise.all([
+      pool.query(`SELECT COUNT(*)::int as count FROM yacht_models y ${whereClause}`, params),
+      pool.query(
+        `SELECT ${fields} FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id ${whereClause} ORDER BY y.${safeSort} ${sortOrder} LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+        [...params, limit, offset],
+      ),
       getCachedFilterOptions(),
     ]);
 
-    const { rows, total } = dataResult;
+    const total = countResult.rows[0]?.count || 0;
 
     // Map results — use lighter mapping for list view
-    const yachts = rows.map((row: any) => view === 'list' ? {
+    const yachts = dataResult.rows.map((row: any) => view === 'list' ? {
       id: row.id,
       manufacturer: row.manufacturer_name ?? '',
       modelName: row.model_name,
@@ -190,7 +153,6 @@ export async function GET(request: Request) {
       updatedAt: row.updated_at ?? undefined,
     });
 
-    // Set cache headers for CDN/Vercel edge
     const response = NextResponse.json({
       yachts,
       total,

--- a/tests/api-performance.test.ts
+++ b/tests/api-performance.test.ts
@@ -12,7 +12,6 @@ vi.mock('@/lib/db', () => ({
   pool: { query: (...args: any[]) => mockQuery(...args) },
 }));
 
-// Import after mocks
 import { GET as yachtsGET } from '../app/api/yachts/route';
 import { GET as searchGET } from '../app/api/search/route';
 
@@ -27,27 +26,27 @@ describe('Yachts API - Performance optimizations', () => {
 
   it('should return list view with fewer fields', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [{ count: 1 }] })
-      .mockResolvedValueOnce({
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] })       // count
+      .mockResolvedValueOnce({                                 // data (list fields only)
         rows: [{
-          id: 1,
-          model_name: 'Test',
-          slug: 'test',
-          manufacturer_name: 'Mfg',
-          length_overall: 10,
+          id: 1, model_name: 'Test', slug: 'test', manufacturer_name: 'Mfg',
+          length_overall: 10, beam: 3, draft: 1.5, displacement: 5000,
+          rig_type: 'Sloop', keel_type: 'Fin', hull_material: 'FG', cabins: 2,
+          year: 2024,
         }],
       })
-      .mockResolvedValueOnce({ rows: [{ rig_type: 'Sloop', keel_type: null, hull_material: 'FG' }] });
+      .mockResolvedValueOnce({ rows: [{ rig_type: 'Sloop', keel_type: null, hull_material: 'FG' }] }); // distinct
 
     const res = await yachtsGET(createRequest('/api/yachts?view=list'));
     const data = await res.json();
 
     expect(data.yachts).toHaveLength(1);
-    expect(data.yachts[0]).toHaveProperty('modelName');
-    // list view should not include description, designNotes, etc.
-    expect(data.yachts[0]).not.toHaveProperty('description');
-    expect(data.yachts[0]).not.toHaveProperty('designNotes');
-    expect(data.yachts[0]).not.toHaveProperty('fuelCapacity');
+    const yacht = data.yachts[0];
+    expect(yacht).toHaveProperty('modelName');
+    expect(yacht).not.toHaveProperty('description');
+    expect(yacht).not.toHaveProperty('designNotes');
+    expect(yacht).not.toHaveProperty('fuelCapacity');
+    expect(yacht).not.toHaveProperty('adminLinks');
   });
 
   it('should include Cache-Control header', async () => {
@@ -60,7 +59,7 @@ describe('Yachts API - Performance optimizations', () => {
     expect(res.headers.get('Cache-Control')).toContain('s-maxage');
   });
 
-  it('should run count and data queries in parallel with filter options', async () => {
+  it('should run count, data, and distinct queries in parallel', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ count: 5 }] })
       .mockResolvedValueOnce({ rows: [{ id: 1, model_name: 'A', slug: 'a', manufacturer_name: 'M' }] })
@@ -72,6 +71,7 @@ describe('Yachts API - Performance optimizations', () => {
     expect(data.total).toBe(5);
     expect(data.distinct.rigTypes).toEqual(['Sloop']);
     expect(data.distinct.keelTypes).toEqual(['Fin']);
+    expect(mockQuery).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -85,6 +85,7 @@ describe('Search API - Performance optimizations', () => {
     const data = await res.json();
     expect(data.yachts).toEqual([]);
     expect(data.total).toBe(0);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it('should include Cache-Control header', async () => {
@@ -96,7 +97,7 @@ describe('Search API - Performance optimizations', () => {
     expect(res.headers.get('Cache-Control')).toContain('s-maxage');
   });
 
-  it('autocomplete mode returns suggestions', async () => {
+  it('autocomplete mode returns suggestions with single query', async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 1, model_name: 'TestYacht', slug: 'testyacht', manufacturer_name: 'Acme', year: 2024, length_overall: 12 }],
     });
@@ -105,5 +106,22 @@ describe('Search API - Performance optimizations', () => {
     const data = await res.json();
     expect(data.suggestions).toHaveLength(1);
     expect(data.suggestions[0].display).toBe('Acme TestYacht');
+    // autocomplete should only make 1 query, not 2
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('full search runs count and data queries in parallel', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '2' }] })
+      .mockResolvedValueOnce({ rows: [
+        { id: 1, model_name: 'A', slug: 'a', manufacturer_name: 'M' },
+        { id: 2, model_name: 'B', slug: 'b', manufacturer_name: 'N' },
+      ]});
+
+    const res = await searchGET(createRequest('/api/search?q=test'));
+    const data = await res.json();
+    expect(data.total).toBe(2);
+    expect(data.yachts).toHaveLength(2);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
- Remove unstable_cache wrapper from yachts/search APIs (not effective per-request)
- Keep module-level cached filter options (works correctly)
- Run count + data + distinct queries in parallel via Promise.all
- Add Cache-Control headers for CDN/Vercel edge caching
- Keep view=list field selection for lighter payloads
- 7 unit tests (up from 6)
