### PR TITLE
feat(a11y): form accessibility & error handling (closes #220)

### DIFF
--- a/app/(main)/compare/CompareClient.tsx
+++ b/app/(main)/compare/CompareClient.tsx
@@ -615,6 +615,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
               <input
                 type="text"
                 placeholder="Search by manufacturer or model..."
+                aria-label="Search yachts to add to comparison"
                 value={search}
                 onChange={e => setSearch(e.target.value)}
                 className="w-full pl-9 pr-4 py-2 rounded-lg border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"

--- a/app/(main)/search/SearchClient.tsx
+++ b/app/(main)/search/SearchClient.tsx
@@ -237,6 +237,7 @@ export function SearchClient() {
                 if (suggestions.length > 0) setShowSuggestions(true);
               }}
               placeholder="Search by manufacturer, model name, rig type..."
+              aria-label="Search yachts"
               className="w-full pl-12 pr-4 py-3 border border-border rounded-lg bg-white text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-base"
               autoComplete="off"
             />
@@ -251,6 +252,8 @@ export function SearchClient() {
               <div
                 ref={suggestionsRef}
                 className="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-lg shadow-lg z-50 overflow-hidden"
+                role="listbox"
+                aria-label="Search suggestions"
               >
                 {suggestions.map((s, i) => (
                   <button
@@ -293,7 +296,7 @@ export function SearchClient() {
 
       {/* Search Results */}
       {searched && (
-        <div>
+        <div role="region" aria-live="polite" aria-label="Search results">
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-muted-foreground">
               {loading
@@ -327,7 +330,7 @@ export function SearchClient() {
           )}
 
           {!loading && results.length === 0 && (
-            <div className="text-center py-12">
+            <div className="text-center py-12" role="status">
               <div className="text-4xl mb-4">⛵</div>
               <h2 className="text-xl font-semibold text-foreground mb-2">
                 No yachts found

--- a/app/(main)/yachts/YachtsClient.tsx
+++ b/app/(main)/yachts/YachtsClient.tsx
@@ -419,14 +419,14 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
 
           {/* Main */}
           <main className="flex-1 min-w-0">
-            {loading && yachts.length === 0 ? (<p className="p-8 text-center text-gray-500">Loading yachts...</p>) : yachts.length === 0 ? (
+            {loading && yachts.length === 0 ? (<p className="p-8 text-center text-gray-500" role="status" aria-live="polite">Loading yachts...</p>) : yachts.length === 0 ? (
               <div className="text-center py-12">
                 <p className="text-gray-500 mb-2">No yachts match your filters.</p>
                 <button onClick={clearFilters} className="text-blue-600 hover:underline text-sm">Clear all filters</button>
               </div>
             ) : (
               <>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6" role="region" aria-label="Yacht listings" aria-live="polite">
                   {yachts.map(yacht => (
                     <div key={yacht.id} className="border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow relative">
                       <div className="flex items-start justify-between gap-2">

--- a/app/components/LeadForm.tsx
+++ b/app/components/LeadForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
 import { Button } from "@/components/ui/button";
 
 interface LeadFormProps {
@@ -47,6 +47,11 @@ export function LeadForm({ yachtIds, leadType, yachtName, className = "" }: Lead
   const [showForm, setShowForm] = useState(false);
 
   const config = FORM_CONFIG[leadType];
+  const nameId = useId();
+  const emailId = useId();
+  const phoneId = useId();
+  const messageId = useId();
+  const errorId = useId();
 
   useEffect(() => {
     // Capture UTM params from URL
@@ -105,7 +110,7 @@ export function LeadForm({ yachtIds, leadType, yachtName, className = "" }: Lead
 
   if (result?.success) {
     return (
-      <div className={`rounded-lg border border-green-200 bg-green-50 p-4 ${className}`}>
+      <div className={`rounded-lg border border-green-200 bg-green-50 p-4 ${className}`} role="status" aria-live="polite">
         <p className="text-green-800 font-medium">✓ {result.message}</p>
       </div>
     );
@@ -118,50 +123,71 @@ export function LeadForm({ yachtIds, leadType, yachtName, className = "" }: Lead
           variant="outline"
           onClick={() => setShowForm(true)}
           className="w-full"
+          aria-expanded={showForm}
         >
           <span className="mr-2">{config.icon}</span>
           {config.title}
         </Button>
       ) : (
-        <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border p-4 bg-gray-50">
+        <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border p-4 bg-gray-50" aria-label={`${config.title} form`}>
           <h4 className="font-semibold text-sm">
             {config.icon} {config.title}
             {yachtName && <span className="font-normal text-gray-500 ml-1">— {yachtName}</span>}
           </h4>
 
-          <input
-            type="text"
-            placeholder="Your name *"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            className="w-full rounded border px-3 py-2 text-sm"
-          />
-          <input
-            type="email"
-            placeholder="Email *"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full rounded border px-3 py-2 text-sm"
-          />
-          <input
-            type="tel"
-            placeholder="Phone (optional)"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-            className="w-full rounded border px-3 py-2 text-sm"
-          />
-          <textarea
-            placeholder={config.placeholder}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            rows={3}
-            className="w-full rounded border px-3 py-2 text-sm"
-          />
+          <div>
+            <label htmlFor={nameId} className="sr-only">Your name (required)</label>
+            <input
+              id={nameId}
+              type="text"
+              placeholder="Your name *"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              aria-describedby={result && !result.success ? errorId : undefined}
+              className="w-full rounded border px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor={emailId} className="sr-only">Email address (required)</label>
+            <input
+              id={emailId}
+              type="email"
+              placeholder="Email *"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              aria-describedby={result && !result.success ? errorId : undefined}
+              className="w-full rounded border px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor={phoneId} className="sr-only">Phone number (optional)</label>
+            <input
+              id={phoneId}
+              type="tel"
+              placeholder="Phone (optional)"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="w-full rounded border px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor={messageId} className="sr-only">Your message</label>
+            <textarea
+              id={messageId}
+              placeholder={config.placeholder}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={3}
+              className="w-full rounded border px-3 py-2 text-sm"
+            />
+          </div>
 
           {result && !result.success && (
-            <p className="text-red-600 text-sm">{result.message}</p>
+            <p id={errorId} className="text-red-600 text-sm" role="alert" aria-live="assertive">
+              {result.message}
+            </p>
           )}
 
           <div className="flex gap-2">

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface NewsletterSignupProps {
   source?: string;
@@ -18,6 +18,8 @@ export default function NewsletterSignup({
     "idle" | "loading" | "success" | "error"
   >("idle");
   const [message, setMessage] = useState("");
+  const inputId = useId();
+  const errorId = useId();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -56,6 +58,8 @@ export default function NewsletterSignup({
     return (
       <div
         className={`text-center ${compact ? "py-3" : "py-6"} ${className}`}
+        role="status"
+        aria-live="polite"
       >
         <div className="text-2xl mb-2">⚓</div>
         <p className="text-green-700 font-medium">{message}</p>
@@ -67,7 +71,7 @@ export default function NewsletterSignup({
     <div className={`${className}`}>
       {!compact && (
         <>
-          <h3 className="text-xl font-bold text-gray-900 mb-2">
+          <h3 className="text-xl font-bold text-gray-900 mb-2" id={`${inputId}-title`}>
             Stay Updated
           </h3>
           <p className="text-gray-600 text-sm mb-4">
@@ -75,8 +79,13 @@ export default function NewsletterSignup({
           </p>
         </>
       )}
-      <form onSubmit={handleSubmit} className="flex gap-2">
+      <form onSubmit={handleSubmit} className="flex gap-2" aria-label="Newsletter signup">
+        {/* Screen-reader-only label */}
+        <label htmlFor={inputId} className="sr-only">
+          Email address
+        </label>
         <input
+          id={inputId}
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
@@ -84,6 +93,8 @@ export default function NewsletterSignup({
             compact ? "Your email for updates" : "Enter your email address"
           }
           required
+          aria-describedby={status === "error" ? errorId : undefined}
+          aria-invalid={status === "error"}
           className={`flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition ${
             compact ? "text-sm" : ""
           }`}
@@ -100,7 +111,9 @@ export default function NewsletterSignup({
         </button>
       </form>
       {status === "error" && (
-        <p className="text-red-600 text-sm mt-2">{message}</p>
+        <p id={errorId} className="text-red-600 text-sm mt-2" role="alert" aria-live="assertive">
+          {message}
+        </p>
       )}
     </div>
   );

--- a/tests/form-accessibility.test.ts
+++ b/tests/form-accessibility.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+
+/**
+ * P13.4 — Form accessibility & error handling tests
+ *
+ * These tests verify:
+ * 1. Newsletter signup: label, aria-describedby for errors, aria-live regions
+ * 2. LeadForm: labels for all inputs, error announcements, aria-label on form
+ * 3. Search input: aria-label, role=listbox on autocomplete, aria-live on results
+ * 4. Compare picker: aria-label on search input, Escape handler
+ * 5. Yachts listing: aria-live on results, role=region on results
+ */
+describe("P13.4: Form accessibility & error handling", () => {
+  // ── NewsletterSignup ──
+  describe("NewsletterSignup", () => {
+    const component = fs.readFileSync(
+      path.join(PROJECT_ROOT, "components/NewsletterSignup.tsx"),
+      "utf-8",
+    );
+
+    it("has a label for the email input", () => {
+      expect(component).toContain("<label");
+      expect(component).toContain("Email address");
+    });
+
+    it("uses sr-only label for compact design", () => {
+      expect(component).toContain("sr-only");
+    });
+
+    it("has aria-label on the form", () => {
+      expect(component).toContain('aria-label="Newsletter signup"');
+    });
+
+    it("links error to input via aria-describedby", () => {
+      expect(component).toContain("aria-describedby");
+      expect(component).toContain("errorId");
+    });
+
+    it("marks input as aria-invalid on error", () => {
+      expect(component).toContain("aria-invalid");
+    });
+
+    it("error message uses role=alert", () => {
+      expect(component).toContain('role="alert"');
+    });
+
+    it("error message uses aria-live=assertive", () => {
+      expect(component).toContain('aria-live="assertive"');
+    });
+
+    it("success message uses role=status", () => {
+      expect(component).toContain('role="status"');
+    });
+
+    it("success message uses aria-live=polite", () => {
+      expect(component).toContain('aria-live="polite"');
+    });
+
+    it("uses useId() for unique IDs", () => {
+      expect(component).toContain("useId");
+    });
+  });
+
+  // ── LeadForm ──
+  describe("LeadForm", () => {
+    const component = fs.readFileSync(
+      path.join(PROJECT_ROOT, "app/components/LeadForm.tsx"),
+      "utf-8",
+    );
+
+    it("has labels for name input", () => {
+      expect(component).toContain("<label");
+      expect(component).toContain("Your name");
+    });
+
+    it("has labels for email input", () => {
+      expect(component).toContain("Email address");
+    });
+
+    it("has labels for phone input", () => {
+      expect(component).toContain("Phone number");
+    });
+
+    it("has labels for message textarea", () => {
+      expect(component).toContain("Your message");
+    });
+
+    it("all labels use sr-only class", () => {
+      const labelMatches = component.match(/<label[^>]*>/g);
+      expect(labelMatches).toBeTruthy();
+      for (const label of labelMatches!) {
+        expect(label).toContain("sr-only");
+      }
+    });
+
+    it("has aria-label on the form", () => {
+      expect(component).toContain("aria-label=");
+      expect(component).toContain("form");
+    });
+
+    it("links inputs to error via aria-describedby", () => {
+      expect(component).toContain("aria-describedby");
+      expect(component).toContain("errorId");
+    });
+
+    it("error message uses role=alert", () => {
+      expect(component).toContain('role="alert"');
+    });
+
+    it("success message uses role=status with aria-live", () => {
+      expect(component).toContain('role="status"');
+      expect(component).toContain('aria-live="polite"');
+    });
+
+    it("trigger button has aria-expanded", () => {
+      expect(component).toContain("aria-expanded");
+    });
+
+    it("uses useId() for unique IDs", () => {
+      expect(component).toContain("useId");
+    });
+  });
+
+  // ── SearchClient ──
+  describe("SearchClient", () => {
+    const component = fs.readFileSync(
+      path.join(PROJECT_ROOT, "app/(main)/search/SearchClient.tsx"),
+      "utf-8",
+    );
+
+    it("search input has aria-label", () => {
+      expect(component).toContain('aria-label="Search yachts"');
+    });
+
+    it("autocomplete suggestions have role=listbox", () => {
+      expect(component).toContain('role="listbox"');
+    });
+
+    it("autocomplete suggestions have aria-label", () => {
+      expect(component).toContain('aria-label="Search suggestions"');
+    });
+
+    it("results region has aria-live", () => {
+      expect(component).toContain('aria-live="polite"');
+    });
+
+    it("results region has aria-label", () => {
+      expect(component).toContain('aria-label="Search results"');
+    });
+
+    it("no-results has role=status", () => {
+      expect(component).toContain('role="status"');
+    });
+  });
+
+  // ── CompareClient ──
+  describe("CompareClient picker search", () => {
+    const component = fs.readFileSync(
+      path.join(PROJECT_ROOT, "app/(main)/compare/CompareClient.tsx"),
+      "utf-8",
+    );
+
+    it("picker search input has aria-label", () => {
+      expect(component).toContain('aria-label="Search yachts to add to comparison"');
+    });
+
+    it("has Escape key handler for picker", () => {
+      expect(component).toContain("Escape");
+      expect(component).toContain("setPickerOpen(false)");
+    });
+  });
+
+  // ── YachtsClient ──
+  describe("YachtsClient results accessibility", () => {
+    const component = fs.readFileSync(
+      path.join(PROJECT_ROOT, "app/(main)/yachts/YachtsClient.tsx"),
+      "utf-8",
+    );
+
+    it("results grid has role=region", () => {
+      expect(component).toContain('role="region"');
+    });
+
+    it("results grid has aria-live", () => {
+      expect(component).toContain('aria-live="polite"');
+    });
+
+    it("results grid has aria-label", () => {
+      expect(component).toContain('aria-label="Yacht listings"');
+    });
+
+    it("loading state has role=status", () => {
+      expect(component).toContain('role="status"');
+    });
+  });
+});


### PR DESCRIPTION
P13.4: Add proper labels, aria-describedby for errors, live regions for
dynamic content updates, and accessible form validation.

- NewsletterSignup: sr-only label, aria-describedby for errors, aria-invalid,
  role=alert on errors, role=status + aria-live=polite on success
- LeadForm: sr-only labels on all inputs (name, email, phone, textarea),
  aria-label on form, aria-describedby linking to error message, role=alert
  on errors, role=status on success, aria-expanded on trigger button
- SearchClient: aria-label on search input, role=listbox + aria-label on
  autocomplete suggestions, role=region + aria-live=polite + aria-label on
  results container, role=status on no-results
- CompareClient: aria-label on picker search input
- YachtsClient: role=region + aria-live=polite + aria-label on results grid,
  role=status on loading state
- All IDs generated via useId() for uniqueness
- 33 unit tests covering all form accessibility patterns
