### PR TITLE
feat(a11y): image alt text & media accessibility (closes #222)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -26,8 +26,8 @@
 ### Phase 13 — Accessibility & Usability (Priority: High)
 - ~~**P13.1 — Accessibility audit & fixes:** Run automated accessibility checks (axe-core via Playwright), fix critical WCAG 2.1 AA violations across all public pages (contrast, missing labels, keyboard nav, focus management). Tests: 25 accessibility tests (23 pass, 2 skip).~~ *(completed 2026-04-24)*
 - ~~**P13.2 — Skip navigation & landmark structure:** Add skip-to-content link, proper ARIA landmarks (banner, main, contentinfo, navigation), and consistent heading hierarchy across all pages. Tests: 27 landmark and heading structure tests.~~ *(completed 2026-04-24)*
-- **P13.3 — Keyboard navigation enhancement:** Ensure all interactive elements (filters, compare selector, search, tabs) are fully keyboard-accessible with visible focus indicators. Tests: keyboard navigation E2E tests.
-- **P13.4 — Form accessibility & error handling:** Add proper labels, aria-describedby for errors, live regions for dynamic content updates, and accessible form validation across search, compare, and newsletter forms. Tests: form accessibility tests.
+- ~~**P13.3 — Keyboard navigation enhancement:** Ensure all interactive elements (filters, compare selector, search, tabs) are fully keyboard-accessible with visible focus indicators. Tests: keyboard navigation E2E tests.~~ *(completed 2026-04-25)*
+- ~~**P13.4 — Form accessibility & error handling:** Add proper labels, aria-describedby for errors, live regions for dynamic content updates, and accessible form validation across search, compare, and newsletter forms. Tests: form accessibility tests.~~ *(completed 2026-04-25)*
 - **P13.5 — Image alt text & media accessibility:** Audit all images for meaningful alt text, add aria-labels to icon-only buttons, ensure SVG icons have accessible names. Tests: media accessibility audit tests.
 - **P13.6 — Reduced motion & responsive accessibility:** Respect prefers-reduced-motion, ensure touch targets are 44px minimum, test with screen reader patterns. Tests: reduced-motion and responsive a11y tests.
 

--- a/app/(main)/MobileMenuKeyboard.tsx
+++ b/app/(main)/MobileMenuKeyboard.tsx
@@ -122,7 +122,7 @@ export function MobileMenuKeyboard() {
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={2}
-        >
+         aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
         {/* Close icon */}
@@ -132,7 +132,7 @@ export function MobileMenuKeyboard() {
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={2}
-        >
+         aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>

--- a/app/(main)/best-value/[slug]/page.tsx
+++ b/app/(main)/best-value/[slug]/page.tsx
@@ -453,7 +453,7 @@ export default async function BestValuePage({
                               viewBox="0 0 24 24"
                               stroke="currentColor"
                               strokeWidth={2}
-                            >
+                             aria-hidden="true">
                               <path
                                 strokeLinecap="round"
                                 strokeLinejoin="round"

--- a/app/(main)/cheaper-alternatives-to/[slug]/page.tsx
+++ b/app/(main)/cheaper-alternatives-to/[slug]/page.tsx
@@ -371,7 +371,7 @@ export default async function CheaperAlternativesPage({
                 viewBox="0 0 24 24"
                 stroke="currentColor"
                 strokeWidth={2}
-              >
+               aria-hidden="true">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"

--- a/app/(main)/compare/CompareClient.tsx
+++ b/app/(main)/compare/CompareClient.tsx
@@ -396,18 +396,18 @@ export function CompareClient({ initialIds }: CompareClientProps) {
             <button
               onClick={handleCopyLink}
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors"
-              title="Copy share link"
+              aria-label="Copy share link"
             >
               {copied ? (
                 <>
-                  <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                   <span className="text-green-600">Copied!</span>
                 </>
               ) : (
                 <>
-                  <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                   </svg>
                   <span>Share</span>
@@ -418,7 +418,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
               onClick={() => { setShowSaveInput(!showSaveInput); setSaveName(''); }}
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors"
             >
-              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
               </svg>
               <span>Save</span>
@@ -427,7 +427,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
               onClick={() => setSavedPanelOpen(!savedPanelOpen)}
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors relative"
             >
-              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
               </svg>
               <span>Saved</span>
@@ -468,7 +468,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
               onClick={() => { setShowSaveInput(false); setSaveName(''); }}
               className="px-3 py-2 text-gray-500 hover:text-gray-700 transition-colors"
             >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -485,7 +485,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
               onClick={() => setSavedPanelOpen(false)}
               className="text-gray-500 hover:text-gray-700 transition-colors"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -514,8 +514,9 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                     }}
                     className="text-gray-300 hover:text-blue-500 transition-colors p-1"
                     title="Copy share link"
+                    aria-label="Copy share link"
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                     </svg>
                   </button>
@@ -523,8 +524,9 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                     onClick={() => handleDelete(sc.id)}
                     className="text-gray-300 hover:text-red-500 transition-colors p-1"
                     title="Delete"
+                    aria-label="Delete saved comparison"
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
                   </button>
@@ -567,8 +569,9 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                       onClick={() => removeYacht(id)}
                       className="text-gray-500 hover:text-red-600 transition-colors p-1"
                       title="Remove"
+                      aria-label="Remove yacht from comparison"
                     >
-                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                       </svg>
                     </button>
@@ -578,7 +581,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                     onClick={() => setPickerOpen(true)}
                     className="w-full text-center py-3 text-gray-500 hover:text-blue-600 transition-colors"
                   >
-                    <svg className="w-6 h-6 mx-auto mb-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <svg className="w-6 h-6 mx-auto mb-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
                     </svg>
                     <span className="text-sm">Add yacht</span>
@@ -595,7 +598,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
             onClick={() => setPickerOpen(!pickerOpen)}
             className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
             </svg>
             {selectedIds.length === 0 ? 'Choose yachts to compare' : 'Add another yacht'}
@@ -609,7 +612,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
           {/* Search */}
           <div className="p-3 border-b border-gray-100 bg-gray-50">
             <div className="relative">
-              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
               </svg>
               <input
@@ -656,7 +659,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
                             : 'border border-gray-300'
                         }`}>
                           {isSelected && (
-                            <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                            <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3} aria-hidden="true">
                               <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                             </svg>
                           )}
@@ -696,7 +699,7 @@ export function CompareClient({ initialIds }: CompareClientProps) {
       {/* Prompt when nothing selected */}
       {selectedIds.length === 0 && !pickerOpen && (
         <div className="text-center py-16 text-gray-500">
-          <svg className="w-16 h-16 mx-auto mb-4 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+          <svg className="w-16 h-16 mx-auto mb-4 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1} aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
           </svg>
           <p className="text-lg font-medium text-gray-500">Select yachts to compare</p>

--- a/app/(main)/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/(main)/compare/[slugA]-vs-[slugB]/page.tsx
@@ -537,7 +537,7 @@ export default async function CanonicalComparePage({
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                     strokeWidth={2}
-                  >
+                   aria-hidden="true">
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
@@ -563,7 +563,7 @@ export default async function CanonicalComparePage({
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                     strokeWidth={2}
-                  >
+                   aria-hidden="true">
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/app/(main)/favorites/FavoritesClient.tsx
+++ b/app/(main)/favorites/FavoritesClient.tsx
@@ -185,7 +185,7 @@ export default function FavoritesClient() {
                       viewBox="0 0 24 24"
                       stroke="currentColor"
                       strokeWidth={2}
-                    >
+                     aria-hidden="true">
                       <path
                         strokeLinecap="round"
                         strokeLinejoin="round"

--- a/app/(main)/guides/[slug]/page.tsx
+++ b/app/(main)/guides/[slug]/page.tsx
@@ -292,7 +292,7 @@ export default async function GuideArticlePage({ params }: PageProps) {
 
           {/* Wave divider */}
           <div className="absolute bottom-0 left-0 right-0">
-            <svg viewBox="0 0 1440 60" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full block" preserveAspectRatio="none">
+            <svg viewBox="0 0 1440 60" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full block" preserveAspectRatio="none" aria-hidden="true">
               <path d="M0 60V30C240 0 480 0 720 30C960 60 1200 60 1440 30V60H0Z" fill="white"/>
             </svg>
           </div>

--- a/app/(main)/manufacturers/[slug]/ManufacturerComparisons.tsx
+++ b/app/(main)/manufacturers/[slug]/ManufacturerComparisons.tsx
@@ -33,7 +33,7 @@ export function ManufacturerComparisons({
   return (
     <section className="mt-10 sm:mt-12 bg-gradient-to-r from-amber-50 via-white to-orange-50 border border-amber-200 rounded-xl p-6">
       <div className="flex items-center gap-2 mb-4">
-        <Scale className="h-5 w-5 text-amber-700" />
+        <Scale className="h-5 w-5 text-amber-700"  aria-hidden="true" />
         <h2 className="text-lg sm:text-xl font-bold text-amber-900">
           Compare {manufacturerName} Yachts
         </h2>

--- a/app/(main)/search/SearchClient.tsx
+++ b/app/(main)/search/SearchClient.tsx
@@ -218,7 +218,7 @@ export function SearchClient() {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
-              >
+               aria-hidden="true">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -313,9 +313,9 @@ export function SearchClient() {
               <button
                 onClick={handleSaveSearch}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition-colors"
-                title="Save this search to your account"
+                aria-label="Save this search to your account"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
                 </svg>
                 {saveMessage || "Save Search"}

--- a/app/(main)/yachts/YachtsClient.tsx
+++ b/app/(main)/yachts/YachtsClient.tsx
@@ -362,7 +362,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
             aria-expanded={filtersOpen}
             aria-controls="filter-sidebar"
           >
-            <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
             </svg>
             Filters

--- a/app/(main)/yachts/[slug]/RelatedArticles.tsx
+++ b/app/(main)/yachts/[slug]/RelatedArticles.tsx
@@ -56,7 +56,7 @@ export function RelatedArticles(yacht: RelatedArticlesProps) {
     return (
       <div className="mt-10 sm:mt-12">
         <h2 className="text-lg sm:text-xl font-bold mb-4 flex items-center gap-2">
-          <ExternalLink className="h-5 w-5" />
+          <ExternalLink className="h-5 w-5"  aria-hidden="true" />
           Related Sailing Articles
         </h2>
         <div className="animate-pulse grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -79,7 +79,7 @@ export function RelatedArticles(yacht: RelatedArticlesProps) {
       data-testid="related-articles-section"
     >
       <h2 className="text-lg sm:text-xl font-bold mb-4 flex items-center gap-2">
-        <ExternalLink className="h-5 w-5" />
+        <ExternalLink className="h-5 w-5"  aria-hidden="true" />
         Related Sailing Articles
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -101,7 +101,7 @@ export function RelatedArticles(yacht: RelatedArticlesProps) {
                   {article.description}
                 </p>
               </div>
-              <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-blue-600 shrink-0 mt-0.5" />
+              <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-blue-600 shrink-0 mt-0.5"  aria-hidden="true" />
             </div>
             <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
               <span className="inline-block px-1.5 py-0.5 bg-muted rounded text-[10px] font-medium">

--- a/app/(main)/yachts/[slug]/RelatedGuides.tsx
+++ b/app/(main)/yachts/[slug]/RelatedGuides.tsx
@@ -49,7 +49,7 @@ export function RelatedGuides({
         data-testid="related-guides-section"
       >
         <div className="flex items-center gap-2 mb-4">
-          <BookOpen className="h-5 w-5 text-sky-700" />
+          <BookOpen className="h-5 w-5 text-sky-700"  aria-hidden="true" />
           <h2 className="text-lg sm:text-xl font-bold text-sky-900">
             Buying Guides & Resources
           </h2>
@@ -74,7 +74,7 @@ export function RelatedGuides({
         data-testid="related-guides-section"
       >
         <div className="flex items-center gap-2 mb-4">
-          <BookOpen className="h-5 w-5 text-sky-700" />
+          <BookOpen className="h-5 w-5 text-sky-700"  aria-hidden="true" />
           <h2 className="text-lg sm:text-xl font-bold text-sky-900">
             Buying Guides & Resources
           </h2>
@@ -87,7 +87,7 @@ export function RelatedGuides({
           className="inline-flex items-center gap-2 text-sm font-medium text-sky-700 hover:text-sky-900 transition"
         >
           Browse all guides
-          <ExternalLink className="h-4 w-4" />
+          <ExternalLink className="h-4 w-4"  aria-hidden="true" />
         </a>
       </section>
     );
@@ -99,7 +99,7 @@ export function RelatedGuides({
       data-testid="related-guides-section"
     >
       <div className="flex items-center gap-2 mb-4">
-        <BookOpen className="h-5 w-5 text-sky-700" />
+        <BookOpen className="h-5 w-5 text-sky-700"  aria-hidden="true" />
         <h2 className="text-lg sm:text-xl font-bold text-sky-900">
           Buying Guides & Resources
         </h2>
@@ -137,7 +137,7 @@ export function RelatedGuides({
                   )}
                 </div>
               </div>
-              <ExternalLink className="h-4 w-4 text-sky-600 flex-shrink-0" />
+              <ExternalLink className="h-4 w-4 text-sky-600 flex-shrink-0"  aria-hidden="true" />
             </div>
           </a>
         ))}

--- a/app/(main)/yachts/[slug]/RelatedManufacturers.tsx
+++ b/app/(main)/yachts/[slug]/RelatedManufacturers.tsx
@@ -119,7 +119,7 @@ export function RelatedManufacturers({
 
               <div className="mt-3 flex items-center text-xs text-primary font-medium">
                 View details
-                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" />
+                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
               </div>
             </div>
           </Link>

--- a/app/(main)/yachts/[slug]/SameSizeAlternatives.tsx
+++ b/app/(main)/yachts/[slug]/SameSizeAlternatives.tsx
@@ -139,7 +139,7 @@ export function SameSizeAlternatives({
 
               <div className="mt-3 flex items-center text-xs text-primary font-medium">
                 View details
-                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" />
+                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform"  aria-hidden="true" />
               </div>
             </div>
           </Link>

--- a/app/(main)/yachts/[slug]/SimilarYachts.tsx
+++ b/app/(main)/yachts/[slug]/SimilarYachts.tsx
@@ -92,7 +92,7 @@ export function SimilarYachts({ slug }: SimilarYachtsProps) {
                   fill
                   className="w-full h-full group-hover:scale-105 transition-transform duration-200"
                   sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                />
+                 aria-hidden="true" />
               </div>
             ) : (
               <div className="h-36 sm:h-40 bg-muted flex items-center justify-center text-muted-foreground text-sm">
@@ -140,7 +140,7 @@ export function SimilarYachts({ slug }: SimilarYachtsProps) {
 
               <div className="mt-2 flex items-center text-xs text-primary font-medium">
                 View details
-                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" />
+                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform"  aria-hidden="true" />
               </div>
             </div>
           </Link>

--- a/app/(main)/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/(main)/yachts/[slug]/YachtDetailClient.tsx
@@ -114,11 +114,11 @@ interface YachtData {
 }
 
 const GROUP_ICONS: Record<string, React.ReactNode> = {
-  dimensions: <Ruler className="h-5 w-5" />,
-  sailplan: <Wind className="h-5 w-5" />,
-  accommodation: <Home className="h-5 w-5" />,
-  technical: <Wrench className="h-5 w-5" />,
-  performance: <Star className="h-5 w-5" />,
+  dimensions: <Ruler className="h-5 w-5"  aria-hidden="true" />,
+  sailplan: <Wind className="h-5 w-5"  aria-hidden="true" />,
+  accommodation: <Home className="h-5 w-5"  aria-hidden="true" />,
+  technical: <Wrench className="h-5 w-5"  aria-hidden="true" />,
+  performance: <Star className="h-5 w-5"  aria-hidden="true" />,
   other: null,
 };
 
@@ -229,7 +229,7 @@ export default function YachtDetailClient() {
             </Link>
           </li>
           <li aria-hidden="true">
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-4 w-4"  aria-hidden="true" />
           </li>
           <li>
             <Link href="/yachts" className="hover:text-foreground transition-colors">
@@ -237,7 +237,7 @@ export default function YachtDetailClient() {
             </Link>
           </li>
           <li aria-hidden="true">
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-4 w-4"  aria-hidden="true" />
           </li>
           <li>
             <Link
@@ -248,7 +248,7 @@ export default function YachtDetailClient() {
             </Link>
           </li>
           <li aria-hidden="true">
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-4 w-4"  aria-hidden="true" />
           </li>
           <li aria-current="page" className="text-foreground font-medium">
             {yacht.modelName}
@@ -260,7 +260,7 @@ export default function YachtDetailClient() {
       <div className="mb-4 sm:mb-6 flex items-center justify-between">
         <Button asChild variant="ghost" size="sm" className="no-print">
           <Link href="/yachts">
-            <ChevronLeft className="h-4 w-4 mr-1" />
+            <ChevronLeft className="h-4 w-4 mr-1"  aria-hidden="true" />
             Back to Browse
           </Link>
         </Button>
@@ -270,7 +270,7 @@ export default function YachtDetailClient() {
           data-testid="print-spec-sheet-btn"
           type="button"
         >
-          <Printer className="h-4 w-4" />
+          <Printer className="h-4 w-4"  aria-hidden="true" />
           Print Spec Sheet
         </button>
       </div>
@@ -289,7 +289,7 @@ export default function YachtDetailClient() {
               className="w-full h-56 sm:h-72 md:h-80 rounded-lg"
               priority
               sizes="(max-width: 768px) 100vw, 50vw"
-            />
+             aria-hidden="true" />
           ) : (
             <div className="w-full h-56 sm:h-72 md:h-80 bg-muted rounded-lg flex items-center justify-center text-muted-foreground">
               No image available
@@ -302,11 +302,11 @@ export default function YachtDetailClient() {
               {yacht.manufacturer} {yacht.modelName} ({yacht.year})
             </h1>
             <div className="no-print">
-              <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel />
+              <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel  aria-hidden="true" />
             </div>
           </div>
           <div className="flex items-center gap-2 mb-2">
-            <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel />
+            <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel  aria-hidden="true" />
           </div>
           <p className="text-base sm:text-lg text-muted-foreground mb-4">
             A sailing yacht built by {yacht.manufacturer}.
@@ -358,10 +358,10 @@ export default function YachtDetailClient() {
           </div>
 
           {/* Price Range Estimate */}
-          <PriceTierDetail info={priceTierInfo} />
+          <PriceTierDetail info={priceTierInfo}  aria-hidden="true" />
 
           {/* Real price data from DB (P8.2) */}
-          <PriceInsightBlock yachtId={yacht.id} modelName={yacht.modelName} />
+          <PriceInsightBlock yachtId={yacht.id} modelName={yacht.modelName}  aria-hidden="true" />
 
           {/* Admin links */}
           {yacht.adminLinks && yacht.adminLinks.length > 0 && (
@@ -394,7 +394,7 @@ export default function YachtDetailClient() {
 
       {/* Media Gallery (P10.2) */}
       {yacht.mediaAssets && yacht.mediaAssets.length > 0 && (
-        <MediaGallery mediaAssets={yacht.mediaAssets} />
+        <MediaGallery mediaAssets={yacht.mediaAssets}  aria-hidden="true" />
       )}
 
       {/* Specs by Group */}
@@ -438,7 +438,7 @@ export default function YachtDetailClient() {
         sourceConfidence={yacht.sourceConfidence}
         lastVerifiedAt={yacht.lastVerifiedAt}
         completenessScore={yacht.completenessScore}
-      />
+       aria-hidden="true" />
 
       {/* User Correction (P10.7) */}
       <CorrectionForm
@@ -554,7 +554,7 @@ export default function YachtDetailClient() {
               reviews={yacht.reviews}
               overallRating={overallRating}
               ratingBreakdown={avgBreakdown}
-            />
+             aria-hidden="true" />
           </div>
         );
       })()}
@@ -582,7 +582,7 @@ export default function YachtDetailClient() {
                   </div>
                   {review.rating && (
                     <div className="flex items-center gap-1">
-                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400"  aria-hidden="true" />
                       <span>{parseFloat(String(review.rating)).toFixed(1)}</span>
                     </div>
                   )}
@@ -625,14 +625,14 @@ export default function YachtDetailClient() {
         <ReviewSubmissionForm
           yachtModelId={yacht.id}
           yachtName={`${yacht.manufacturer} ${yacht.modelName}`}
-        />
+         aria-hidden="true" />
       </div>
 
       {/* INTERNAL LINKING MODULES (P6.7) */}
 
       {/* 1. Compare with similar boats - already implemented as SimilarYachts */}
       <div className="similar-yachts-section no-print">
-        <SimilarYachts slug={slug} />
+        <SimilarYachts slug={slug}  aria-hidden="true" />
       </div>
 
       {/* 2. Same size alternatives - NEW */}
@@ -641,7 +641,7 @@ export default function YachtDetailClient() {
           <SameSizeAlternatives
             targetLength={yacht.lengthOverall}
             currentYachtId={yacht.id}
-          />
+           aria-hidden="true" />
         </div>
       )}
 
@@ -652,7 +652,7 @@ export default function YachtDetailClient() {
             manufacturerId={yacht.manufacturerId}
             manufacturerSlug={slugify(yacht.manufacturer)}
             currentYachtId={yacht.id}
-          />
+           aria-hidden="true" />
         </div>
       )}
 
@@ -685,7 +685,7 @@ export default function YachtDetailClient() {
           manufacturer={yacht.manufacturer}
           lengthOverall={yacht.lengthOverall}
           rigType={yacht.rigType}
-        />
+         aria-hidden="true" />
       </div>
 
       {/* Related Sailing Articles from sailboats.fr */}
@@ -698,18 +698,18 @@ export default function YachtDetailClient() {
           hullMaterial={yacht.hullMaterial}
           cabins={yacht.cabins}
           displacement={yacht.displacement}
-        />
+         aria-hidden="true" />
       </div>
 
       {/* Lead Forms */}
       <div className="lead-forms-section mt-8 grid grid-cols-1 md:grid-cols-2 gap-4 no-print">
-        <LeadForm yachtIds={[yacht.id]} leadType="dealer_inquiry" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} />
-        <LeadForm yachtIds={[yacht.id]} leadType="price_request" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} />
+        <LeadForm yachtIds={[yacht.id]} leadType="dealer_inquiry" yachtName={`${yacht.manufacturer} ${yacht.modelName}`}  aria-hidden="true" />
+        <LeadForm yachtIds={[yacht.id]} leadType="price_request" yachtName={`${yacht.manufacturer} ${yacht.modelName}`}  aria-hidden="true" />
       </div>
 
       {/* Affiliate Recommendations */}
       <div className="affiliate-recommendations-section no-print">
-        <AffiliateRecommendations categories={affiliateRecommendations} />
+        <AffiliateRecommendations categories={affiliateRecommendations}  aria-hidden="true" />
       </div>
 
       {/* Compare Button */}

--- a/app/components/AffiliateRecommendations.tsx
+++ b/app/components/AffiliateRecommendations.tsx
@@ -21,7 +21,7 @@ export default function AffiliateRecommendations({ categories }: AffiliateRecomm
     <section className="affiliate-recommendations mt-10 sm:mt-12 no-print">
       <div className="bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-200 rounded-xl p-6 sm:p-8">
         <div className="flex items-center gap-2 mb-6">
-          <ShoppingBag className="h-6 w-6 text-blue-700" />
+          <ShoppingBag className="h-6 w-6 text-blue-700"  aria-hidden="true" />
           <h2 className="text-xl sm:text-2xl font-bold text-blue-900">
             Recommended Gear & Equipment
           </h2>
@@ -34,7 +34,7 @@ export default function AffiliateRecommendations({ categories }: AffiliateRecomm
             className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors"
             type="button"
           >
-            <Info className="h-3 w-3" />
+            <Info className="h-3 w-3"  aria-hidden="true" />
             {showDisclosure ? "Hide" : "Show"} affiliate disclosure
           </button>
           {showDisclosure && (
@@ -76,7 +76,7 @@ export default function AffiliateRecommendations({ categories }: AffiliateRecomm
                       <h4 className="font-semibold text-gray-900 group-hover:text-blue-700 transition-colors text-sm sm:text-base">
                         {product.name}
                       </h4>
-                      <ExternalLink className="h-4 w-4 text-gray-500 group-hover:text-blue-600 flex-shrink-0 ml-2" />
+                      <ExternalLink className="h-4 w-4 text-gray-500 group-hover:text-blue-600 flex-shrink-0 ml-2"  aria-hidden="true" />
                     </div>
 
                     <p className="text-xs sm:text-sm text-gray-600 mb-2">

--- a/app/components/BuyerChecklist.tsx
+++ b/app/components/BuyerChecklist.tsx
@@ -91,9 +91,9 @@ export function BuyerChecklist({ yachtIds, yachtNames }: BuyerChecklistProps) {
         <button
           onClick={handlePrint}
           className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white hover:bg-gray-50 transition-colors print:hidden"
-          title="Print checklist"
+          aria-label="Print checklist"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
           </svg>
           Print

--- a/app/components/CompareExport.tsx
+++ b/app/components/CompareExport.tsx
@@ -99,7 +99,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
               className="w-4 h-4 animate-spin"
               fill="none"
               viewBox="0 0 24 24"
-            >
+             aria-hidden="true">
               <circle
                 className="opacity-25"
                 cx="12"
@@ -124,7 +124,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={2}
-            >
+             aria-hidden="true">
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -138,7 +138,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={2}
-            >
+             aria-hidden="true">
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -175,7 +175,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
                 viewBox="0 0 24 24"
                 stroke="currentColor"
                 strokeWidth={1.5}
-              >
+               aria-hidden="true">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -198,7 +198,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
                 viewBox="0 0 24 24"
                 stroke="currentColor"
                 strokeWidth={1.5}
-              >
+               aria-hidden="true">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -226,7 +226,7 @@ export function CompareExport({ yachtIds, yachtNames }: CompareExportProps) {
                   viewBox="0 0 24 24"
                   stroke="currentColor"
                   strokeWidth={2}
-                >
+                 aria-hidden="true">
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"

--- a/app/components/CompareMonetization.tsx
+++ b/app/components/CompareMonetization.tsx
@@ -151,7 +151,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
             onClick={() => { setShowInquiryModal(true); trackInquiryModalOpen({ yachtIds: yachts.map(y => y.id), source: "broker_cta_banner" }); }}
             className="inline-flex items-center gap-2 px-5 py-2.5 bg-white text-blue-600 rounded-lg font-medium hover:bg-blue-50 transition-colors"
           >
-            <Mail className="w-4 h-4" />
+            <Mail className="w-4 h-4"  aria-hidden="true" />
             Talk to a Broker
           </button>
         </div>
@@ -170,7 +170,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
         >
           <div className="flex items-center gap-3 mb-3">
             <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center">
-              <svg className="w-5 h-5 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-5 h-5 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
               </svg>
             </div>
@@ -193,7 +193,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
         >
           <div className="flex items-center gap-3 mb-3">
             <div className="w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center">
-              <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
               </svg>
@@ -217,7 +217,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
         >
           <div className="flex items-center gap-3 mb-3">
             <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center">
-              <svg className="w-5 h-5 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg className="w-5 h-5 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
               </svg>
             </div>
@@ -242,7 +242,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
             }`}
           >
             <span className="inline-flex items-center gap-1.5">
-              <ShoppingBag className="w-4 h-4" />
+              <ShoppingBag className="w-4 h-4"  aria-hidden="true" />
               Recommended Gear
             </span>
           </button>
@@ -255,7 +255,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
             }`}
           >
             <span className="inline-flex items-center gap-1.5">
-              <Phone className="w-4 h-4" />
+              <Phone className="w-4 h-4"  aria-hidden="true" />
               Request Info
             </span>
           </button>
@@ -264,7 +264,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
 
       {/* Affiliate Recommendations Tab */}
       {activeTab === "affiliate" && (
-        <AffiliateRecommendations categories={uniqueAffiliateCategories} />
+        <AffiliateRecommendations categories={uniqueAffiliateCategories}  aria-hidden="true" />
       )}
 
       {/* Inquiry Modal */}
@@ -282,7 +282,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
                 }}
                 className="text-gray-500 hover:text-gray-700 transition-colors"
               >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
@@ -293,7 +293,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
               {inquirySubmitted ? (
                 <div className="text-center py-8">
                   <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4">
-                    <CheckCircle2 className="w-8 h-8 text-green-600" />
+                    <CheckCircle2 className="w-8 h-8 text-green-600"  aria-hidden="true" />
                   </div>
                   <h3 className="text-lg font-semibold text-gray-900 mb-2">Inquiry Submitted</h3>
                   <p className="text-gray-600 mb-4">
@@ -387,7 +387,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
                     )}
 
                     <div className="flex items-start gap-2 text-xs text-gray-500">
-                      <Info className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                      <Info className="w-4 h-4 flex-shrink-0 mt-0.5"  aria-hidden="true" />
                       <p>
                         Your inquiry will be routed to partner brokers and dealers. We may share your contact
                         information with relevant brokers to help you find the right yacht.
@@ -412,7 +412,7 @@ export function CompareMonetization({ yachts }: CompareMonetizationProps) {
                       >
                         {inquiryLoading ? (
                           <span className="inline-flex items-center gap-1.5">
-                            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                             </svg>

--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -55,7 +55,7 @@ export function FavoriteButton({
         viewBox="0 0 24 24"
         stroke="currentColor"
         strokeWidth={2}
-      >
+       aria-hidden="true">
         <path
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/app/components/PriceInsightBlock.tsx
+++ b/app/components/PriceInsightBlock.tsx
@@ -88,7 +88,7 @@ function PriceUnavailableFallback({ status }: { status: "contact" | "unavailable
     return (
       <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center" data-testid="price-contact">
         <div className="flex items-center justify-center gap-2 text-gray-600">
-          <PhoneIcon />
+          <PhoneIcon  aria-hidden="true" />
           <span className="font-medium">Contact for price</span>
         </div>
         <p className="mt-1 text-xs text-gray-500">Pricing available upon request from dealers</p>
@@ -99,7 +99,7 @@ function PriceUnavailableFallback({ status }: { status: "contact" | "unavailable
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center" data-testid="price-unavailable">
       <div className="flex items-center justify-center gap-2 text-gray-500">
-        <DashIcon />
+        <DashIcon  aria-hidden="true" />
         <span className="font-medium">Price not available</span>
       </div>
       <p className="mt-1 text-xs text-gray-500">No pricing data found for this model</p>
@@ -204,7 +204,7 @@ function PriceRow({
       <div>
         <span className="text-sm font-medium text-gray-600">{label}</span>
         {showConfidence && (
-          <ConfidenceBadge score={priceRange.confidence} />
+          <ConfidenceBadge score={priceRange.confidence}  aria-hidden="true" />
         )}
       </div>
       <div className="text-right">
@@ -223,7 +223,7 @@ function PriceRow({
 
 function CheckIcon() {
   return (
-    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
       <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
     </svg>
   );
@@ -231,7 +231,7 @@ function CheckIcon() {
 
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
       <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
     </svg>
   );
@@ -239,7 +239,7 @@ function InfoIcon() {
 
 function AlertIcon() {
   return (
-    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
       <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
     </svg>
   );
@@ -247,7 +247,7 @@ function AlertIcon() {
 
 function PhoneIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
     </svg>
   );
@@ -255,7 +255,7 @@ function PhoneIcon() {
 
 function DashIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
     </svg>
   );
@@ -343,12 +343,12 @@ export function PriceInsightBlock({
         data-testid="price-insight-block"
       >
         <h3 className="font-semibold text-gray-900 flex items-center gap-2 mb-3">
-          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Pricing
         </h3>
-        <PriceUnavailableFallback status={displayInfo.status} />
+        <PriceUnavailableFallback status={displayInfo.status}  aria-hidden="true" />
       </div>
     );
   }
@@ -364,12 +364,12 @@ export function PriceInsightBlock({
         data-testid="price-insight-block"
       >
         <h3 className="font-semibold text-gray-900 flex items-center gap-2 mb-3">
-          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Pricing
         </h3>
-        <PriceUnavailableFallback status="unavailable" />
+        <PriceUnavailableFallback status="unavailable"  aria-hidden="true" />
       </div>
     );
   }
@@ -388,34 +388,34 @@ export function PriceInsightBlock({
       {/* Header with currency selector */}
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Price Range
         </h3>
         <div className="flex items-center gap-2">
-          <ConfidenceBadge score={bestConfidence} />
+          <ConfidenceBadge score={bestConfidence}  aria-hidden="true" />
         </div>
       </div>
 
       {/* Currency selector */}
       <div className="mb-3">
-        <CurrencySelector selected={currency} onChange={setCurrency} />
+        <CurrencySelector selected={currency} onChange={setCurrency}  aria-hidden="true" />
       </div>
 
       {/* Price Rows */}
       <div className="space-y-0">
         {hasNewPrice && displayInfo.priceRange && (
-          <PriceRow label="New Boat Price" priceRange={displayInfo.priceRange} />
+          <PriceRow label="New Boat Price" priceRange={displayInfo.priceRange}  aria-hidden="true" />
         )}
         {hasUsedPrice && displayInfo.usedPriceRange && (
-          <PriceRow label="Used / Brokerage" priceRange={displayInfo.usedPriceRange} />
+          <PriceRow label="Used / Brokerage" priceRange={displayInfo.usedPriceRange}  aria-hidden="true" />
         )}
       </div>
 
       {/* Price trend chart */}
       {history.length >= 2 && (
-        <PriceTrendSparkline data={history} />
+        <PriceTrendSparkline data={history}  aria-hidden="true" />
       )}
 
       {/* Footer */}

--- a/app/components/icons/ArrowRight.tsx
+++ b/app/components/icons/ArrowRight.tsx
@@ -11,7 +11,7 @@ export default function ArrowRight({ className }: { className?: string }) {
       strokeLinecap="round"
       strokeLinejoin="round"
       className={className}
-    >
+     aria-hidden="true">
       <path d="M5 12h14" />
       <path d="m12 5 7 7-7 7" />
     </svg>

--- a/app/components/yacht/YachtImage.tsx
+++ b/app/components/yacht/YachtImage.tsx
@@ -5,12 +5,12 @@ import { useState } from 'react'
 
 // Compact shimmer blur placeholder (20x20 gray gradient)
 const SHIMMER_BLUR = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(
-  '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><defs><linearGradient id="s" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="%23e2e8f0"/><stop offset="50%" stop-color="%23cbd5e1"/><stop offset="100%" stop-color="%23e2e8f0"/></linearGradient></defs><rect width="20" height="20" fill="url(%23s)"/></svg>'
+  '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" aria-hidden="true"><defs><linearGradient id="s" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="%23e2e8f0"/><stop offset="50%" stop-color="%23cbd5e1"/><stop offset="100%" stop-color="%23e2e8f0"/></linearGradient></defs><rect width="20" height="20" fill="url(%23s)"/></svg>'
 )
 
 // Inline SVG fallback as data URI — always works, no file dependency
 const FALLBACK_IMAGE = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(
-  '<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg"><rect width="400" height="300" fill="%23f3f4f6"/><text x="200" y="155" text-anchor="middle" fill="%239ca3af" font-family="Arial,sans-serif" font-size="14">No image available</text></svg>'
+  '<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect width="400" height="300" fill="%23f3f4f6"/><text x="200" y="155" text-anchor="middle" fill="%239ca3af" font-family="Arial,sans-serif" font-size="14">No image available</text></svg>'
 )
 
 interface YachtImageProps {

--- a/components/CorrectionForm.tsx
+++ b/components/CorrectionForm.tsx
@@ -106,7 +106,7 @@ export function CorrectionForm({ yachtId, yachtSlug, specFields }: CorrectionFor
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
         data-testid="suggest-correction-btn"
       >
-        <AlertTriangle className="h-3.5 w-3.5" />
+        <AlertTriangle className="h-3.5 w-3.5"  aria-hidden="true" />
         Suggest a Correction
       </button>
 
@@ -125,7 +125,7 @@ export function CorrectionForm({ yachtId, yachtSlug, specFields }: CorrectionFor
             {/* Header */}
             <div className="flex items-center justify-between px-5 py-4 border-b border-border">
               <h3 className="text-lg font-semibold flex items-center gap-2">
-                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                <AlertTriangle className="h-5 w-5 text-amber-500"  aria-hidden="true" />
                 Suggest a Correction
               </h3>
               <button
@@ -134,7 +134,7 @@ export function CorrectionForm({ yachtId, yachtSlug, specFields }: CorrectionFor
                 className="p-1 rounded-md hover:bg-muted transition-colors"
                 aria-label="Close"
               >
-                <X className="h-5 w-5" />
+                <X className="h-5 w-5"  aria-hidden="true" />
               </button>
             </div>
 
@@ -326,7 +326,7 @@ export function CorrectionForm({ yachtId, yachtSlug, specFields }: CorrectionFor
                     className="inline-flex items-center gap-1.5 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
                     data-testid="correction-submit-btn"
                   >
-                    <Send className="h-3.5 w-3.5" />
+                    <Send className="h-3.5 w-3.5"  aria-hidden="true" />
                     {status === "submitting" ? "Submitting…" : "Submit Correction"}
                   </button>
                 </div>

--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -41,14 +41,14 @@ interface MediaGalleryProps {
 type TabKey = "photos" | "videos" | "brochures" | "more";
 
 const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
-  { key: "photos", label: "Photos", icon: <ImageIcon className="h-4 w-4" /> },
-  { key: "videos", label: "Videos", icon: <PlayCircle className="h-4 w-4" /> },
+  { key: "photos", label: "Photos", icon: <ImageIcon className="h-4 w-4"  aria-hidden="true" /> },
+  { key: "videos", label: "Videos", icon: <PlayCircle className="h-4 w-4"  aria-hidden="true" /> },
   {
     key: "brochures",
     label: "Brochures & Plans",
-    icon: <FileText className="h-4 w-4" />,
+    icon: <FileText className="h-4 w-4"  aria-hidden="true" />,
   },
-  { key: "more", label: "More", icon: <Box className="h-4 w-4" /> },
+  { key: "more", label: "More", icon: <Box className="h-4 w-4"  aria-hidden="true" /> },
 ];
 
 function groupByType(assets: MediaAsset[]) {
@@ -214,9 +214,9 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
             onPhotoClick={(idx) => setLightboxIndex(idx)}
           />
         )}
-        {activeTab === "videos" && <VideoList videos={videos} />}
-        {activeTab === "brochures" && <BrochureList items={brochures} />}
-        {activeTab === "more" && <MoreList items={more} />}
+        {activeTab === "videos" && <VideoList videos={videos}  aria-hidden="true" />}
+        {activeTab === "brochures" && <BrochureList items={brochures}  aria-hidden="true" />}
+        {activeTab === "more" && <MoreList items={more}  aria-hidden="true" />}
       </div>
 
       {/* Lightbox */}
@@ -234,7 +234,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
             onClick={closeLightbox}
             aria-label="Close lightbox"
           >
-            <X className="h-8 w-8" />
+            <X className="h-8 w-8"  aria-hidden="true" />
           </button>
           {lightboxIndex != null && lightboxIndex > 0 && (
             <button
@@ -245,7 +245,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
               }}
               aria-label="Previous photo"
             >
-              <ChevronLeft className="h-10 w-10" />
+              <ChevronLeft className="h-10 w-10"  aria-hidden="true" />
             </button>
           )}
           {lightboxIndex != null && lightboxIndex < currentLightboxPhotos.length - 1 && (
@@ -257,7 +257,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
               }}
               aria-label="Next photo"
             >
-              <ChevronRight className="h-10 w-10" />
+              <ChevronRight className="h-10 w-10"  aria-hidden="true" />
             </button>
           )}
           <div
@@ -384,16 +384,16 @@ function VideoList({ videos }: { videos: MediaAsset[] }) {
                     rel="noopener noreferrer"
                     className="bg-black/50 rounded-full p-3 hover:bg-black/70 transition-colors"
                   >
-                    <PlayCircle className="h-10 w-10 text-white" />
+                    <PlayCircle className="h-10 w-10 text-white"  aria-hidden="true" />
                   </a>
                 ) : (
-                  <Video className="h-10 w-10 text-white/50" />
+                  <Video className="h-10 w-10 text-white/50"  aria-hidden="true" />
                 )}
               </div>
             </div>
           ) : (
             <div className="aspect-video bg-muted flex items-center justify-center">
-              <Video className="h-10 w-10 text-muted-foreground" />
+              <Video className="h-10 w-10 text-muted-foreground"  aria-hidden="true" />
             </div>
           )}
           <div className="p-3">
@@ -425,9 +425,9 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
   }
 
   const typeIcons: Record<string, React.ReactNode> = {
-    brochure: <FileText className="h-6 w-6" />,
-    deck_plan: <Map className="h-6 w-6" />,
-    interior_layout: <Layout className="h-6 w-6" />,
+    brochure: <FileText className="h-6 w-6"  aria-hidden="true" />,
+    deck_plan: <Map className="h-6 w-6"  aria-hidden="true" />,
+    interior_layout: <Layout className="h-6 w-6"  aria-hidden="true" />,
   };
 
   const typeLabels: Record<string, string> = {
@@ -445,7 +445,7 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
           data-testid="media-brochure-card"
         >
           <div className="shrink-0 text-primary">
-            {typeIcons[item.mediaType] || <FileText className="h-6 w-6" />}
+            {typeIcons[item.mediaType] || <FileText className="h-6 w-6"  aria-hidden="true" />}
           </div>
           <div className="min-w-0 flex-1">
             <h4 className="font-medium text-sm truncate">
@@ -469,7 +469,7 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <Download className="h-3 w-3" />
+                <Download className="h-3 w-3"  aria-hidden="true" />
                 Download
               </a>
             )}
@@ -480,7 +480,7 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <ExternalLink className="h-3 w-3" />
+                <ExternalLink className="h-3 w-3"  aria-hidden="true" />
                 View Source
               </a>
             )}
@@ -521,9 +521,9 @@ function MoreList({ items }: { items: MediaAsset[] }) {
           ) : (
             <div className="aspect-video bg-muted flex flex-col items-center justify-center gap-2">
               {item.mediaType === "360_tour" ? (
-                <RotateCcw className="h-8 w-8 text-muted-foreground" />
+                <RotateCcw className="h-8 w-8 text-muted-foreground"  aria-hidden="true" />
               ) : (
-                <Box className="h-8 w-8 text-muted-foreground" />
+                <Box className="h-8 w-8 text-muted-foreground"  aria-hidden="true" />
               )}
               <span className="text-sm text-muted-foreground">
                 {item.mediaType === "360_tour"
@@ -551,7 +551,7 @@ function MoreList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <ExternalLink className="h-3 w-3" />
+                <ExternalLink className="h-3 w-3"  aria-hidden="true" />
                 Open
               </a>
             )}

--- a/components/ReviewSubmissionForm.tsx
+++ b/components/ReviewSubmissionForm.tsx
@@ -46,7 +46,7 @@ function StarSelector({
                 ? "fill-yellow-400 text-yellow-400"
                 : "fill-muted text-muted-foreground/30"
             } hover:scale-110`}
-          />
+           aria-hidden="true" />
         </button>
       ))}
     </div>
@@ -172,7 +172,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
   if (submitted) {
     return (
       <div className="bg-card border border-border rounded-xl p-6 sm:p-8 text-center" data-testid="review-submitted">
-        <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4" />
+        <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4"  aria-hidden="true" />
         <h3 className="text-lg font-bold mb-2">Thank you for your review!</h3>
         <p className="text-muted-foreground">
           Your review of the {yachtName} has been submitted and will be visible after moderation.
@@ -248,7 +248,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
           <label className="block text-sm font-medium mb-1.5">
             Overall Rating <span className="text-red-500">*</span>
           </label>
-          <StarSelector value={rating} onChange={setRating} />
+          <StarSelector value={rating} onChange={setRating}  aria-hidden="true" />
         </div>
 
         {/* Summary */}
@@ -337,7 +337,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
               onClick={addPro}
               className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4"  aria-hidden="true" />
               Add
             </button>
           </div>
@@ -353,7 +353,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
                   onClick={() => removePro(idx)}
                   className="ml-1 hover:text-green-900"
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3"  aria-hidden="true" />
                 </button>
               </span>
             ))}
@@ -383,7 +383,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
               onClick={addCon}
               className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4"  aria-hidden="true" />
               Add
             </button>
           </div>
@@ -399,7 +399,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
                   onClick={() => removeCon(idx)}
                   className="ml-1 hover:text-red-900"
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3"  aria-hidden="true" />
                 </button>
               </span>
             ))}
@@ -420,7 +420,7 @@ export function ReviewSubmissionForm({ yachtModelId, yachtName }: ReviewSubmissi
           className="inline-flex items-center gap-2 px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           data-testid="submit-review-btn"
         >
-          <Send className="h-4 w-4" />
+          <Send className="h-4 w-4"  aria-hidden="true" />
           {submitting ? "Submitting..." : "Submit Review"}
         </button>
       </div>

--- a/components/ReviewSummary.tsx
+++ b/components/ReviewSummary.tsx
@@ -48,7 +48,7 @@ function StarRating({ rating, size = "md" }: { rating: number; size?: "sm" | "md
               ? "fill-yellow-400 text-yellow-400"
               : "fill-muted text-muted-foreground/30"
           }`}
-        />
+         aria-hidden="true" />
       ))}
     </div>
   );
@@ -93,7 +93,7 @@ export function ReviewSummary({ reviews, overallRating, ratingBreakdown }: Revie
           <div className="text-5xl font-bold mb-2">
             {overallRating > 0 ? overallRating.toFixed(1) : "—"}
           </div>
-          <StarRating rating={overallRating} size="lg" />
+          <StarRating rating={overallRating} size="lg"  aria-hidden="true" />
           <p className="text-sm text-muted-foreground mt-2">
             Based on {reviews.length} review{reviews.length !== 1 ? "s" : ""}
           </p>
@@ -116,10 +116,10 @@ export function ReviewSummary({ reviews, overallRating, ratingBreakdown }: Revie
           <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
             Rating Breakdown
           </h3>
-          <RatingBar label="Build Quality" value={ratingBreakdown.build_quality} />
-          <RatingBar label="Sailing Performance" value={ratingBreakdown.sailing_performance} />
-          <RatingBar label="Comfort" value={ratingBreakdown.comfort} />
-          <RatingBar label="Value for Money" value={ratingBreakdown.value_for_money} />
+          <RatingBar label="Build Quality" value={ratingBreakdown.build_quality}  aria-hidden="true" />
+          <RatingBar label="Sailing Performance" value={ratingBreakdown.sailing_performance}  aria-hidden="true" />
+          <RatingBar label="Comfort" value={ratingBreakdown.comfort}  aria-hidden="true" />
+          <RatingBar label="Value for Money" value={ratingBreakdown.value_for_money}  aria-hidden="true" />
         </div>
       </div>
     </section>

--- a/components/SourceProvenance.tsx
+++ b/components/SourceProvenance.tsx
@@ -74,16 +74,16 @@ export default function SourceProvenance({
         data-testid="source-provenance-toggle"
       >
         <div className="flex items-center gap-2 text-sm sm:text-base font-semibold">
-          <Shield className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
+          <Shield className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground"  aria-hidden="true" />
           <span>Data Source &amp; Quality</span>
           {completenessScore !== null && (
-            <CompletenessBadge score={completenessScore} size="sm" />
+            <CompletenessBadge score={completenessScore} size="sm"  aria-hidden="true" />
           )}
         </div>
         {expanded ? (
-          <ChevronUp className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
+          <ChevronUp className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground"  aria-hidden="true" />
         ) : (
-          <ChevronDown className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
+          <ChevronDown className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground"  aria-hidden="true" />
         )}
       </button>
 
@@ -92,9 +92,9 @@ export default function SourceProvenance({
           {/* Completeness Score */}
           {completenessScore !== null && (
             <div className="flex items-center gap-3">
-              <Database className="h-4 w-4 text-muted-foreground shrink-0" />
+              <Database className="h-4 w-4 text-muted-foreground shrink-0"  aria-hidden="true" />
               <div className="flex items-center gap-2 flex-wrap">
-                <CompletenessBadge score={completenessScore} size="md" showLabel />
+                <CompletenessBadge score={completenessScore} size="md" showLabel  aria-hidden="true" />
                 <span className="text-sm text-muted-foreground">
                   Data completeness: {completenessScore}%
                 </span>
@@ -104,7 +104,7 @@ export default function SourceProvenance({
 
           {/* Source */}
           <div className="flex items-start gap-3">
-            <ExternalLink className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <ExternalLink className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0"  aria-hidden="true" />
             <div>
               <span className="text-sm text-muted-foreground">Source:</span>{" "}
               {sourceUrl ? (
@@ -126,7 +126,7 @@ export default function SourceProvenance({
 
           {/* Confidence */}
           <div className="flex items-center gap-3">
-            <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Shield className="h-4 w-4 text-muted-foreground shrink-0"  aria-hidden="true" />
             <div className="flex items-center gap-2 flex-1">
               <span className="text-sm text-muted-foreground whitespace-nowrap">
                 Source confidence: {confidence.label}
@@ -144,7 +144,7 @@ export default function SourceProvenance({
 
           {/* Last Verified */}
           <div className="flex items-center gap-3">
-            <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Calendar className="h-4 w-4 text-muted-foreground shrink-0"  aria-hidden="true" />
             <span className="text-sm text-muted-foreground">
               Last verified:{" "}
               <span className={lastVerifiedAt ? "text-foreground" : "italic"}>
@@ -155,7 +155,7 @@ export default function SourceProvenance({
 
           {/* Data Source Type */}
           <div className="flex items-center gap-3">
-            <Database className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Database className="h-4 w-4 text-muted-foreground shrink-0"  aria-hidden="true" />
             <span className="text-sm text-muted-foreground">
               Data source: <span className="text-foreground">{sourceLabel}</span>
             </span>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -26,7 +26,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -44,7 +44,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="h-4 w-4" aria-hidden="true" />
   </SelectPrimitive.ScrollUpButton>
 ));
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
@@ -61,7 +61,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="h-4 w-4"  aria-hidden="true" />
   </SelectPrimitive.ScrollDownButton>
 ));
 SelectScrollDownButton.displayName =
@@ -125,7 +125,7 @@ const SelectItem = React.forwardRef<
   >
     <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/scripts/fix-media-a11y.js
+++ b/scripts/fix-media-a11y.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * P13.5: Fix media accessibility issues across the codebase.
+ * 
+ * 1. Add aria-hidden="true" to decorative inline SVGs (those without aria-label or role)
+ * 2. Add aria-label to icon-only buttons (buttons that only contain SVG + no visible text)
+ * 3. Add alt text to <img> tags missing it
+ */
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+function findTsxFiles(dir) {
+  const results = [];
+  function walk(d) {
+    const entries = fs.readdirSync(d, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.next') continue;
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.tsx') || entry.name.endsWith('.jsx')) results.push(full);
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+// Fix 1: Add aria-hidden to decorative SVGs
+function fixSvgAriaHidden(content, filePath) {
+  let changed = false;
+  
+  // Match <svg ...> that don't already have aria-hidden or aria-label
+  // We need to be careful - some SVGs are meaningful (like the hero scales icon)
+  content = content.replace(/<svg(\s[^>]*)>/g, (match, attrs) => {
+    // Skip if already has aria-hidden or aria-label
+    if (attrs.includes('aria-hidden') || attrs.includes('aria-label')) return match;
+    // Skip if SVG has a <title> child (meaningful)
+    // We'll handle those manually
+    changed = true;
+    return `<svg${attrs} aria-hidden="true">`;
+  });
+  
+  return { content, changed };
+}
+
+// Fix 2: Add aria-label to icon-only buttons
+function fixIconButtonAriaLabel(content, filePath) {
+  let changed = false;
+  
+  // Pattern: <button ...><svg .../></button> with no text content
+  // We'll look for buttons that have title attributes but no aria-label
+  content = content.replace(
+    /<button(\s[^>]*?)title="([^"]*)"([^>]*?)>/g,
+    (match, before, title, after) => {
+      if (before.includes('aria-label') || after.includes('aria-label')) return match;
+      changed = true;
+      return `<button${before}aria-label="${title}"${after}>`;
+    }
+  );
+  
+  return { content, changed };
+}
+
+// Process files
+const dirs = ['app', 'components'];
+let totalFixed = 0;
+
+for (const dir of dirs) {
+  const fullDir = path.join(process.cwd(), dir);
+  if (!fs.existsSync(fullDir)) continue;
+  
+  const files = findTsxFiles(fullDir);
+  for (const file of files) {
+    let content = fs.readFileSync(file, 'utf-8');
+    const original = content;
+    const relPath = path.relative(process.cwd(), file);
+    
+    // Apply SVG fixes
+    const svgResult = fixSvgAriaHidden(content, relPath);
+    content = svgResult.content;
+    
+    // Apply icon button fixes
+    const btnResult = fixIconButtonAriaLabel(content, relPath);
+    content = btnResult.content;
+    
+    if (content !== original) {
+      fs.writeFileSync(file, content);
+      console.log(`Fixed: ${relPath}`);
+      totalFixed++;
+    }
+  }
+}
+
+console.log(`\nTotal files fixed: ${totalFixed}`);

--- a/tests/media-accessibility.spec.ts
+++ b/tests/media-accessibility.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://info.sailboats.fr';
+
+test.describe('Media Accessibility — P13.5', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  /**
+   * Helper: Get all elements matching selector and return their accessibility attributes
+   */
+  async function getAccessibilityInfo(page: any, selector: string) {
+    return page.$$eval(selector, (elements: Element[]) =>
+      elements.map((el, idx) => ({
+        index: idx,
+        tagName: el.tagName.toLowerCase(),
+        alt: el.getAttribute('alt'),
+        ariaLabel: el.getAttribute('aria-label'),
+        ariaHidden: el.getAttribute('aria-hidden'),
+        role: el.getAttribute('role'),
+        title: el.getAttribute('title'),
+        hasTitleChild: el.querySelector('title') !== null,
+        textContent: el.textContent?.substring(0, 50),
+      }))
+    );
+  }
+
+  const pages = [
+    { name: 'Home', path: '/' },
+    { name: 'Yachts listing', path: '/yachts' },
+    { name: 'Search', path: '/search' },
+    { name: 'Compare', path: '/compare' },
+    { name: 'Manufacturers', path: '/manufacturers' },
+    { name: 'Guides hub', path: '/guides' },
+  ];
+
+  for (const pageInfo of pages) {
+    test(`${pageInfo.name}: all <img> elements have alt text`, async ({ page }) => {
+      await page.goto(`${BASE_URL}${pageInfo.path}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+
+      const images = await getAccessibilityInfo(page, 'img');
+      
+      for (const img of images) {
+        // Every <img> must have an alt attribute (can be empty for decorative)
+        expect(
+          img.alt,
+          `<img> at index ${img.index} on ${pageInfo.name} is missing alt attribute. Text: "${img.textContent}"`
+        ).not.toBeNull();
+      }
+    });
+
+    test(`${pageInfo.name}: decorative SVGs have aria-hidden`, async ({ page }) => {
+      await page.goto(`${BASE_URL}${pageInfo.path}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+
+      const svgs = await getAccessibilityInfo(page, 'svg');
+      
+      for (const svg of svgs) {
+        const isDecorative = !svg.ariaLabel && !svg.role && !svg.hasTitleChild;
+        if (isDecorative) {
+          expect(
+            svg.ariaHidden,
+            `Decorative <svg> at index ${svg.index} on ${pageInfo.name} should have aria-hidden="true"`
+          ).toBe('true');
+        }
+      }
+    });
+  }
+
+  test('Yacht detail page: images have meaningful alt text', async ({ page }) => {
+    // Navigate to a yacht detail page
+    await page.goto(`${BASE_URL}/yachts`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Click the first yacht link
+    const firstYachtLink = page.locator('a[href^="/yachts/"]').first();
+    if (await firstYachtLink.count() === 0) {
+      test.skip();
+      return;
+    }
+    
+    await firstYachtLink.click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    const images = await getAccessibilityInfo(page, 'img');
+    
+    for (const img of images) {
+      // Images on detail page should have meaningful alt text (not empty)
+      expect(
+        img.alt,
+        `Image on yacht detail page at index ${img.index} has empty or missing alt text`
+      ).toBeTruthy();
+      expect(
+        img.alt?.length,
+        `Image on yacht detail page at index ${img.index} has too-short alt text: "${img.alt}"`
+      ).toBeGreaterThan(2);
+    }
+  });
+
+  test('Compare page: icon-only buttons have aria-labels', async ({ page }) => {
+    await page.goto(`${BASE_URL}/compare`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Find all buttons that contain only SVGs (icon-only)
+    const iconButtons = await page.$$eval('button', (buttons: HTMLButtonElement[]) =>
+      buttons
+        .map((btn, idx) => {
+          const textContent = btn.textContent?.trim() || '';
+          const hasSvg = btn.querySelector('svg') !== null;
+          const hasOnlyWhitespaceText = textContent.length === 0 || /^(|\s)$/.test(textContent);
+          // Check if button only contains SVGs and whitespace
+          const children = Array.from(btn.childNodes);
+          const onlySvgAndText = children.every(child => {
+            if (child.nodeType === 1) return (child as Element).tagName === 'svg' || (child as Element).tagName === 'SPAN';
+            if (child.nodeType === 3) return !child.textContent?.trim();
+            return false;
+          });
+          const isIconButton = hasSvg && hasOnlyWhitespaceText;
+          
+          return {
+            idx,
+            isIconButton,
+            textContent: textContent.substring(0, 50),
+            ariaLabel: btn.getAttribute('aria-label'),
+            title: btn.getAttribute('title'),
+          };
+        })
+        .filter(b => b.isIconButton)
+    );
+
+    for (const btn of iconButtons) {
+      // Icon-only buttons must have aria-label or title
+      expect(
+        btn.ariaLabel || btn.title,
+        `Icon-only button at index ${btn.idx} on compare page needs aria-label or title. Text: "${btn.textContent}"`
+      ).toBeTruthy();
+    }
+  });
+
+  test('No SVG without accessible name or aria-hidden', async ({ page }) => {
+    await page.goto(`${BASE_URL}/yachts`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    const svgs = await getAccessibilityInfo(page, 'svg');
+    
+    const problemSvgs = svgs.filter(svg => 
+      !svg.ariaHidden && !svg.ariaLabel && !svg.role && !svg.hasTitleChild
+    );
+
+    expect(
+      problemSvgs.length,
+      `Found ${problemSvgs.length} SVGs without aria-hidden, aria-label, role, or <title>. Indices: ${problemSvgs.map(s => s.index).join(', ')}`
+    ).toBe(0);
+  });
+
+  test('Search page: SVGs are properly hidden', async ({ page }) => {
+    await page.goto(`${BASE_URL}/search`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    const svgs = await getAccessibilityInfo(page, 'svg');
+    
+    for (const svg of svgs) {
+      const hasAccessibleName = svg.ariaLabel || svg.role || svg.hasTitleChild;
+      if (!hasAccessibleName) {
+        expect(
+          svg.ariaHidden,
+          `SVG at index ${svg.index} on search page has no accessible name and no aria-hidden`
+        ).toBe('true');
+      }
+    }
+  });
+});

--- a/tests/media-accessibility.test.ts
+++ b/tests/media-accessibility.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * P13.5 — Media Accessibility: Static analysis of TSX source files
+ * Ensures all <img>, <svg>, and icon-only buttons follow accessibility rules.
+ */
+
+function findTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+  function walk(d: string) {
+    if (!fs.existsSync(d)) return;
+    const entries = fs.readdirSync(d, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === '.cache') continue;
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.tsx') || entry.name.endsWith('.jsx')) results.push(full);
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const APP_DIR = path.join(PROJECT_ROOT, 'app');
+const COMPONENTS_DIR = path.join(PROJECT_ROOT, 'components');
+
+const allFiles = [...findTsxFiles(APP_DIR), ...findTsxFiles(COMPONENTS_DIR)]
+  .filter(f => !f.includes('/admin/'));
+
+// Known Lucide icon component names
+const LUCIDE_ICONS = new Set([
+  'ArrowRight', 'ChevronLeft', 'ChevronRight', 'ChevronDown', 'ChevronUp',
+  'Ruler', 'Wind', 'Home', 'Wrench', 'Star', 'Printer',
+  'ExternalLink', 'ShoppingBag', 'Mail', 'Phone', 'Info', 'Clock', 'CheckCircle2',
+  'PlayCircle', 'FileText', 'Layout', 'Map', 'RotateCcw', 'Box',
+  'X', 'Download', 'Video', 'AlertTriangle', 'Send', 'Plus', 'CheckCircle',
+  'Shield', 'Calendar', 'Database', 'Scale', 'BookOpen', 'Check',
+  'ImageIcon', 'Search',
+]);
+
+/**
+ * Extract a full opening tag that may span multiple lines.
+ * Tracks angle brackets to find the actual closing '>' of the opening tag.
+ */
+function extractFullTag(content: string, startIdx: number): string {
+  let depth = 0;
+  let inString: string | null = null;
+  let i = startIdx;
+  
+  while (i < content.length) {
+    const ch = content[i];
+    
+    // Handle string literals
+    if (inString) {
+      if (ch === inString && content[i - 1] !== '\\') inString = null;
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = ch;
+      i++;
+      continue;
+    }
+    
+    if (ch === '<') depth++;
+    if (ch === '>') {
+      depth--;
+      if (depth === 0) {
+        return content.substring(startIdx, i + 1);
+      }
+    }
+    i++;
+  }
+  
+  return content.substring(startIdx);
+}
+
+describe('P13.5 — Media Accessibility', () => {
+  describe('Image alt text', () => {
+    it('all <img> tags have alt attribute', () => {
+      const violations: string[] = [];
+      
+      for (const file of allFiles) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const relPath = path.relative(PROJECT_ROOT, file);
+        
+        const imgRegex = /<img\s[^>]*>/g;
+        let match;
+        while ((match = imgRegex.exec(content)) !== null) {
+          const tag = match[0];
+          if (!tag.includes('alt=')) {
+            const line = content.substring(0, match.index).split('\n').length;
+            violations.push(`${relPath}:${line} — <img> missing alt attribute`);
+          }
+        }
+      }
+      
+      expect(violations, `Missing alt attributes:\n${violations.join('\n')}`).toHaveLength(0);
+    });
+  });
+
+  describe('SVG accessibility', () => {
+    it('all inline <svg> have aria-hidden or accessible name', () => {
+      const violations: string[] = [];
+      
+      for (const file of allFiles) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const relPath = path.relative(PROJECT_ROOT, file);
+        
+        // Skip data URI SVGs
+        const svgRegex = /<svg\s/g;
+        let match;
+        while ((match = svgRegex.exec(content)) !== null) {
+          // Check if this is inside a string literal (data URI)
+          const before = content.substring(Math.max(0, match.index - 100), match.index);
+          if (before.includes("'data:image/svg+xml") || before.includes('"data:image/svg+xml')) continue;
+          
+          const fullTag = extractFullTag(content, match.index);
+          
+          const hasAriaHidden = fullTag.includes('aria-hidden="true"');
+          const hasAriaLabel = fullTag.includes('aria-label=');
+          const hasRole = fullTag.includes('role=');
+          
+          if (!hasAriaHidden && !hasAriaLabel && !hasRole) {
+            const line = content.substring(0, match.index).split('\n').length;
+            violations.push(`${relPath}:${line} — <svg> missing aria-hidden or accessible name`);
+          }
+        }
+      }
+      
+      expect(violations, `SVGs without accessibility:\n${violations.join('\n')}`).toHaveLength(0);
+    });
+  });
+
+  describe('Icon-only buttons', () => {
+    it('buttons with title attribute also have aria-label', () => {
+      const violations: string[] = [];
+      
+      for (const file of allFiles) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const relPath = path.relative(PROJECT_ROOT, file);
+        
+        const lines = content.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          if (!line.includes('title=') || !line.includes('<button')) continue;
+          
+          const context = lines.slice(i, Math.min(i + 3, lines.length)).join('\n');
+          
+          if (context.includes('title=') && !context.includes('aria-label=')) {
+            violations.push(`${relPath}:${i + 1} — <button> with title but no aria-label`);
+          }
+        }
+      }
+      
+      expect(violations, `Buttons missing aria-label:\n${violations.join('\n')}`).toHaveLength(0);
+    });
+  });
+
+  describe('Lucide icons accessibility', () => {
+    it('lucide icon components have aria-hidden when decorative', () => {
+      const violations: string[] = [];
+      
+      for (const file of allFiles) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const relPath = path.relative(PROJECT_ROOT, file);
+        
+        for (const iconName of LUCIDE_ICONS) {
+          const regex = new RegExp(`<${iconName}\\s[^>]*?\\/>`, 'g');
+          let match;
+          while ((match = regex.exec(content)) !== null) {
+            const tag = match[0];
+            if (tag.includes('aria-hidden') || tag.includes('aria-label')) continue;
+            
+            const line = content.substring(0, match.index).split('\n').length;
+            violations.push(`${relPath}:${line} — <${iconName}> missing aria-hidden="true"`);
+          }
+        }
+      }
+      
+      expect(violations, `Icons missing aria-hidden:\n${violations.join('\n')}`).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
- Add aria-hidden='true' to all decorative inline SVGs across 16 files
- Add aria-hidden='true' to all Lucide icon components (20+ icons)
- Add aria-label to icon-only buttons missing accessible names
- Verify all <img> tags have meaningful alt text
- Add 4 static analysis tests (img alt, svg aria, button aria-label, lucide icons)
- Add 6 Playwright E2E media accessibility tests
- Update FUTURE_ROADMAP.md: mark P13.3, P13.4 as completed
- Add bulk fix script: scripts/fix-media-a11y.js
