### PR TITLE
fix: resolve 500 errors on all locale routes (/en, /fr)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -100,18 +100,14 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
             {t("footer.dataSource")}
           </p>
           <p className="mt-2 text-xs">
-            {t.rich("footer.builtBy", {
-              link3dput: (children: React.ReactNode) => (
-                <a href="https://3dput.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">
-                  {children}
-                </a>
-              ),
-              linkSailboats: (children: React.ReactNode) => (
-                <a href="https://sailboats.fr" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">
-                  {children}
-                </a>
-              ),
-            })}
+            {t("footer.builtByPrefix")}{" "}
+            <a href="https://3dput.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">
+              {t("footer.builtBy3dput")}
+            </a>{" "}
+            {t("footer.builtBySeparator")}{" "}
+            <a href="https://sailboats.fr" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground transition-colors">
+              {t("footer.builtBySailboats")}
+            </a>
           </p>
         </div>
       </footer>

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,7 +26,11 @@
     "footer": {
       "copyright": "© {year} Sailing Yacht Info. All rights reserved.",
       "dataSource": "Data sourced from manufacturer specifications.",
-      "builtBy": "Built with ❤️ by {link3dput} · {linkSailboats}"
+      "builtBy": "Built with ❤️ by {link3dput} · {linkSailboats}",
+      "builtBy3dput": "3DPUT",
+      "builtBySailboats": "Sailboats.fr",
+      "builtByPrefix": "Built with ❤️ by",
+      "builtBySeparator": "·"
     },
     "auth": {
       "signIn": "Sign In",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -26,7 +26,11 @@
     "footer": {
       "copyright": "© {year} Sailing Yacht Info. Tous droits réservés.",
       "dataSource": "Données issues des spécifications des constructeurs.",
-      "builtBy": "Créé avec ❤️ par {link3dput} · {linkSailboats}"
+      "builtBy": "Créé avec ❤️ par {link3dput} · {linkSailboats}",
+      "builtByPrefix": "Créé avec ❤️ par",
+      "builtBySeparator": "·",
+      "builtBy3dput": "3DPUT",
+      "builtBySailboats": "Sailboats.fr"
     },
     "auth": {
       "signIn": "Connexion",


### PR DESCRIPTION
## Problem

After the P14.1 i18n merge (PR #227), **every locale-prefixed route returns HTTP 500** on production:
- `/en` → 500
- `/fr` → 500
- `/en/yachts`, `/en/compare`, `/fr/manufacturers/*` → all 500

The error: `Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server".`

## Root Cause

`t.rich("footer.builtBy", { link3dput: (children) => <a>...</a>, linkSailboats: (children) => <a>...</a> })` in `app/[locale]/layout.tsx` passes callback **functions** as values. In `next-intl` v4 with React Server Components, these functions get included in the serialized output sent to client components, breaking the server→client boundary.

Error detail from Vercel logs: `[..., function, " · ", function]`

## Fix

Replace `t.rich()` with individual `t()` calls composed in JSX:
```tsx
// Before (broken):
{t.rich("footer.builtBy", { link3dput: (ch) => <a>...</a>, linkSailboats: (ch) => <a>...</a> })}

// After (working):
{t("footer.builtByPrefix")}{' '}
<a href="https://3dput.com" ...>{t("footer.builtBy3dput")}</a>{' '}
{t("footer.builtBySeparator")}{' '}
<a href="https://sailboats.fr" ...>{t("footer.builtBySailboats")}</a>
```

Added translation keys to both `messages/en.json` and `messages/fr.json`.

## Verification

Local testing (after build):
- `/en` → 200 ✓
- `/fr` → 200 ✓
- `/en/yachts` → 200 ✓
- `/en/compare` → 200 ✓
- `/en/search` → 200 ✓
- `/en/manufacturers` → 200 ✓
- `/en/guides` → 200 ✓
- `/fr/yachts` → 200 ✓
- Old routes (`/`, `/yachts`, `/compare`) → 307 redirect ✓
- No server errors in logs ✓

Closes #226