### PR TITLE
feat(i18n): French translations for yacht listing & search pages (P14.2)

### DIFF
--- a/app/[locale]/search/SearchClient.tsx
+++ b/app/[locale]/search/SearchClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 interface SearchResult {
   id: number;
@@ -31,6 +32,7 @@ interface AutocompleteSuggestion {
 }
 
 export function SearchClient() {
+  const t = useTranslations("Search");
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [total, setTotal] = useState(0);
@@ -146,14 +148,14 @@ export function SearchClient() {
         }),
       });
       if (res.ok) {
-        setSaveMessage("Saved!");
+        setSaveMessage(t("saved"));
         setTimeout(() => setSaveMessage(null), 2000);
       } else {
-        setSaveMessage("Failed");
+        setSaveMessage(t("saveFailed"));
         setTimeout(() => setSaveMessage(null), 2000);
       }
     } catch {
-      setSaveMessage("Failed");
+      setSaveMessage(t("saveFailed"));
       setTimeout(() => setSaveMessage(null), 2000);
     }
   };
@@ -201,10 +203,10 @@ export function SearchClient() {
       {/* Hero / Search Header */}
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-foreground mb-2">
-          Search Yachts
+          {t("heading")}
         </h1>
         <p className="text-muted-foreground">
-          Find sailing yachts by manufacturer, model, or specifications
+          {t("subtitle")}
         </p>
       </div>
 
@@ -236,8 +238,8 @@ export function SearchClient() {
               onFocus={() => {
                 if (suggestions.length > 0) setShowSuggestions(true);
               }}
-              placeholder="Search by manufacturer, model name, rig type..."
-              aria-label="Search yachts"
+              placeholder={t("placeholder")}
+              aria-label={t("heading")}
               className="w-full pl-12 pr-4 py-3 border border-border rounded-lg bg-white text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-base"
               autoComplete="off"
             />
@@ -253,7 +255,7 @@ export function SearchClient() {
                 ref={suggestionsRef}
                 className="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-lg shadow-lg z-50 overflow-hidden"
                 role="listbox"
-                aria-label="Search suggestions"
+                aria-label={t("suggestions.label")}
               >
                 {suggestions.map((s, i) => (
                   <button
@@ -286,11 +288,11 @@ export function SearchClient() {
             disabled={loading || !query.trim()}
             className="px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors sm:w-auto w-full"
           >
-            {loading ? "Searching..." : "Search"}
+            {loading ? t("searching") : t("searchButton")}
           </button>
         </div>
         <p className="mt-2 text-xs text-muted-foreground">
-          Type at least 2 characters for suggestions. Press Enter to search.
+          {t("hint")}
         </p>
       </div>
 
@@ -300,11 +302,11 @@ export function SearchClient() {
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-muted-foreground">
               {loading
-                ? "Searching..."
-                : total + " yacht" + (total !== 1 ? "s" : "") + " found"}
+                ? t("results.searching")
+                : t("results.count", { total })}
               {query && (
                 <span>
-                  {" "}for &ldquo;<span className="font-medium text-foreground">{query}</span>&rdquo;
+                  {" "}{t("results.for")} &ldquo;<span className="font-medium text-foreground">{query}</span>&rdquo;
                 </span>
               )}
             </p>
@@ -313,12 +315,12 @@ export function SearchClient() {
               <button
                 onClick={handleSaveSearch}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition-colors"
-                aria-label="Save this search to your account"
+                aria-label={t("saveSearch")}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
                 </svg>
-                {saveMessage || "Save Search"}
+                {saveMessage || t("saveSearch")}
               </button>
             )}
           </div>
@@ -333,10 +335,10 @@ export function SearchClient() {
             <div className="text-center py-12" role="status">
               <div className="text-4xl mb-4">⛵</div>
               <h2 className="text-xl font-semibold text-foreground mb-2">
-                No yachts found
+                {t("empty.heading")}
               </h2>
               <p className="text-muted-foreground mb-4">
-                Try searching with different keywords
+                {t("empty.description")}
               </p>
               <div className="flex flex-wrap justify-center gap-2">
                 {["Beneteau", "Hanse", "Jeanneau", "Bavaria", "sloop"].map(
@@ -408,7 +410,7 @@ export function SearchClient() {
                             {yacht.lengthOverall}m
                           </div>
                           <div className="text-xs text-muted-foreground">
-                            LOA
+                            {t("results.loa")}
                           </div>
                         </div>
                       )}
@@ -418,7 +420,7 @@ export function SearchClient() {
                             {yacht.beam}m
                           </div>
                           <div className="text-xs text-muted-foreground">
-                            Beam
+                            {t("results.beam")}
                           </div>
                         </div>
                       )}
@@ -428,7 +430,7 @@ export function SearchClient() {
                             {yacht.draft}m
                           </div>
                           <div className="text-xs text-muted-foreground">
-                            Draft
+                            {t("results.draft")}
                           </div>
                         </div>
                       )}
@@ -445,7 +447,7 @@ export function SearchClient() {
       {!searched && (
         <div className="mt-4">
           <h2 className="text-sm font-medium text-muted-foreground mb-3">
-            Popular searches
+            {t("popular")}
           </h2>
           <div className="flex flex-wrap gap-2">
             {[

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -3,33 +3,44 @@ import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
 import dynamic from "next/dynamic";
 const SearchClient = dynamic(() => import("./SearchClient").then(m => ({ default: m.SearchClient })), { ssr: false, loading: () => null });
 import { shouldNoindexSearchPage } from "@/lib/thin-page-governance";
+import { getTranslations } from "next-intl/server";
+
+interface SearchPageProps {
+  params: Promise<{ locale: string }>;
+}
 
 /**
  * Search page metadata.
  * Search results pages should be noindexed for user-specific queries,
  * but the base /search page itself can be indexed.
  */
-export const metadata: Metadata = {
-  title: "Search Yachts — Sailing Yacht Info",
-  description:
-    "Search sailing yachts by manufacturer, model name, rig type, keel type, and more. Find the perfect sailboat with our comprehensive database.",
-  alternates: {
-    canonical: "/search",
-  },
-  openGraph: {
-    title: "Search Sailing Yacht Info",
-    description:
-      "Search and find sailing yachts by manufacturer, model, and specifications.",
-  },
-  robots: shouldNoindexSearchPage()
-    ? { index: false, follow: false }
-    : { index: true, follow: true },
-};
+export async function generateMetadata({ params }: SearchPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Search" });
 
-export default function SearchPage() {
+  return {
+    title: t("meta.title"),
+    description: t("meta.description"),
+    alternates: {
+      canonical: `/${locale}/search`,
+    },
+    openGraph: {
+      title: t("meta.title"),
+      description: t("meta.description"),
+    },
+    robots: shouldNoindexSearchPage()
+      ? { index: false, follow: false }
+      : { index: true, follow: true },
+  };
+}
+
+export default async function SearchPage({ params }: SearchPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Search" });
+
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
-    { name: "Search" },
+    { name: t("heading") },
   ]);
 
   return (

--- a/app/[locale]/yachts/YachtsClient.tsx
+++ b/app/[locale]/yachts/YachtsClient.tsx
@@ -10,6 +10,7 @@ import { FILTER_PRESETS, detectActivePreset, type FilterPreset } from '@/lib/fil
 import type { YachtsListingResult, FilterOptions, YachtListItem } from '@/lib/yachts';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 // Use the shared type from lib/yachts
 type Yacht = YachtListItem;
@@ -27,6 +28,7 @@ interface YachtsClientProps {
 
 export default function YachtsClient({ initialData, filterOptions: initialFilterOptions }: YachtsClientProps) {
   const searchParams = useSearchParams();
+  const t = useTranslations('Yachts');
 
   // Initialize from SSR data if available
   const [manufacturers, setManufacturers] = useState<Array<{ id: number; name: string }>>(
@@ -181,7 +183,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
 
     // Focus the modal close button
     requestAnimationFrame(() => {
-      const closeBtn = modalRef.current?.querySelector<HTMLButtonElement>('button[aria-label="Close modal"]');
+      const closeBtn = modalRef.current?.querySelector<HTMLButtonElement>('button[aria-label="' + t('modal.close') + '"]');
       closeBtn?.focus();
     });
 
@@ -269,18 +271,18 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
   const format = (v: number | null | undefined) => (v != null ? v.toLocaleString() : '—');
 
   const FilterSidebar = () => (
-    <div className="bg-white rounded-lg shadow p-4" role="group" aria-label="Filter yachts">
+    <div className="bg-white rounded-lg shadow p-4" role="group" aria-label={t('filters.heading')}>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="font-semibold" id="filters-heading">Filters</h2>
+        <h2 className="font-semibold" id="filters-heading">{t('filters.heading')}</h2>
         {activeFilterCount > 0 && (
           <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded-full font-medium" aria-live="polite">
-            {activeFilterCount} active
+            {t('filters.activeCount', { count: activeFilterCount })}
           </span>
         )}
       </div>
 
       <div className="mb-6">
-        <h3 className="text-sm font-medium mb-2" id="filter-manufacturer-heading">Manufacturer</h3>
+        <h3 className="text-sm font-medium mb-2" id="filter-manufacturer-heading">{t('filters.manufacturer')}</h3>
         {manufacturers.length === 0 ? <p className="text-sm text-gray-500">Loading...</p> : (
           <ul className="space-y-1 max-h-48 overflow-y-auto" role="group" aria-labelledby="filter-manufacturer-heading">
             {manufacturers.map(m => (
@@ -296,8 +298,8 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
       </div>
 
       <div className="mb-6">
-        <h3 className="text-sm font-medium mb-2" id="filter-rigtype-heading">Rig Type</h3>
-        {distinct.rigTypes.length === 0 ? <p className="text-sm text-gray-500">No options</p> : (
+        <h3 className="text-sm font-medium mb-2" id="filter-rigtype-heading">{t('filters.rigType')}</h3>
+        {distinct.rigTypes.length === 0 ? <p className="text-sm text-gray-500">{t('filters.noOptions')}</p> : (
           <ul className="space-y-1 max-h-48 overflow-y-auto" role="radiogroup" aria-labelledby="filter-rigtype-heading">
             {distinct.rigTypes.map(v => (
               <li key={v}>
@@ -312,8 +314,8 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
       </div>
 
       <div className="mb-6">
-        <h3 className="text-sm font-medium mb-2" id="filter-keeltype-heading">Keel Type</h3>
-        {distinct.keelTypes.length === 0 ? <p className="text-sm text-gray-500">No options</p> : (
+        <h3 className="text-sm font-medium mb-2" id="filter-keeltype-heading">{t('filters.keelType')}</h3>
+        {distinct.keelTypes.length === 0 ? <p className="text-sm text-gray-500">{t('filters.noOptions')}</p> : (
           <ul className="space-y-1 max-h-48 overflow-y-auto" role="radiogroup" aria-labelledby="filter-keeltype-heading">
             {distinct.keelTypes.map(v => (
               <li key={v}>
@@ -328,8 +330,8 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
       </div>
 
       <div className="mb-6">
-        <h3 className="text-sm font-medium mb-2" id="filter-hull-heading">Hull Material</h3>
-        {distinct.hullMaterials.length === 0 ? <p className="text-sm text-gray-500">No options</p> : (
+        <h3 className="text-sm font-medium mb-2" id="filter-hull-heading">{t('filters.hullMaterial')}</h3>
+        {distinct.hullMaterials.length === 0 ? <p className="text-sm text-gray-500">{t('filters.noOptions')}</p> : (
           <ul className="space-y-1 max-h-48 overflow-y-auto" role="radiogroup" aria-labelledby="filter-hull-heading">
             {distinct.hullMaterials.map(v => (
               <li key={v}>
@@ -344,7 +346,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
       </div>
 
       <button onClick={clearFilters} className="w-full py-2 px-4 bg-gray-200 hover:bg-gray-300 rounded text-sm transition-colors">
-        Clear Filters
+        {t('filters.clearFilters')}
       </button>
     </div>
   );
@@ -354,7 +356,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
       <div className="max-w-7xl mx-auto p-4 sm:p-6">
         {/* Header with mobile filter toggle */}
         <div className="flex items-center justify-between mb-4 sm:mb-6">
-          <h1 className="text-2xl sm:text-3xl font-bold">Sail Yachts</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold">{t('heading')}</h1>
           <button
             ref={filterToggleRef}
             onClick={() => setFiltersOpen(!filtersOpen)}
@@ -365,7 +367,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
             <svg className="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
             </svg>
-            Filters
+            {t('filters.toggle')}
             {activeFilterCount > 0 && (
               <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-blue-600 text-white font-semibold">
                 {activeFilterCount}
@@ -375,13 +377,13 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
         </div>
 
         {/* Filter Presets */}
-        <div className="mb-4 sm:mb-6" role="group" aria-label="Quick filter presets">
+        <div className="mb-4 sm:mb-6" role="group" aria-label={t('presets.label')}>
           <div className="flex flex-wrap gap-2">
             {FILTER_PRESETS.map(preset => (
               <button
                 key={preset.id}
                 onClick={() => applyPreset(preset)}
-                title={preset.description}
+                title={t(`presets.${preset.id}.description`)}
                 aria-pressed={activePresetId === preset.id}
                 className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${
                   activePresetId === preset.id
@@ -390,18 +392,18 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
                 }`}
               >
                 <span>{preset.icon}</span>
-                <span>{preset.label}</span>
+                <span>{t(`presets.${preset.id}.label`)}</span>
               </button>
             ))}
           </div>
           {activePreset && (
             <div className="mt-2 flex items-center gap-2">
-              <span className="text-sm text-gray-500">{activePreset.icon} {activePreset.description}</span>
+              <span className="text-sm text-gray-500">{activePreset.icon} {t(`presets.${activePreset.id}.description`)}</span>
               <button
                 onClick={clearFilters}
                 className="text-xs text-blue-600 hover:text-blue-800 underline"
               >
-                Clear preset
+                {t('presets.clearPreset')}
               </button>
             </div>
           )}
@@ -419,10 +421,10 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
 
           {/* Main */}
           <main className="flex-1 min-w-0">
-            {loading && yachts.length === 0 ? (<p className="p-8 text-center text-gray-500" role="status" aria-live="polite">Loading yachts...</p>) : yachts.length === 0 ? (
+            {loading && yachts.length === 0 ? (<p className="p-8 text-center text-gray-500" role="status" aria-live="polite">{t('loading')}</p>) : yachts.length === 0 ? (
               <div className="text-center py-12">
-                <p className="text-gray-500 mb-2">No yachts match your filters.</p>
-                <button onClick={clearFilters} className="text-blue-600 hover:underline text-sm">Clear all filters</button>
+                <p className="text-gray-500 mb-2">{t('noResults')}</p>
+                <button onClick={clearFilters} className="text-blue-600 hover:underline text-sm">{t('clearAllFilters')}</button>
               </div>
             ) : (
               <>
@@ -455,17 +457,17 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
                         <CompletenessBadge score={calculateCompletenessScore(yacht)} />
                       </div>
                       <dl className="mt-3 text-sm">
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Length:</dt><dd className="font-medium">{format(yacht.lengthOverall)} m</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Beam:</dt><dd className="font-medium">{format(yacht.beam)} m</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Draft:</dt><dd className="font-medium">{format(yacht.draft)} m</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Displacement:</dt><dd className="font-medium">{format(yacht.displacement)} kg</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Rig:</dt><dd className="font-medium">{yacht.rigType ?? '—'}</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Keel:</dt><dd className="font-medium">{yacht.keelType ?? '—'}</dd></div>
-                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">Hull:</dt><dd className="font-medium">{yacht.hullMaterial ?? '—'}</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.length')}</dt><dd className="font-medium">{format(yacht.lengthOverall)} m</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.beam')}</dt><dd className="font-medium">{format(yacht.beam)} m</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.draft')}</dt><dd className="font-medium">{format(yacht.draft)} m</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.displacement')}</dt><dd className="font-medium">{format(yacht.displacement)} kg</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.rig')}</dt><dd className="font-medium">{yacht.rigType ?? '—'}</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.keel')}</dt><dd className="font-medium">{yacht.keelType ?? '—'}</dd></div>
+                        <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.hull')}</dt><dd className="font-medium">{yacht.hullMaterial ?? '—'}</dd></div>
                       </dl>
                       {yacht.slug && (
                         <a href={`/yachts/${yacht.slug}`} className="mt-3 text-blue-600 hover:underline text-sm font-medium inline-block">
-                          View Details →
+                          {t('viewDetails')}
                         </a>
                       )}
                     </div>
@@ -474,9 +476,9 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
 
                 {totalPages > 1 && (
                   <nav className="mt-6 flex items-center justify-between text-sm" aria-label="Pagination">
-                    <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="px-4 py-2 border rounded-lg disabled:opacity-50 hover:bg-gray-50 transition-colors">Previous</button>
-                    <span className="text-gray-600" aria-live="polite">Page {page} of {totalPages} <span className="text-gray-500">({total} total)</span></span>
-                    <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-4 py-2 border rounded-lg disabled:opacity-50 hover:bg-gray-50 transition-colors">Next</button>
+                    <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="px-4 py-2 border rounded-lg disabled:opacity-50 hover:bg-gray-50 transition-colors">{t('pagination.previous')}</button>
+                    <span className="text-gray-600" aria-live="polite">{t('pagination.pageInfo', { page, totalPages })} <span className="text-gray-500">{t('pagination.total', { total })}</span></span>
+                    <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-4 py-2 border rounded-lg disabled:opacity-50 hover:bg-gray-50 transition-colors">{t('pagination.next')}</button>
                   </nav>
                 )}
               </>
@@ -508,34 +510,34 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
               <button
                 onClick={closeModal}
                 className="text-gray-500 hover:text-gray-700 text-2xl leading-none flex-shrink-0"
-                aria-label="Close modal"
+                aria-label={t('modal.close')}
               >
                 &times;
               </button>
             </div>
             <p className="text-gray-600 mb-4">{selectedYacht.year ?? ''}</p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Length Overall:</span> <span className="font-medium">{format(selectedYacht.lengthOverall)} m</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Beam:</span> <span className="font-medium">{format(selectedYacht.beam)} m</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Draft:</span> <span className="font-medium">{format(selectedYacht.draft)} m</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Displacement:</span> <span className="font-medium">{format(selectedYacht.displacement)} kg</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Ballast:</span> <span className="font-medium">{format(selectedYacht.ballast)} kg</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Sail Area:</span> <span className="font-medium">{format(selectedYacht.sailAreaMain)} m²</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Rig Type:</span> <span className="font-medium">{selectedYacht.rigType ?? '—'}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Keel Type:</span> <span className="font-medium">{selectedYacht.keelType ?? '—'}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Hull:</span> <span className="font-medium">{selectedYacht.hullMaterial ?? '—'}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Cabins:</span> <span className="font-medium">{format(selectedYacht.cabins)}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Berths:</span> <span className="font-medium">{format(selectedYacht.berths)}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Heads:</span> <span className="font-medium">{format(selectedYacht.heads)}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Max Occupancy:</span> <span className="font-medium">{format(selectedYacht.maxOccupancy)}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Engine HP:</span> <span className="font-medium">{format(selectedYacht.engineHp)}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Engine:</span> <span className="font-medium">{selectedYacht.engineType ?? '—'}</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Fuel:</span> <span className="font-medium">{format(selectedYacht.fuelCapacity)} L</span></div>
-              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">Water:</span> <span className="font-medium">{format(selectedYacht.waterCapacity)} L</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.lengthOverall')}</span> <span className="font-medium">{format(selectedYacht.lengthOverall)} m</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.beam')}</span> <span className="font-medium">{format(selectedYacht.beam)} m</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.draft')}</span> <span className="font-medium">{format(selectedYacht.draft)} m</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.displacement')}</span> <span className="font-medium">{format(selectedYacht.displacement)} kg</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.ballast')}</span> <span className="font-medium">{format(selectedYacht.ballast)} kg</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.sailArea')}</span> <span className="font-medium">{format(selectedYacht.sailAreaMain)} m²</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.rigType')}</span> <span className="font-medium">{selectedYacht.rigType ?? '—'}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.keelType')}</span> <span className="font-medium">{selectedYacht.keelType ?? '—'}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.hull')}</span> <span className="font-medium">{selectedYacht.hullMaterial ?? '—'}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.cabins')}</span> <span className="font-medium">{format(selectedYacht.cabins)}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.berths')}</span> <span className="font-medium">{format(selectedYacht.berths)}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.heads')}</span> <span className="font-medium">{format(selectedYacht.heads)}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.maxOccupancy')}</span> <span className="font-medium">{format(selectedYacht.maxOccupancy)}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.engineHp')}</span> <span className="font-medium">{format(selectedYacht.engineHp)}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.engine')}</span> <span className="font-medium">{selectedYacht.engineType ?? '—'}</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.fuel')}</span> <span className="font-medium">{format(selectedYacht.fuelCapacity)} L</span></div>
+              <div className="flex justify-between sm:block"><span className="text-gray-500 sm:text-xs sm:uppercase sm:tracking-wide">{t('specs.water')}</span> <span className="font-medium">{format(selectedYacht.waterCapacity)} L</span></div>
             </div>
             {selectedYacht.description && (
               <div className="mt-4 pt-4 border-t">
-                <h3 className="font-semibold text-sm text-gray-500 uppercase tracking-wide mb-1">Description</h3>
+                <h3 className="font-semibold text-sm text-gray-500 uppercase tracking-wide mb-1">{t('specs.description')}</h3>
                 <p className="text-gray-700 text-sm leading-relaxed">{selectedYacht.description}</p>
               </div>
             )}
@@ -546,7 +548,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
                   href={`/yachts/${selectedYacht.slug}`}
                   className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 font-medium text-sm"
                 >
-                  View Full Spec Sheet →
+                  {t('viewFullSpec')}
                 </a>
               </div>
             )}

--- a/app/[locale]/yachts/page.tsx
+++ b/app/[locale]/yachts/page.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next";
-import { generateYachtsListMetadata, generateBreadcrumbJsonLd, generateCollectionPageJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, generateCollectionPageJsonLd, getSiteUrl } from "@/lib/seo";
 import { Suspense } from "react";
 import dynamic from "next/dynamic";
 const YachtsClient = dynamic(() => import("./YachtsClient"), { ssr: false, loading: () => null });
 import { shouldNoindexYachtsPage, generateYachtsPageCanonical } from "@/lib/thin-page-governance";
 import { getYachtsListing, getFilterOptions, type YachtsListingResult, type FilterOptions } from "@/lib/yachts";
+import { getTranslations } from "next-intl/server";
 
 // Revalidate every 60 minutes — yacht list doesn't change frequently
 export const revalidate = 3600;
 
 interface YachtsPageParams {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{
     page?: string;
     'filters[manufacturers]'?: string[];
@@ -29,31 +31,32 @@ interface YachtsPageParams {
  * Generate dynamic metadata for yachts page based on search params.
  * Implements thin-page governance with canonical URLs and noindex rules.
  */
-export async function generateMetadata({ searchParams }: YachtsPageParams): Promise<Metadata> {
-  const params = await searchParams;
+export async function generateMetadata({ params, searchParams }: YachtsPageParams): Promise<Metadata> {
+  const { locale } = await params;
+  const sp = await searchParams;
+  const t = await getTranslations({ locale, namespace: "Yachts" });
 
   const normalizedParams = {
-    page: params.page,
-    manufacturers: params['filters[manufacturers]'],
-    rigType: params['filters[rigType]'],
-    keelType: params['filters[keelType]'],
-    hullMaterial: params['filters[hullMaterial]'],
-    lengthMin: params['filters[lengthMin]'],
-    lengthMax: params['filters[lengthMax]'],
-    displacementMin: params['filters[displacementMin]'],
-    displacementMax: params['filters[displacementMax]'],
-    cabinsMin: params['filters[cabinsMin]'],
-    cabinsMax: params['filters[cabinsMax]'],
+    page: sp.page,
+    manufacturers: sp['filters[manufacturers]'],
+    rigType: sp['filters[rigType]'],
+    keelType: sp['filters[keelType]'],
+    hullMaterial: sp['filters[hullMaterial]'],
+    lengthMin: sp['filters[lengthMin]'],
+    lengthMax: sp['filters[lengthMax]'],
+    displacementMin: sp['filters[displacementMin]'],
+    displacementMax: sp['filters[displacementMax]'],
+    cabinsMin: sp['filters[cabinsMin]'],
+    cabinsMax: sp['filters[cabinsMax]'],
   };
 
   const noindex = shouldNoindexYachtsPage(normalizedParams);
   const canonicalPath = generateYachtsPageCanonical(normalizedParams);
   const canonicalUrl = getSiteUrl(canonicalPath);
 
-  const baseMetadata = generateYachtsListMetadata();
-
   return {
-    ...baseMetadata,
+    title: t("meta.title"),
+    description: t("meta.description"),
     alternates: {
       canonical: canonicalUrl,
     },
@@ -63,12 +66,15 @@ export async function generateMetadata({ searchParams }: YachtsPageParams): Prom
   };
 }
 
-export default async function YachtsPage({ searchParams }: YachtsPageParams) {
+export default async function YachtsPage({ params, searchParams }: YachtsPageParams) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Yachts" });
+
   // Fetch default listing data server-side for SEO
   // Only pre-fetch for the default (no-filter) view — filtered views use client-side fetching
-  const params = await searchParams;
-  const hasFilters = Object.keys(params).some(k => k.startsWith('filters['));
-  const page = parseInt(params.page || '1', 10);
+  const sp = await searchParams;
+  const hasFilters = Object.keys(sp).some(k => k.startsWith('filters['));
+  const page = parseInt(sp.page || '1', 10);
 
   let initialData: YachtsListingResult | null = null;
   let filterOptions: FilterOptions | null = null;
@@ -87,12 +93,12 @@ export default async function YachtsPage({ searchParams }: YachtsPageParams) {
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
-    { name: "Browse Yachts" },
+    { name: t("heading") },
   ]);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
-    name: "Browse Sailing Yacht Info",
-    description: "Search and filter sailing yachts by manufacturer, length, year, and more.",
+    name: t("meta.title"),
+    description: t("meta.description"),
     url: getSiteUrl("/yachts"),
   });
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -113,5 +113,111 @@
     "en": "English",
     "fr": "Français",
     "switchTo": "Switch to {language}"
+  },
+  "Yachts": {
+    "meta": {
+      "title": "Browse Sailing Yachts — Sailing Yacht Info",
+      "description": "Search and filter sailing yachts by manufacturer, length, year, and more."
+    },
+    "heading": "Sail Yachts",
+    "loading": "Loading yachts...",
+    "noResults": "No yachts match your filters.",
+    "clearAllFilters": "Clear all filters",
+    "filters": {
+      "heading": "Filters",
+      "activeCount": "{count} active",
+      "manufacturer": "Manufacturer",
+      "rigType": "Rig Type",
+      "keelType": "Keel Type",
+      "hullMaterial": "Hull Material",
+      "noOptions": "No options",
+      "clearFilters": "Clear Filters",
+      "toggle": "Filters"
+    },
+    "presets": {
+      "label": "Quick filter presets",
+      "clearPreset": "Clear preset",
+      "bluewater": {
+        "label": "Bluewater Cruisers",
+        "description": "Ocean-ready yachts 35–55ft with heavy displacement and proven keel designs"
+      },
+      "racing": {
+        "label": "Racing Yachts",
+        "description": "Light, fast yachts with performance rigs and fin/bulb keels"
+      },
+      "budget": {
+        "label": "Budget Friendly",
+        "description": "Affordable compact cruisers under 30ft, great for first-time buyers"
+      },
+      "family": {
+        "label": "Family Cruisers",
+        "description": "Comfortable cruising yachts with 3+ cabins, 30–45ft"
+      }
+    },
+    "specs": {
+      "length": "Length:",
+      "beam": "Beam:",
+      "draft": "Draft:",
+      "displacement": "Displacement:",
+      "rig": "Rig:",
+      "keel": "Keel:",
+      "hull": "Hull:",
+      "lengthOverall": "Length Overall:",
+      "ballast": "Ballast:",
+      "sailArea": "Sail Area:",
+      "rigType": "Rig Type:",
+      "keelType": "Keel Type:",
+      "cabins": "Cabins:",
+      "berths": "Berths:",
+      "heads": "Heads:",
+      "maxOccupancy": "Max Occupancy:",
+      "engineHp": "Engine HP:",
+      "engine": "Engine:",
+      "fuel": "Fuel:",
+      "water": "Water:",
+      "description": "Description"
+    },
+    "viewDetails": "View Details →",
+    "viewFullSpec": "View Full Spec Sheet →",
+    "pagination": {
+      "previous": "Previous",
+      "next": "Next",
+      "pageInfo": "Page {page} of {totalPages}",
+      "total": "({total} total)"
+    },
+    "modal": {
+      "close": "Close modal"
+    }
+  },
+  "Search": {
+    "meta": {
+      "title": "Search Yachts — Sailing Yacht Info",
+      "description": "Search sailing yachts by manufacturer, model name, rig type, keel type, and more."
+    },
+    "heading": "Search Yachts",
+    "subtitle": "Find sailing yachts by manufacturer, model, or specifications",
+    "placeholder": "Search by manufacturer, model name, rig type...",
+    "searchButton": "Search",
+    "searching": "Searching...",
+    "hint": "Type at least 2 characters for suggestions. Press Enter to search.",
+    "results": {
+      "count": "{total} yacht{total, plural, one {} other {s}} found",
+      "searching": "Searching...",
+      "for": "for",
+      "loa": "LOA",
+      "beam": "Beam",
+      "draft": "Draft"
+    },
+    "saveSearch": "Save Search",
+    "saved": "Saved!",
+    "saveFailed": "Failed",
+    "empty": {
+      "heading": "No yachts found",
+      "description": "Try searching with different keywords"
+    },
+    "popular": "Popular searches",
+    "suggestions": {
+      "label": "Search suggestions"
+    }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -113,5 +113,111 @@
     "en": "English",
     "fr": "Français",
     "switchTo": "Passer en {language}"
+  },
+  "Yachts": {
+    "meta": {
+      "title": "Parcourir les yachts à voile — Sailing Yacht Info",
+      "description": "Recherchez et filtrez les yachts à voile par constructeur, longueur, année et plus encore."
+    },
+    "heading": "Yachts à voile",
+    "loading": "Chargement des yachts...",
+    "noResults": "Aucun yacht ne correspond à vos filtres.",
+    "clearAllFilters": "Effacer tous les filtres",
+    "filters": {
+      "heading": "Filtres",
+      "activeCount": "{count} actif{count, plural, one {} other {s}}",
+      "manufacturer": "Constructeur",
+      "rigType": "Type de gréement",
+      "keelType": "Type de quille",
+      "hullMaterial": "Matériau de coque",
+      "noOptions": "Aucune option",
+      "clearFilters": "Effacer les filtres",
+      "toggle": "Filtres"
+    },
+    "presets": {
+      "label": "Filtres rapides",
+      "clearPreset": "Effacer le filtre",
+      "bluewater": {
+        "label": "Croiseurs hauturiers",
+        "description": "Yachts prêts pour l'océan de 35 à 55 pi avec un déplacement lourd et des quilles éprouvées"
+      },
+      "racing": {
+        "label": "Yachts de course",
+        "description": "Yachts légers et rapides avec gréements de performance et quilles à bulbe"
+      },
+      "budget": {
+        "label": "Petit budget",
+        "description": "Croiseurs compacts abordables de moins de 30 pi, idéaux pour les premiers acheteurs"
+      },
+      "family": {
+        "label": "Croiseurs familiaux",
+        "description": "Yachts de croisière confortables avec 3+ cabines, de 30 à 45 pi"
+      }
+    },
+    "specs": {
+      "length": "Longueur :",
+      "beam": "Bau :",
+      "draft": "Tirant d'eau :",
+      "displacement": "Déplacement :",
+      "rig": "Gréement :",
+      "keel": "Quille :",
+      "hull": "Coque :",
+      "lengthOverall": "Longueur hors tout :",
+      "ballast": "Lest :",
+      "sailArea": "Surface de voilure :",
+      "rigType": "Type de gréement :",
+      "keelType": "Type de quille :",
+      "cabins": "Cabines :",
+      "berths": "Couchettes :",
+      "heads": "Toilettes :",
+      "maxOccupancy": "Capacité max :",
+      "engineHp": "Puissance moteur :",
+      "engine": "Moteur :",
+      "fuel": "Carburant :",
+      "water": "Eau :",
+      "description": "Description"
+    },
+    "viewDetails": "Voir les détails →",
+    "viewFullSpec": "Voir la fiche complète →",
+    "pagination": {
+      "previous": "Précédent",
+      "next": "Suivant",
+      "pageInfo": "Page {page} sur {totalPages}",
+      "total": "({total} au total)"
+    },
+    "modal": {
+      "close": "Fermer la fenêtre"
+    }
+  },
+  "Search": {
+    "meta": {
+      "title": "Rechercher des yachts — Sailing Yacht Info",
+      "description": "Recherchez des yachts à voile par constructeur, nom de modèle, type de gréement, type de quille et plus encore."
+    },
+    "heading": "Rechercher des yachts",
+    "subtitle": "Trouvez des yachts à voile par constructeur, modèle ou spécifications",
+    "placeholder": "Recherchez par constructeur, nom de modèle, type de gréement...",
+    "searchButton": "Rechercher",
+    "searching": "Recherche en cours...",
+    "hint": "Tapez au moins 2 caractères pour les suggestions. Appuyez sur Entrée pour rechercher.",
+    "results": {
+      "count": "{total} yacht{total, plural, one {} other {s}} trouvé{total, plural, one {} other {s}}",
+      "searching": "Recherche en cours...",
+      "for": "pour",
+      "loa": "LOA",
+      "beam": "Bau",
+      "draft": "Tirant d'eau"
+    },
+    "saveSearch": "Enregistrer la recherche",
+    "saved": "Enregistré !",
+    "saveFailed": "Échec",
+    "empty": {
+      "heading": "Aucun yacht trouvé",
+      "description": "Essayez avec d'autres mots-clés"
+    },
+    "popular": "Recherches populaires",
+    "suggestions": {
+      "label": "Suggestions de recherche"
+    }
   }
 }

--- a/tests/i18n-yachts-search.test.ts
+++ b/tests/i18n-yachts-search.test.ts
@@ -1,0 +1,196 @@
+/**
+ * i18n message catalog validation tests for Yachts & Search namespaces.
+ *
+ * Ensures both en.json and fr.json have identical key structures
+ * for the Yachts and Search translation namespaces, and that
+ * no keys are missing or have empty values.
+ */
+import { describe, it, expect } from "vitest";
+import en from "../messages/en.json";
+import fr from "../messages/fr.json";
+
+type NestedKeys = string[];
+
+function collectKeys(obj: unknown, prefix = ""): NestedKeys {
+  if (typeof obj !== "object" || obj === null) return [];
+  const keys: NestedKeys = [];
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === "object" && v !== null) {
+      keys.push(...collectKeys(v, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}
+
+describe("i18n message catalogs — Yachts namespace", () => {
+  const enKeys = new Set(collectKeys(en.Yachts));
+  const frKeys = new Set(collectKeys(fr.Yachts));
+
+  it("en.json has Yachts namespace", () => {
+    expect(en.Yachts).toBeDefined();
+    expect(typeof en.Yachts).toBe("object");
+  });
+
+  it("fr.json has Yachts namespace", () => {
+    expect(fr.Yachts).toBeDefined();
+    expect(typeof fr.Yachts).toBe("object");
+  });
+
+  it("fr.json has all keys from en.json Yachts", () => {
+    const missing = Array.from(enKeys).filter(k => !frKeys.has(k));
+    expect(missing, `Missing keys in fr.json Yachts: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("en.json has all keys from fr.json Yachts", () => {
+    const extra = Array.from(frKeys).filter(k => !enKeys.has(k));
+    expect(extra, `Extra keys in fr.json Yachts: ${extra.join(", ")}`).toEqual([]);
+  });
+
+  it("no empty French translations in Yachts", () => {
+    const emptyKeys = Array.from(frKeys).filter(k => {
+      const parts = k.split(".");
+      let val: unknown = fr.Yachts;
+      for (const p of parts) val = (val as Record<string, unknown>)[p];
+      return typeof val === "string" && val.trim() === "";
+    });
+    expect(emptyKeys, `Empty translations in fr.json Yachts: ${emptyKeys.join(", ")}`).toEqual([]);
+  });
+
+  // Spot-check critical keys
+  const criticalKeys = [
+    "heading",
+    "loading",
+    "noResults",
+    "clearAllFilters",
+    "filters.heading",
+    "filters.manufacturer",
+    "filters.rigType",
+    "filters.keelType",
+    "filters.hullMaterial",
+    "filters.clearFilters",
+    "presets.bluewater.label",
+    "presets.racing.label",
+    "presets.budget.label",
+    "presets.family.label",
+    "presets.bluewater.description",
+    "presets.racing.description",
+    "presets.budget.description",
+    "presets.family.description",
+    "specs.length",
+    "specs.beam",
+    "specs.draft",
+    "specs.displacement",
+    "specs.cabins",
+    "specs.berths",
+    "specs.heads",
+    "viewDetails",
+    "viewFullSpec",
+    "pagination.previous",
+    "pagination.next",
+    "pagination.pageInfo",
+    "pagination.total",
+    "modal.close",
+  ];
+
+  it.each(criticalKeys)("has critical key Yachts.%s in en.json", (key) => {
+    expect(enKeys.has(key), `Missing Yachts.${key} in en.json`).toBe(true);
+  });
+
+  it.each(criticalKeys)("has critical key Yachts.%s in fr.json", (key) => {
+    expect(frKeys.has(key), `Missing Yachts.${key} in fr.json`).toBe(true);
+  });
+});
+
+describe("i18n message catalogs — Search namespace", () => {
+  const enKeys = new Set(collectKeys(en.Search));
+  const frKeys = new Set(collectKeys(fr.Search));
+
+  it("en.json has Search namespace", () => {
+    expect(en.Search).toBeDefined();
+    expect(typeof en.Search).toBe("object");
+  });
+
+  it("fr.json has Search namespace", () => {
+    expect(fr.Search).toBeDefined();
+    expect(typeof fr.Search).toBe("object");
+  });
+
+  it("fr.json has all keys from en.json Search", () => {
+    const missing = Array.from(enKeys).filter(k => !frKeys.has(k));
+    expect(missing, `Missing keys in fr.json Search: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("en.json has all keys from fr.json Search", () => {
+    const extra = Array.from(frKeys).filter(k => !enKeys.has(k));
+    expect(extra, `Extra keys in fr.json Search: ${extra.join(", ")}`).toEqual([]);
+  });
+
+  it("no empty French translations in Search", () => {
+    const emptyKeys = Array.from(frKeys).filter(k => {
+      const parts = k.split(".");
+      let val: unknown = fr.Search;
+      for (const p of parts) val = (val as Record<string, unknown>)[p];
+      return typeof val === "string" && val.trim() === "";
+    });
+    expect(emptyKeys, `Empty translations in fr.json Search: ${emptyKeys.join(", ")}`).toEqual([]);
+  });
+
+  // Spot-check critical keys
+  const criticalKeys = [
+    "heading",
+    "subtitle",
+    "placeholder",
+    "searchButton",
+    "searching",
+    "hint",
+    "results.count",
+    "results.searching",
+    "results.for",
+    "results.loa",
+    "results.beam",
+    "results.draft",
+    "saveSearch",
+    "saved",
+    "saveFailed",
+    "empty.heading",
+    "empty.description",
+    "popular",
+    "suggestions.label",
+    "meta.title",
+    "meta.description",
+  ];
+
+  it.each(criticalKeys)("has critical key Search.%s in en.json", (key) => {
+    expect(enKeys.has(key), `Missing Search.${key} in en.json`).toBe(true);
+  });
+
+  it.each(criticalKeys)("has critical key Search.%s in fr.json", (key) => {
+    expect(frKeys.has(key), `Missing Search.${key} in fr.json`).toBe(true);
+  });
+});
+
+describe("i18n filter presets translations", () => {
+  it("all preset IDs have translations in both locales", () => {
+    const presetIds = ["bluewater", "racing", "budget", "family"];
+    for (const id of presetIds) {
+      // EN
+      expect(en.Yachts.presets[id as keyof typeof en.Yachts.presets]).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const enPreset = (en.Yachts.presets as any)[id];
+      expect(enPreset.label).toBeTruthy();
+      expect(enPreset.description).toBeTruthy();
+
+      // FR
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const frPreset = (fr.Yachts.presets as any)[id];
+      expect(frPreset.label).toBeTruthy();
+      expect(frPreset.description).toBeTruthy();
+
+      // FR should be different from EN (actually translated)
+      expect(frPreset.label).not.toBe(enPreset.label);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Implements P14.2 — French translations for yacht listing & search pages (closes #229).

### Changes
- **messages/en.json & messages/fr.json**: Added `Yachts` and `Search` translation namespaces with all UI strings
- **YachtsClient.tsx**: Converted all hardcoded strings to `useTranslations('Yachts')` — filters, spec labels, pagination, modal, filter presets
- **SearchClient.tsx**: Converted all hardcoded strings to `useTranslations('Search')` — heading, placeholder, results, empty state, popular searches
- **yachts/page.tsx & search/page.tsx**: Server-side metadata and breadcrumbs now use `getTranslations` for localized SEO
- **Filter presets**: All 4 presets (Bluewater Cruisers, Racing Yachts, Budget Friendly, Family Cruisers) now have French translations
- **tests/i18n-yachts-search.test.ts**: 117 vitest tests validating key parity, non-empty translations, and critical key coverage

### French translations include
- Filter headings: Constructeur, Type de gréement, Type de quille, Matériau de coque
- Spec labels: Longueur, Bau, Tirant d'eau, Déplacement, Gréement, Quille, Coque, Cabines, Couchettes, etc.
- Pagination: Précédent, Suivant, Page X sur Y
- Filter presets: Croiseurs hauturiers, Yachts de course, Petit budget, Croiseurs familiaux
- Search: Rechercher des yachts, placeholder, résultats, recherches populaires

### Test Results
- ✅ Typecheck: Pass
- ✅ Build: Pass
- ✅ Vitest: 117/117 tests pass

### Verification
- /en/yachts and /fr/yachts should render with translated UI
- /en/search and /fr/search should render with translated UI
- All filter presets, spec labels, and pagination controls should be in the correct language