### PR TITLE
fix(i18n): pass locale to getMessages() for correct client translations

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -22,7 +22,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
   }
 
   // Providing all messages to the client side
-  const messages = await getMessages();
+  const messages = await getMessages({ locale });
   const t = await getTranslations({ locale, namespace: "Layout" });
 
   const navItems = [


### PR DESCRIPTION
## Fix: Client components showing English on /fr/ routes

### Problem
All client-side components using `useTranslations()` rendered in English even on `/fr/` routes. Server-side `getTranslations({ locale })` worked correctly because it received the locale from params.

### Root Cause
`getMessages()` in `app/[locale]/layout.tsx` was called without a locale parameter. In next-intl v4.9.1, it fell back to the default locale (en) instead of using the URL segment locale. This meant `NextIntlClientProvider` passed English messages to all client components.

### Fix
Pass locale explicitly: `getMessages({ locale })`

### Impact
- Fixes P14.1 and P14.2 client-side translations (navigation, footer, yachts listing, search were also affected)
- Fixes P14.3 client-side translations (yacht detail, compare)

### Testing
- Typecheck: ✅
- Build: ✅