### PR TITLE
fix(i18n): pass locale prop to NextIntlClientProvider

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -35,7 +35,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
   ];
 
   return (
-    <NextIntlClientProvider messages={messages}>
+    <NextIntlClientProvider locale={locale} messages={messages}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Fix: NextIntlClientProvider missing locale prop

The `NextIntlClientProvider` was receiving French messages (from the getMessages fix in PR #234) but still defaulting its `locale` prop to `en`. This caused `useTranslations()` in client components to not resolve locale-aware features correctly.

### Fix
Pass `locale={locale}` explicitly to `NextIntlClientProvider`.

Typecheck: ✅ Build: ✅