### PR TITLE
feat(seo): French SEO & metadata — hreflang, localized sitemaps, French JSON-LD, French RSS (closes #238)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -8,7 +8,7 @@ The site lives on `info.sailboats.fr` (a French domain) and cross-links with `sa
 
 - ~~**P14.3 — French translations for yacht detail & comparison pages:** Translate yacht detail page labels (specs table headers, performance ratios, "Who is this boat for?", related yachts section). Translate compare page headers and labels. Tests: French rendering tests for detail and compare pages. *(completed 2026-04-28 — PR #232 + hotfix PRs #234 #235 for getMessages locale bug & NextIntlClientProvider locale prop)*
 
-- [ ] **P14.4 — French translations for manufacturers, guides & glossary:** Translate manufacturer listing page, guide pages, and glossary pages. Add French glossary descriptions alongside English. Tests: French rendering tests for content pages.
+- ~~**P14.4 — French translations for manufacturers, guides & glossary:** Translate manufacturer listing page, guide pages, and glossary pages. Add French glossary descriptions alongside English. Tests: French rendering tests for content pages.~~ *(completed 2026-04-28 — PR #237)*
 
 - [ ] **P14.5 — French SEO & metadata:** Add French meta tags, JSON-LD, Open Graph, alternate hreflang tags (en/fr), French sitemap entries, and French RSS feed. Tests: SEO metadata tests for both locales.
 
@@ -21,4 +21,4 @@ The site lives on `info.sailboats.fr` (a French domain) and cross-links with `sa
 - UI strings, labels, descriptions, and SEO metadata get translated.
 - **⚠️ P14.1 gotcha:** `t.rich()` in `next-intl` v4 with RSC passes functions across server→client boundary, causing 500 errors. Use `t()` + direct JSX composition instead.
 - **⚠️ P14.3 gotcha:** `getMessages()` without explicit `{ locale }` falls back to default locale (en) for client components. Also `NextIntlClientProvider` needs explicit `locale={locale}` prop. Both must be set in `app/[locale]/layout.tsx`.
-- **Phase 14 is in progress.** P14.1–P14.3 complete, P14.4–P14.6 remaining.
+- **Phase 14 is in progress.** P14.1–P14.4 complete, P14.5–P14.6 remaining.

--- a/app/[locale]/best-value/[slug]/page.tsx
+++ b/app/[locale]/best-value/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { pool } from "@/lib/db";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 
 // ISR: Revalidate every 6 hours
 export const revalidate = 21600;
@@ -96,9 +96,9 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const pageDef = BEST_VALUE_PAGES.find((p) => p.slug === slug);
 
   if (!pageDef) {
@@ -122,9 +122,7 @@ export async function generateMetadata({
       type: "website",
       siteName: "Sailing Yacht Info",
     },
-    alternates: {
-      canonical: getSiteUrl(`/best-value/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/best-value/${slug}`),
   };
 }
 
@@ -282,9 +280,9 @@ function formatPrice(
 export default async function BestValuePage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const pageDef = BEST_VALUE_PAGES.find((p) => p.slug === slug);
 
   if (!pageDef) {
@@ -308,7 +306,7 @@ export default async function BestValuePage({
     { name: "Yachts", path: "/yachts" },
     { name: "Best Value", path: "/best-value" },
     { name: pageDef.title },
-  ]);
+  ], locale);
 
   const collectionJsonLd = {
     "@context": "https://schema.org",

--- a/app/[locale]/best-value/page.tsx
+++ b/app/[locale]/best-value/page.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getSiteUrl } from "@/lib/seo";
+import { getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Best Value Sailboats — Ranked by Specs-Per-Dollar",
   description:
     "Find the best value sailing yachts ranked by our proprietary value score. Compare specs, accommodation, and pricing to spot the smartest buys.",
-  alternates: {
-    canonical: getSiteUrl("/best-value"),
-  },
+  alternates: buildLocaleAlternates("/best-value"),
 };
 
 const BEST_VALUE_CATEGORIES = [

--- a/app/[locale]/best/[slug]/page.tsx
+++ b/app/[locale]/best/[slug]/page.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 import { unstable_cache } from "next/cache";
 import { getLandingPageYachts } from "@/lib/landing-pages";
 import { getLandingPageBySlug, getAllLandingPageSlugs } from "@/data/landing-pages";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
-import { generateCollectionPageJsonLd, generateYachtJsonLd } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl, generateCollectionPageJsonLd, generateYachtJsonLd, buildLocaleAlternates } from "@/lib/seo";
 import { db, yachtModels, manufacturers } from "@/lib/db";
 import { sql, count } from "drizzle-orm";
 
@@ -20,9 +19,9 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const pageDefinition = getLandingPageBySlug(slug);
 
   if (!pageDefinition) {
@@ -45,7 +44,7 @@ export async function generateMetadata({
     openGraph: {
       title: pageDefinition.title,
       description: pageDefinition.metaDescription,
-      url: getSiteUrl(`/best/${slug}`),
+      url: getSiteUrl(`/${locale}/best/${slug}`),
       type: "website",
       siteName: "Sailing Yacht Info",
     },
@@ -54,9 +53,7 @@ export async function generateMetadata({
       title: pageDefinition.title,
       description: pageDefinition.metaDescription,
     },
-    alternates: {
-      canonical: getSiteUrl(`/best/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/best/${slug}`),
   };
 }
 
@@ -64,9 +61,9 @@ export async function generateMetadata({
 export default async function LandingPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const pageDefinition = getLandingPageBySlug(slug);
 
   if (!pageDefinition) {
@@ -98,12 +95,12 @@ export default async function LandingPage({
     { name: "Browse Yachts", path: "/yachts" },
     { name: "Best Yachts", path: "/best" },
     { name: pageDefinition.title },
-  ]);
+  ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
     name: pageDefinition.title,
     description: pageDefinition.metaDescription,
-    url: getSiteUrl(`/best/${slug}`),
+    url: getSiteUrl(`/${locale}/best/${slug}`),
     itemCount: yachts.length,
   });
 
@@ -134,7 +131,7 @@ export default async function LandingPage({
           key={yacht.id}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(generateYachtJsonLd(yacht)),
+            __html: JSON.stringify(generateYachtJsonLd(yacht, locale)),
           }}
         />
       ))}

--- a/app/[locale]/cheaper-alternatives-to/[slug]/page.tsx
+++ b/app/[locale]/cheaper-alternatives-to/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { pool } from "@/lib/db";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 
 // ISR: Revalidate every 6 hours
 export const revalidate = 21600;
@@ -37,9 +37,9 @@ interface SourceYacht {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug, locale } = await params;
 
   // Parse manufacturer-model from slug
   const sourceYacht = await getSourceYacht(slug);
@@ -66,9 +66,7 @@ export async function generateMetadata({
       type: "website",
       siteName: "Sailing Yacht Info",
     },
-    alternates: {
-      canonical: getSiteUrl(`/cheaper-alternatives-to/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/cheaper-alternatives-to/${slug}`),
   };
 }
 
@@ -194,9 +192,9 @@ function formatPrice(
 export default async function CheaperAlternativesPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const sourceYacht = await getSourceYacht(slug);
 
   if (!sourceYacht) {
@@ -223,7 +221,7 @@ export default async function CheaperAlternativesPage({
       path: `/yachts/${sourceYacht.slug}`,
     },
     { name: "Cheaper Alternatives" },
-  ]);
+  ], locale);
 
   return (
     <>

--- a/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getYachtsBySlugs, generateComparisonIntro, generateComparisonMetadata, getPrimaryImage, type YachtComparisonData } from "@/lib/compare-canonical";
-import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd , buildLocaleAlternates } from "@/lib/seo";
 import { PriceTierBadge } from "@/app/components/PriceTierBadge";
 import { calculatePriceTier } from "@/lib/price-tier";
 
@@ -12,9 +12,9 @@ export const revalidate = 21600;
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slugA: string; slugB: string }>;
+  params: Promise<{ slugA: string; slugB: string; locale: string }>;
 }): Promise<Metadata> {
-  const { slugA, slugB } = await params;
+  const { slugA, slugB, locale } = await params;
   const { yachtA, yachtB } = await getYachtsBySlugs(slugA, slugB);
 
   if (!yachtA || !yachtB) {
@@ -42,18 +42,16 @@ export async function generateMetadata({
       title: meta.title,
       description: meta.description,
     },
-    alternates: {
-      canonical: getSiteUrl(`/compare/${slugA}-vs-${slugB}`),
-    },
+    alternates: buildLocaleAlternates(`/compare/${slugA}-vs-${slugB}`),
   };
 }
 
 export default async function CanonicalComparePage({
   params,
 }: {
-  params: Promise<{ slugA: string; slugB: string }>;
+  params: Promise<{ slugA: string; slugB: string; locale: string }>;
 }) {
-  const { slugA, slugB } = await params;
+  const { slugA, slugB, locale } = await params;
   const { yachtA, yachtB } = await getYachtsBySlugs(slugA, slugB);
 
   if (!yachtA || !yachtB) {
@@ -91,7 +89,7 @@ export default async function CanonicalComparePage({
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Compare Yachts", path: "/compare" },
     { name: `${fullNameA} vs ${fullNameB}` },
-  ]);
+  ], locale);
 
   // Generate individual yacht JSON-LD
   const yachtALdData = {
@@ -134,13 +132,13 @@ export default async function CanonicalComparePage({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(generateYachtJsonLd(yachtALdData)),
+          __html: JSON.stringify(generateYachtJsonLd(yachtALdData, locale)),
         }}
       />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(generateYachtJsonLd(yachtBLdData)),
+          __html: JSON.stringify(generateYachtJsonLd(yachtBLdData, locale)),
         }}
       />
 

--- a/app/[locale]/compare/page.tsx
+++ b/app/[locale]/compare/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { generateCompareMetadata, generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateCompareMetadata, generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 import dynamic from "next/dynamic";
 const CompareClient = dynamic(() => import("./CompareClient").then(m => ({ default: m.CompareClient })), { ssr: false, loading: () => null });
 import { shouldNoindexComparePage } from "@/lib/thin-page-governance";
@@ -28,9 +28,7 @@ export async function generateMetadata({ searchParams }: ComparePageParams): Pro
 
   return {
     ...baseMetadata,
-    alternates: {
-      canonical: "/compare",
-    },
+    alternates: buildLocaleAlternates("/compare"),
     robots: shouldNoindexComparePage(initialIds)
       ? { index: false, follow: false }
       : { index: true, follow: true },
@@ -58,7 +56,7 @@ export default async function ComparePage({
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
     { name: t("heading") },
-  ]);
+  ], locale);
 
   return (
     <>

--- a/app/[locale]/favorites/page.tsx
+++ b/app/[locale]/favorites/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
+import { buildLocaleAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "My Favorites",
   description: "Your saved favorite sailing yachts for quick access and comparison.",
-  alternates: {
-    canonical: "/favorites",
-  },
+  alternates: buildLocaleAlternates("/favorites"),
   robots: { index: false, follow: false },
 };
 

--- a/app/[locale]/feed.xml/route.ts
+++ b/app/[locale]/feed.xml/route.ts
@@ -1,0 +1,103 @@
+import { unstable_cache } from "next/cache";
+import { db, yachtModels, manufacturers } from "@/lib/db";
+import { desc, eq } from "drizzle-orm";
+import { buildSafeQuery } from "@/lib/build-safe";
+import { getTranslations } from "next-intl/server";
+
+// ISR: Revalidate feed every hour
+export const revalidate = 3600;
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+
+// French feed channel info
+const CHANNEL_INFO: Record<string, { title: string; description: string }> = {
+  en: {
+    title: "Sailing Yacht Info",
+    description: "Latest sailing yacht specifications and updates",
+  },
+  fr: {
+    title: "Sailing Yacht Info — Voiliers",
+    description: "Spécifications et actualités des voiliers",
+  },
+};
+
+async function getFeedItems(locale: string) {
+  return unstable_cache(
+    async () => {
+      const items = await buildSafeQuery(
+        async () => {
+          const yachts = await db
+            .select({
+              yacht: yachtModels,
+              manufacturer: manufacturers.name,
+            })
+            .from(yachtModels)
+            .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+            .orderBy(desc(yachtModels.createdAt))
+            .limit(50);
+
+          return yachts.map((row: any) => {
+            const name = `${row.manufacturer || "Unknown"} ${row.yacht.modelName}`;
+            const link = row.yacht.slug ? `${SITE_URL}/${locale}/yachts/${row.yacht.slug}` : "";
+            const desc =
+              row.yacht.description ||
+              `${name} — ${row.yacht.year} sailing yacht specifications.`;
+            const pubDate = row.yacht.createdAt
+              ? new Date(row.yacht.createdAt).toUTCString()
+              : new Date().toUTCString();
+
+            return `    <item>
+      <title><![CDATA[${name} (${row.yacht.year})]]></title>
+      <link>${link}</link>
+      <description><![CDATA[${desc}]]></description>
+      <pubDate>${pubDate}</pubDate>
+      <guid isPermaLink="true">${link}</guid>
+    </item>`;
+          }).join("\n");
+        },
+        []
+      );
+      return items;
+    },
+    [`feed-items-${locale}`],
+    { tags: ["yachts"], revalidate: 3600 }
+  )();
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ locale: string }> }
+) {
+  const { locale } = await params;
+  const channelInfo = CHANNEL_INFO[locale] || CHANNEL_INFO.en;
+  const items = await getFeedItems(locale);
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${channelInfo.title}</title>
+    <description>${channelInfo.description}</description>
+    <link>${SITE_URL}/${locale}</link>
+    <atom:link href="${SITE_URL}/${locale}/feed.xml" rel="self" type="application/rss+xml" />
+    <language>${locale === "fr" ? "fr" : "en"}</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <generator>Sailing Yacht Info</generator>
+    ${items.length > 0 ? items : `
+    <item>
+      <title>${locale === "fr" ? "Base de données en construction" : "Building Database"}</title>
+      <link>${SITE_URL}/${locale}</link>
+      <description>${locale === "fr" ? "La base de données de voiliers est en cours de construction." : "The sailing yacht database is currently building."}</description>
+      <pubDate>${new Date().toUTCString()}</pubDate>
+      <guid isPermaLink="true">${SITE_URL}/${locale}</guid>
+    </item>`}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=600",
+    },
+  });
+}

--- a/app/[locale]/glossary/[slug]/page.tsx
+++ b/app/[locale]/glossary/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getTermBySlug, getRelatedTerms } from "@/lib/glossary";
-import { getSiteUrl, generateBreadcrumbJsonLd } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd , buildLocaleAlternates } from "@/lib/seo";
 
 // ISR: Revalidate glossary term pages every 6 hours
 export const revalidate = 21600;
@@ -51,9 +51,7 @@ export async function generateMetadata({
       title: `${term.term} – Sailing Glossary`,
       description,
     },
-    alternates: {
-      canonical: getSiteUrl(`/glossary/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/glossary/${slug}`),
   };
 }
 

--- a/app/[locale]/glossary/page.tsx
+++ b/app/[locale]/glossary/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { getAllGlossaryTerms, getGlossaryCategories } from "@/lib/glossary";
-import { getSiteUrl, generateBreadcrumbJsonLd, generateCollectionPageJsonLd } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd, generateCollectionPageJsonLd , buildLocaleAlternates } from "@/lib/seo";
 
 // ISR: Revalidate glossary every 6 hours
 export const revalidate = 21600;
@@ -49,9 +49,7 @@ export async function generateMetadata({
       title: t("meta.title"),
       description: t("meta.description", { count: terms.length }),
     },
-    alternates: {
-      canonical: getSiteUrl("/glossary"),
-    },
+    alternates: buildLocaleAlternates("/glossary"),
   };
 }
 

--- a/app/[locale]/guides/[slug]/page.tsx
+++ b/app/[locale]/guides/[slug]/page.tsx
@@ -7,7 +7,7 @@ import {
   getArticleBySlug,
   getRelatedArticles,
 } from "@/lib/articles";
-import { getSiteUrl, generateBreadcrumbJsonLd } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd , buildLocaleAlternates } from "@/lib/seo";
 import NewsletterSignup from "@/components/NewsletterSignup";
 import BuyingGuideYachtList from "@/components/BuyingGuideYachtList";
 import { getTemplateById } from "@/lib/buying-guides";
@@ -120,9 +120,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       title: article.title,
       description: article.excerpt || undefined,
     },
-    alternates: {
-      canonical: url,
-    },
+    alternates: buildLocaleAlternates(`/guides/${slug}`),
   };
 }
 
@@ -149,7 +147,7 @@ export default async function GuideArticlePage({ params }: PageProps) {
     { name: "Home", path: "/" },
     { name: "Guides", path: "/guides" },
     { name: article.title, path: `/guides/${article.slug}` },
-  ]);
+  ], locale);
 
   const articleUrl = getSiteUrl(`/guides/${article.slug}`);
   const wordCount = countWords(contentHtml);

--- a/app/[locale]/guides/feed.xml/route.ts
+++ b/app/[locale]/guides/feed.xml/route.ts
@@ -3,16 +3,34 @@ import { getSiteUrl } from "@/lib/seo";
 
 export const revalidate = 3600;
 
-export async function GET() {
+const CHANNEL_INFO: Record<string, { title: string; description: string }> = {
+  en: {
+    title: "Sailing Yacht Info - Guides",
+    description:
+      "Expert sailing guides, buying advice, and educational resources for yacht buyers and sailors.",
+  },
+  fr: {
+    title: "Sailing Yacht Info — Guides",
+    description:
+      "Guides experts, conseils d'achat et ressources éducatives pour les acheteurs de yachts et marins.",
+  },
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ locale: string }> }
+) {
+  const { locale } = await params;
   const articles = await getAllPublishedArticles();
   const siteUrl = getSiteUrl();
+  const channelInfo = CHANNEL_INFO[locale] || CHANNEL_INFO.en;
 
   const items = articles
     .map((article) => {
       const pubDate = article.publishedAt
         ? new Date(article.publishedAt).toUTCString()
         : new Date(article.createdAt).toUTCString();
-      const link = `${siteUrl}/guides/${article.slug}`;
+      const link = `${siteUrl}/${locale}/guides/${article.slug}`;
       return `    <item>
       <title><![CDATA[${article.title}]]></title>
       <link>${link}</link>
@@ -28,11 +46,11 @@ export async function GET() {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Sailing Yacht Info - Guides</title>
-    <description>Expert sailing guides, buying advice, and educational resources for yacht buyers and sailors.</description>
-    <link>${siteUrl}/guides</link>
-    <atom:link href="${siteUrl}/guides/feed.xml" rel="self" type="application/rss+xml" />
-    <language>en</language>
+    <title>${channelInfo.title}</title>
+    <description>${channelInfo.description}</description>
+    <link>${siteUrl}/${locale}/guides</link>
+    <atom:link href="${siteUrl}/${locale}/guides/feed.xml" rel="self" type="application/rss+xml" />
+    <language>${locale === "fr" ? "fr" : "en"}</language>
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     <generator>Sailing Yacht Info</generator>
 ${items}

--- a/app/[locale]/guides/page.tsx
+++ b/app/[locale]/guides/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { getAllPublishedArticles, getAllCategories, getBuyingGuideArticles } from "@/lib/articles";
-import { getSiteUrl } from "@/lib/seo";
+import { getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 import { BUYING_GUIDE_TEMPLATES, type GuideType } from "@/lib/buying-guides";
 
 // ISR: Revalidate guides hub every hour
@@ -41,9 +41,7 @@ export async function generateMetadata({
       title: t("meta.title"),
       description: t("meta.description"),
     },
-    alternates: {
-      canonical: getSiteUrl("/guides"),
-    },
+    alternates: buildLocaleAlternates("/guides"),
   };
 }
 

--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   generateBreadcrumbJsonLd,
   generateCollectionPageJsonLd,
   getSiteUrl,
+  buildLocaleAlternates,
 } from "@/lib/seo";
 import {
   getManufacturerBySlug,
@@ -94,9 +95,7 @@ export async function generateMetadata({
       description,
       images: [getSiteUrl("/api/og")],
     },
-    alternates: {
-      canonical: getSiteUrl(`/manufacturers/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/manufacturers/${slug}`),
   };
 }
 
@@ -117,7 +116,7 @@ export default async function ManufacturerPage({
     { name: "Home", path: "/" },
     { name: "Manufacturers", path: "/manufacturers" },
     { name: manufacturer.name },
-  ]);
+  ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
     name: `${manufacturer.name} Yachts`,

--- a/app/[locale]/manufacturers/[slug]/partners/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/partners/page.tsx
@@ -8,6 +8,7 @@ import {
   generateBreadcrumbJsonLd,
   generateLocalBusinessJsonLd,
   getSiteUrl,
+  buildLocaleAlternates,
 } from "@/lib/seo";
 import {
   getPartnerOffersByManufacturerId,
@@ -85,9 +86,7 @@ export async function generateMetadata({
       description,
       images: [getSiteUrl("/api/og")],
     },
-    alternates: {
-      canonical: getSiteUrl(`/manufacturers/${slug}/partners`),
-    },
+    alternates: buildLocaleAlternates(`/manufacturers/${slug}/partners`),
   };
 }
 
@@ -109,7 +108,7 @@ export default async function PartnersPage({
     { name: "Manufacturers", path: "/manufacturers" },
     { name: manufacturer.name, path: `/manufacturers/${slug}` },
     { name: "Partners & Dealers" },
-  ]);
+  ], locale);
 
   // Aggregate data for schema
   const hasOffers = partnerOffers.length > 0;

--- a/app/[locale]/manufacturers/[slug]/spotlight/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/spotlight/page.tsx
@@ -6,7 +6,7 @@ import { getTranslations } from "next-intl/server";
 import { marked } from "marked";
 
 import { getSpotlightBySlug } from "@/lib/manufacturer-spotlights";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -98,9 +98,7 @@ export async function generateMetadata({
       description,
       images: [getSiteUrl("/api/og")],
     },
-    alternates: {
-      canonical: url,
-    },
+    alternates: buildLocaleAlternates(`/manufacturers/${slug}/spotlight`),
   };
 }
 
@@ -129,7 +127,7 @@ export default async function ManufacturerSpotlightPage({
       name: "Spotlight",
       path: `/manufacturers/${spotlight.manufacturer.slug}/spotlight`,
     },
-  ]);
+  ], locale);
 
   const organizationJsonLd = {
     "@context": "https://schema.org",

--- a/app/[locale]/manufacturers/page.tsx
+++ b/app/[locale]/manufacturers/page.tsx
@@ -10,6 +10,7 @@ import {
   generateCollectionPageJsonLd,
   generateItemListJsonLd,
   getSiteUrl,
+  buildLocaleAlternates,
 } from "@/lib/seo";
 
 // ISR: Revalidate manufacturers list every hour
@@ -53,9 +54,7 @@ export const metadata: Metadata = {
     description: jsonLdDescription,
     images: ["https://info.sailboats.fr/api/og?title=Sailing%20Yacht%20Manufacturers&description=Browse%20builders%2C%20brands%2C%20and%20model%20counts&length=Brand%20directory"],
   },
-  alternates: {
-    canonical: "/manufacturers",
-  },
+  alternates: buildLocaleAlternates("/manufacturers"),
 };
 
 interface ManufacturersListingPageProps {
@@ -71,7 +70,7 @@ export default async function ManufacturersPage({ params }: ManufacturersListing
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
     { name: "Manufacturers" },
-  ]);
+  ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
     name: jsonLdTitle,

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -5,7 +5,7 @@ import NewsletterSignup from "@/components/NewsletterSignup";
 import { PersonalizedRecommendations } from "@/components/PersonalizedRecommendations";
 import { db, yachtModels, manufacturers } from "@/lib/db";
 import { desc, sql } from "drizzle-orm";
-import { generateWebsiteJsonLd, generateFaqJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateWebsiteJsonLd, generateFaqJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 import { slugify } from "@/lib/utils/slugify";
 import { getSiteStats, formatYachtPhrase, formatYachtCountFAQ } from "@/lib/site-stats";
 import { buildSafeQuery } from "@/lib/build-safe";
@@ -112,10 +112,7 @@ export async function generateMetadata({ params }: HomeProps) {
       title: t("meta.twitterTitle"),
       description: t("meta.twitterDescription", { yachtPhrase }),
     },
-    alternates: {
-      canonical: getSiteUrl(`/${locale}`),
-      languages: { en: getSiteUrl("/en"), fr: getSiteUrl("/fr") },
-    },
+    alternates: buildLocaleAlternates("/"),
   };
 }
 
@@ -137,7 +134,7 @@ export default async function Home({ params }: HomeProps) {
     { q: t("faq.q4"), a: t("faq.a4") },
   ];
 
-  const jsonLd = generateWebsiteJsonLd();
+  const jsonLd = generateWebsiteJsonLd(locale);
   const faqJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",

--- a/app/[locale]/search-intent/[slug]/page.tsx
+++ b/app/[locale]/search-intent/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getSearchIntentBySlug } from "@/lib/search-intents";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
-import { generateCollectionPageJsonLd, generateYachtJsonLd } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl, generateCollectionPageJsonLd, generateYachtJsonLd, buildLocaleAlternates } from "@/lib/seo";
 
 // ISR: Revalidate search intent pages every 6 hours
 export const revalidate = 21600;
@@ -13,9 +12,9 @@ export const dynamicParams = true;
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const { intent } = await getSearchIntentBySlug(slug);
 
   if (!intent || intent.id === 0) {
@@ -42,7 +41,7 @@ export async function generateMetadata({
     openGraph: {
       title: intent.title,
       description: intent.metaDescription || intent.intro.substring(0, 160),
-      url: getSiteUrl(`/search-intent/${slug}`),
+      url: getSiteUrl(`/${locale}/search-intent/${slug}`),
       type: "website",
       siteName: "Sailing Yacht Info",
     },
@@ -51,9 +50,7 @@ export async function generateMetadata({
       title: intent.title,
       description: intent.metaDescription || intent.intro.substring(0, 160),
     },
-    alternates: {
-      canonical: getSiteUrl(`/search-intent/${slug}`),
-    },
+    alternates: buildLocaleAlternates(`/search-intent/${slug}`),
     robots: {
       index: true,
       follow: true,
@@ -65,9 +62,9 @@ export async function generateMetadata({
 export default async function SearchIntentPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; locale: string }>;
 }) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const { intent, yachts, totalCount } = await getSearchIntentBySlug(slug);
 
   // Not found
@@ -97,12 +94,12 @@ export default async function SearchIntentPage({
     { name: "Browse Yachts", path: "/yachts" },
     { name: intent.category || "Search Results", path: `/search-intent/${slug}` },
     { name: intent.title },
-  ]);
+  ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
     name: intent.title,
     description: intent.metaDescription || intent.intro,
-    url: getSiteUrl(`/search-intent/${slug}`),
+    url: getSiteUrl(`/${locale}/search-intent/${slug}`),
     itemCount: totalCount,
   });
 
@@ -133,7 +130,7 @@ export default async function SearchIntentPage({
           key={yacht.id}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(generateYachtJsonLd(yacht)),
+            __html: JSON.stringify(generateYachtJsonLd(yacht, locale)),
           }}
         />
       ))}

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { generateBreadcrumbJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 import dynamic from "next/dynamic";
 const SearchClient = dynamic(() => import("./SearchClient").then(m => ({ default: m.SearchClient })), { ssr: false, loading: () => null });
 import { shouldNoindexSearchPage } from "@/lib/thin-page-governance";
@@ -21,9 +21,7 @@ export async function generateMetadata({ params }: SearchPageProps): Promise<Met
   return {
     title: t("meta.title"),
     description: t("meta.description"),
-    alternates: {
-      canonical: `/${locale}/search`,
-    },
+    alternates: buildLocaleAlternates("/search"),
     openGraph: {
       title: t("meta.title"),
       description: t("meta.description"),
@@ -41,7 +39,7 @@ export default async function SearchPage({ params }: SearchPageProps) {
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
     { name: t("heading") },
-  ]);
+  ], locale);
 
   return (
     <>

--- a/app/[locale]/yachts/[slug]/page.tsx
+++ b/app/[locale]/yachts/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   generateImageObjectJsonLd,
   generateVideoObjectJsonLd,
   generateDigitalDocumentJsonLd,
+  buildLocaleAlternates,
 } from "@/lib/seo";
 import { getYachtDetailData, getPrimaryImage } from "@/lib/yachts";
 import { getPriceSummary } from "@/lib/price-data";
@@ -125,7 +126,7 @@ export async function generateMetadata({
       ? parseFloat(data.yacht.lengthOverall)
       : null,
     primaryImage: primaryImage ?? undefined,
-  });
+  }, locale);
 
   // P10.5: Calculate completeness score
   const completenessScore = calculateCompletenessScore(data.yacht);
@@ -137,13 +138,7 @@ export async function generateMetadata({
     ...(noindexThin && {
       robots: { index: false, follow: true },
     }),
-    alternates: {
-      canonical: getSiteUrl(`/yachts/${slug}`),
-      languages: {
-        en: getSiteUrl(`/yachts/${slug}`),
-        fr: "https://sailboats.fr",
-      },
-    },
+    alternates: buildLocaleAlternates(`/yachts/${slug}`),
   };
 }
 
@@ -198,13 +193,13 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
     cabins: yachtData.cabins ?? undefined,
     primaryImage: primaryImage?.url ?? undefined,
     reviews: reviewData,
-  });
+  }, locale);
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: t("breadcrumb.home"), path: "/" },
     { name: t("breadcrumb.yachts"), path: "/yachts" },
     { name: `${manufacturerName} ${yachtData.modelName}`, path: `/yachts/${slug}` },
-  ]);
+  ], locale);
 
   // ImageObject structured data for primary image
   const imageObjectJsonLd = primaryImage?.url
@@ -247,7 +242,7 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
     draft: yachtData.draft ? parseFloat(yachtData.draft) : null,
     cabins: yachtData.cabins ?? undefined,
     beam: yachtData.beam ? parseFloat(yachtData.beam) : null,
-  });
+  }, locale);
 
   // P8.2: Fetch price data for AggregateOffer JSON-LD
   let offerJsonLd: any = null;

--- a/app/[locale]/yachts/page.tsx
+++ b/app/[locale]/yachts/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { generateBreadcrumbJsonLd, generateCollectionPageJsonLd, getSiteUrl } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, generateCollectionPageJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
 import { Suspense } from "react";
 import dynamic from "next/dynamic";
 const YachtsClient = dynamic(() => import("./YachtsClient"), { ssr: false, loading: () => null });
@@ -57,9 +57,7 @@ export async function generateMetadata({ params, searchParams }: YachtsPageParam
   return {
     title: t("meta.title"),
     description: t("meta.description"),
-    alternates: {
-      canonical: canonicalUrl,
-    },
+    alternates: buildLocaleAlternates("/yachts"),
     robots: noindex
       ? { index: false, follow: false }
       : { index: true, follow: true },
@@ -94,7 +92,7 @@ export default async function YachtsPage({ params, searchParams }: YachtsPagePar
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
     { name: t("heading") },
-  ]);
+  ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({
     name: t("meta.title"),

--- a/app/sitemap-compare.xml/route.ts
+++ b/app/sitemap-compare.xml/route.ts
@@ -5,6 +5,8 @@ import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/
 
 export const revalidate = 3600;
 
+const LOCALES = ["en", "fr"] as const;
+
 async function getCompareEntries(): Promise<SitemapEntry[]> {
   return unstable_cache(
     async () => {
@@ -24,11 +26,14 @@ async function getCompareEntries(): Promise<SitemapEntry[]> {
           const yachtB = topYachts[j];
 
           if (yachtA.slug && yachtB.slug) {
-            entries.push({
-              loc: `${SITE_URL}/compare/${yachtA.slug}-vs-${yachtB.slug}`,
-              changefreq: "monthly",
-              priority: "0.5",
-            });
+            // Generate entries for both locales
+            for (const locale of LOCALES) {
+              entries.push({
+                loc: `${SITE_URL}/${locale}/compare/${yachtA.slug}-vs-${yachtB.slug}`,
+                changefreq: "monthly",
+                priority: "0.5",
+              });
+            }
           }
         }
       }

--- a/app/sitemap-guides.xml/route.ts
+++ b/app/sitemap-guides.xml/route.ts
@@ -9,6 +9,8 @@ import {
 // ISR: Revalidate guides sitemap every 6 hours
 export const revalidate = 21600;
 
+const LOCALES = ["en", "fr"] as const;
+
 export async function GET() {
   try {
     const result = await pool.query(
@@ -18,17 +20,13 @@ export async function GET() {
        ORDER BY published_at DESC`
     );
 
-    const entries: SitemapEntry[] = [
+    const pages = [
       // Guides hub page
-      {
-        loc: `${SITE_URL}/guides`,
-        changefreq: "weekly",
-        priority: "0.7",
-      },
+      { path: "/guides", changefreq: "weekly", priority: "0.7" },
       // Individual guide pages
       ...result.rows.map(
         (row: { slug: string; published: Date; lastmod: Date }) => ({
-          loc: `${SITE_URL}/guides/${row.slug}`,
+          path: `/guides/${row.slug}`,
           lastmod: new Date(row.lastmod).toISOString(),
           changefreq: "monthly" as const,
           priority: "0.6",
@@ -36,19 +34,29 @@ export async function GET() {
       ),
     ];
 
+    // Generate entries for both locales
+    const entries: SitemapEntry[] = pages.flatMap((page) =>
+      LOCALES.map((locale) => ({
+        loc: `${SITE_URL}/${locale}${page.path}`,
+        lastmod: "lastmod" in page ? page.lastmod : undefined,
+        changefreq: page.changefreq,
+        priority: page.priority,
+      }))
+    );
+
     return sitemapResponse(buildSitemapXml(entries));
   } catch (error) {
     console.error("[sitemap-guides] Error:", error);
 
     // Return a minimal valid sitemap on error
     return sitemapResponse(
-      buildSitemapXml([
-        {
-          loc: `${SITE_URL}/guides`,
+      buildSitemapXml(
+        LOCALES.map((locale) => ({
+          loc: `${SITE_URL}/${locale}/guides`,
           changefreq: "weekly",
           priority: "0.7",
-        },
-      ])
+        }))
+      )
     );
   }
 }

--- a/app/sitemap-images.xml/route.ts
+++ b/app/sitemap-images.xml/route.ts
@@ -5,6 +5,8 @@ import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/
 
 export const revalidate = 3600;
 
+const LOCALES = ["en", "fr"] as const;
+
 async function getImageEntries(): Promise<SitemapEntry[]> {
   return unstable_cache(
     async () => {
@@ -42,15 +44,17 @@ async function getImageEntries(): Promise<SitemapEntry[]> {
         });
       }
 
-      // Build entries, limiting to 10 images per yacht (Google's recommendation)
+      // Build entries for both locales, limiting to 10 images per yacht
       const entries: SitemapEntry[] = [];
       for (const [slug, imgs] of yachtImageMap) {
-        entries.push({
-          loc: `${SITE_URL}/yachts/${slug}`,
-          changefreq: "weekly",
-          priority: "0.7",
-          images: imgs.slice(0, 10),
-        });
+        for (const locale of LOCALES) {
+          entries.push({
+            loc: `${SITE_URL}/${locale}/yachts/${slug}`,
+            changefreq: "weekly",
+            priority: "0.7",
+            images: imgs.slice(0, 10),
+          });
+        }
       }
 
       return entries;

--- a/app/sitemap-manufacturers.xml/route.ts
+++ b/app/sitemap-manufacturers.xml/route.ts
@@ -6,6 +6,8 @@ import { eq } from "drizzle-orm";
 
 export const revalidate = 3600;
 
+const LOCALES = ["en", "fr"] as const;
+
 async function getManufacturerEntries(): Promise<SitemapEntry[]> {
   return unstable_cache(
     async () => {
@@ -17,11 +19,13 @@ async function getManufacturerEntries(): Promise<SitemapEntry[]> {
 
       const manufacturerEntries: SitemapEntry[] = mfrs
         .filter((m: { name: string | null }) => m.name !== null)
-        .map((m: { name: string | null }) => ({
-          loc: `${SITE_URL}/manufacturers/${slugify(m.name!)}`,
-          changefreq: "weekly" as const,
-          priority: "0.6",
-        }));
+        .flatMap((m: { name: string | null }) =>
+          LOCALES.map((locale) => ({
+            loc: `${SITE_URL}/${locale}/manufacturers/${slugify(m.name!)}`,
+            changefreq: "weekly" as const,
+            priority: "0.6",
+          }))
+        );
 
       // Add spotlight pages
       const spotlights = await db
@@ -34,11 +38,13 @@ async function getManufacturerEntries(): Promise<SitemapEntry[]> {
 
       const spotlightEntries: SitemapEntry[] = spotlights
         .filter((s: { manufacturerName: string | null }) => s.manufacturerName !== null)
-        .map((s: { manufacturerName: string | null }) => ({
-          loc: `${SITE_URL}/manufacturers/${slugify(s.manufacturerName!)}/spotlight`,
-          changefreq: "monthly" as const,
-          priority: "0.7",
-        }));
+        .flatMap((s: { manufacturerName: string | null }) =>
+          LOCALES.map((locale) => ({
+            loc: `${SITE_URL}/${locale}/manufacturers/${slugify(s.manufacturerName!)}/spotlight`,
+            changefreq: "monthly" as const,
+            priority: "0.7",
+          }))
+        );
 
       return [...manufacturerEntries, ...spotlightEntries];
     },

--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -4,23 +4,34 @@ import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/
 
 export const revalidate = 86400;
 
+const LOCALES = ["en", "fr"] as const;
+
 export async function GET() {
-  const entries: SitemapEntry[] = [
-    { loc: `${SITE_URL}/`, changefreq: "daily", priority: "1.0" },
-    { loc: `${SITE_URL}/yachts`, changefreq: "daily", priority: "0.9" },
-    { loc: `${SITE_URL}/manufacturers`, changefreq: "weekly", priority: "0.8" },
-    { loc: `${SITE_URL}/guides`, changefreq: "weekly", priority: "0.8" },
-    { loc: `${SITE_URL}/glossary`, changefreq: "monthly", priority: "0.6" },
-    { loc: `${SITE_URL}/compare`, changefreq: "weekly", priority: "0.7" },
-    { loc: `${SITE_URL}/search`, changefreq: "monthly", priority: "0.6" },
-    { loc: `${SITE_URL}/favorites`, changefreq: "monthly", priority: "0.4" },
+  const pages = [
+    { path: "/", changefreq: "daily", priority: "1.0" },
+    { path: "/yachts", changefreq: "daily", priority: "0.9" },
+    { path: "/manufacturers", changefreq: "weekly", priority: "0.8" },
+    { path: "/guides", changefreq: "weekly", priority: "0.8" },
+    { path: "/glossary", changefreq: "monthly", priority: "0.6" },
+    { path: "/compare", changefreq: "weekly", priority: "0.7" },
+    { path: "/search", changefreq: "monthly", priority: "0.6" },
+    { path: "/favorites", changefreq: "monthly", priority: "0.4" },
     // Landing pages from /best/[slug]
     ...LANDING_PAGES.map((lp: LandingPageDefinition) => ({
-      loc: `${SITE_URL}/best/${lp.slug}`,
+      path: `/best/${lp.slug}`,
       changefreq: "weekly" as const,
       priority: "0.8",
     })),
   ];
+
+  // Generate entries for both locales
+  const entries: SitemapEntry[] = pages.flatMap((page) =>
+    LOCALES.map((locale) => ({
+      loc: `${SITE_URL}/${locale}${page.path === "/" ? "" : page.path}`,
+      changefreq: page.changefreq,
+      priority: page.priority,
+    }))
+  );
 
   return sitemapResponse(buildSitemapXml(entries));
 }

--- a/app/sitemap-yachts.xml/route.ts
+++ b/app/sitemap-yachts.xml/route.ts
@@ -5,6 +5,8 @@ import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/
 
 export const revalidate = 3600;
 
+const LOCALES = ["en", "fr"] as const;
+
 async function getYachtEntries(): Promise<SitemapEntry[]> {
   return unstable_cache(
     async () => {
@@ -17,12 +19,15 @@ async function getYachtEntries(): Promise<SitemapEntry[]> {
           .from(yachtModels)
           .where(isNotNull(yachtModels.slug));
 
-      return yachts.map((y: { slug: string | null; updatedAt: Date | null }) => ({
-        loc: `${SITE_URL}/yachts/${y.slug}`,
-        lastmod: y.updatedAt ? new Date(y.updatedAt).toISOString() : undefined,
-        changefreq: "weekly" as const,
-        priority: "0.8",
-      }));
+      // Generate entries for both locales
+      return yachts.flatMap((y: { slug: string | null; updatedAt: Date | null }) =>
+        LOCALES.map((locale) => ({
+          loc: `${SITE_URL}/${locale}/yachts/${y.slug}`,
+          lastmod: y.updatedAt ? new Date(y.updatedAt).toISOString() : undefined,
+          changefreq: "weekly" as const,
+          priority: "0.8",
+        }))
+      );
     },
     ["sitemap-yachts"],
     { tags: ["yachts"], revalidate: 3600 }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -10,6 +10,27 @@ export function getSiteUrl(path = ""): string {
   return `${SITE_URL}${path}`;
 }
 
+/**
+ * Build locale-aware alternate URLs for hreflang tags.
+ * Given a path like "/yachts/beneteau-first-27", returns:
+ * { canonical: "/en/yachts/beneteau-first-27", languages: { en: "/en/...", fr: "/fr/..." } }
+ * If path already starts with /en or /fr, strips it first.
+ */
+export function buildLocaleAlternates(pathWithoutLocale: string): {
+  canonical: string;
+  languages: Record<string, string>;
+} {
+  const clean = pathWithoutLocale.replace(/^\/(en|fr)/, "");
+  const path = clean.startsWith("/") ? clean : "/" + clean;
+  return {
+    canonical: getSiteUrl(`/en${path}`),
+    languages: {
+      en: getSiteUrl(`/en${path}`),
+      fr: getSiteUrl(`/fr${path}`),
+    },
+  };
+}
+
 export function buildOgImageUrl(params: {
   title: string;
   description?: string | null;
@@ -50,17 +71,21 @@ export interface JsonLdWebsite {
   };
 }
 
-export function generateWebsiteJsonLd(): JsonLdWebsite {
+const SITE_DESCRIPTIONS: Record<string, string> = {
+  en: "Comprehensive database of sailing yacht specifications with advanced search and comparison tools.",
+  fr: "Base de données complète de spécifications de voiliers avec recherche avancée et outils de comparaison.",
+};
+
+export function generateWebsiteJsonLd(locale = "en"): JsonLdWebsite {
   return {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: SITE_NAME,
-    url: SITE_URL,
-    description:
-      "Comprehensive database of sailing yacht specifications with advanced search and comparison tools.",
+    url: `${SITE_URL}/${locale}`,
+    description: SITE_DESCRIPTIONS[locale] || SITE_DESCRIPTIONS.en,
     potentialAction: {
       "@type": "SearchAction",
-      target: `${SITE_URL}/yachts?q={search_term_string}`,
+      target: `${SITE_URL}/${locale}/yachts?q={search_term_string}`,
       "query-input": "required name=search_term_string",
     },
   };
@@ -119,23 +144,39 @@ export function generateYachtJsonLd(yacht: {
     authorName?: string | null;
     reviewDate?: Date | null;
   }> | null;
-}): JsonLdProduct {
+}, locale = "en"): JsonLdProduct {
+  // Localized property names
+  const propNames: Record<string, Record<string, string>> = {
+    loa: { en: "Length Overall", fr: "Longueur hors tout" },
+    beam: { en: "Beam", fr: "Bau" },
+    draft: { en: "Draft", fr: "Tirant d\'eau" },
+    displacement: { en: "Displacement", fr: "Déplacement" },
+    hullMaterial: { en: "Hull Material", fr: "Matériau de coque" },
+    rigType: { en: "Rig Type", fr: "Type de gréement" },
+    cabins: { en: "Cabins", fr: "Cabines" },
+  };
+
+  const descFallbacks: Record<string, string> = {
+    en: "sailing yacht specifications and details",
+    fr: "spécifications et détails du voilier",
+  };
+
   const props: JsonLdProduct["additionalProperty"] = [];
 
-  if (yacht.lengthOverall) props.push({ "@type": "PropertyValue", name: "Length Overall", value: yacht.lengthOverall, unitCode: "MTR" });
-  if (yacht.beam) props.push({ "@type": "PropertyValue", name: "Beam", value: yacht.beam, unitCode: "MTR" });
-  if (yacht.draft) props.push({ "@type": "PropertyValue", name: "Draft", value: yacht.draft, unitCode: "MTR" });
-  if (yacht.displacement) props.push({ "@type": "PropertyValue", name: "Displacement", value: yacht.displacement, unitCode: "KGM" });
-  if (yacht.hullMaterial) props.push({ "@type": "PropertyValue", name: "Hull Material", value: yacht.hullMaterial });
-  if (yacht.rigType) props.push({ "@type": "PropertyValue", name: "Rig Type", value: yacht.rigType });
-  if (yacht.cabins) props.push({ "@type": "PropertyValue", name: "Cabins", value: yacht.cabins });
+  if (yacht.lengthOverall) props.push({ "@type": "PropertyValue", name: propNames.loa[locale] || propNames.loa.en, value: yacht.lengthOverall, unitCode: "MTR" });
+  if (yacht.beam) props.push({ "@type": "PropertyValue", name: propNames.beam[locale] || propNames.beam.en, value: yacht.beam, unitCode: "MTR" });
+  if (yacht.draft) props.push({ "@type": "PropertyValue", name: propNames.draft[locale] || propNames.draft.en, value: yacht.draft, unitCode: "MTR" });
+  if (yacht.displacement) props.push({ "@type": "PropertyValue", name: propNames.displacement[locale] || propNames.displacement.en, value: yacht.displacement, unitCode: "KGM" });
+  if (yacht.hullMaterial) props.push({ "@type": "PropertyValue", name: propNames.hullMaterial[locale] || propNames.hullMaterial.en, value: yacht.hullMaterial });
+  if (yacht.rigType) props.push({ "@type": "PropertyValue", name: propNames.rigType[locale] || propNames.rigType.en, value: yacht.rigType });
+  if (yacht.cabins) props.push({ "@type": "PropertyValue", name: propNames.cabins[locale] || propNames.cabins.en, value: yacht.cabins });
 
   const result: JsonLdProduct = {
     "@context": "https://schema.org",
     "@type": "Product",
     name: `${yacht.manufacturer} ${yacht.modelName} (${yacht.year})`,
-    description: yacht.description || `${yacht.manufacturer} ${yacht.modelName} sailing yacht specifications and details.`,
-    url: getSiteUrl(`/yachts/${yacht.slug}`),
+    description: yacht.description || `${yacht.manufacturer} ${yacht.modelName} ${descFallbacks[locale] || descFallbacks.en}.`,
+    url: getSiteUrl(`/${locale}/yachts/${yacht.slug}`),
     brand: {
       "@type": "Brand",
       name: yacht.manufacturer,
@@ -200,8 +241,10 @@ export interface JsonLdBreadcrumb {
 }
 
 export function generateBreadcrumbJsonLd(
-  items: Array<{ name: string; path?: string }>
+  items: Array<{ name: string; path?: string }>,
+  locale?: string
 ): JsonLdBreadcrumb {
+  const localePrefix = locale ? `/${locale}` : "";
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -209,7 +252,7 @@ export function generateBreadcrumbJsonLd(
       "@type": "ListItem",
       position: idx + 1,
       name: item.name,
-      ...(item.path ? { item: getSiteUrl(item.path) } : {}),
+      ...(item.path ? { item: getSiteUrl(`${localePrefix}${item.path}`) } : {}),
     })),
   };
 }
@@ -342,7 +385,7 @@ export function generateYachtPageMetadata(yacht: {
   description?: string | null;
   lengthOverall?: number | null;
   primaryImage?: string;
-}): Metadata {
+}, locale = "en"): Metadata {
   const title = `${yacht.manufacturer} ${yacht.modelName} (${yacht.year})`;
   const desc =
     yacht.description ||
@@ -369,7 +412,7 @@ export function generateYachtPageMetadata(yacht: {
     openGraph: {
       title,
       description: desc,
-      url: getSiteUrl(`/yachts/${yacht.slug}`),
+      url: getSiteUrl(`/${locale}/yachts/${yacht.slug}`),
       type: "website",
       siteName: SITE_NAME,
       images: [
@@ -485,51 +528,80 @@ export function generateFaqJsonLd(yacht: {
   draft?: number | null;
   cabins?: number | null;
   beam?: number | null;
-}): JsonLdFAQ | null {
+}, locale = "en"): JsonLdFAQ | null {
   const fullName = `${yacht.manufacturer} ${yacht.modelName}`;
   const questions: JsonLdFAQ["mainEntity"] = [];
 
+  // French templates
+  const templates: Record<string, {
+    weightQ: (n: string) => string;
+    weightA: (n: string, kg: string, lbs: string) => string;
+    lengthQ: (n: string) => string;
+    lengthA: (n: string, m: string, ft: string) => string;
+    draftQ: (n: string) => string;
+    draftA: (n: string, m: string, ft: string) => string;
+    cabinsQ: (n: string) => string;
+    cabinsA: (n: string, c: number) => string;
+  }> = {
+    en: {
+      weightQ: (n) => `How much does ${n} weigh?`,
+      weightA: (n, kg, lbs) => `The ${n} has a displacement of ${kg} kg (${lbs} lbs).`,
+      lengthQ: (n) => `How long is ${n}?`,
+      lengthA: (n, m, ft) => `The ${n} has a length overall (LOA) of ${m} m (${ft} ft).`,
+      draftQ: (n) => `What is the draft of ${n}?`,
+      draftA: (n, m, ft) => `The ${n} has a draft of ${m} m (${ft} ft).`,
+      cabinsQ: (n) => `How many cabins does ${n} have?`,
+      cabinsA: (n, c) => `The ${n} has ${c} cabin${c > 1 ? "s" : ""}.`,
+    },
+    fr: {
+      weightQ: (n) => `Combien pèse le ${n} ?`,
+      weightA: (n, kg, lbs) => `Le ${n} a un déplacement de ${kg} kg (${lbs} lbs).`,
+      lengthQ: (n) => `Quelle est la longueur du ${n} ?`,
+      lengthA: (n, m, ft) => `Le ${n} a une longueur hors tout (LOA) de ${m} m (${ft} ft).`,
+      draftQ: (n) => `Quel est le tirant d'eau du ${n} ?`,
+      draftA: (n, m, ft) => `Le ${n} a un tirant d'eau de ${m} m (${ft} ft).`,
+      cabinsQ: (n) => `Combien de cabines possède le ${n} ?`,
+      cabinsA: (n, c) => `Le ${n} possède ${c} cabine${c > 1 ? "s" : ""}.`,
+    },
+  };
+
+  const t = templates[locale] || templates.en;
+
   if (yacht.displacement) {
+    const kg = yacht.displacement.toLocaleString();
+    const lbs = (yacht.displacement * 2.20462).toLocaleString(undefined, {maximumFractionDigits: 0});
     questions.push({
       "@type": "Question",
-      name: `How much does ${fullName} weigh?`,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `The ${fullName} has a displacement of ${yacht.displacement.toLocaleString()} kg (${(yacht.displacement * 2.20462).toLocaleString(undefined, {maximumFractionDigits: 0})} lbs).`,
-      },
+      name: t.weightQ(fullName),
+      acceptedAnswer: { "@type": "Answer", text: t.weightA(fullName, kg, lbs) },
     });
   }
 
   if (yacht.lengthOverall) {
+    const m = String(yacht.lengthOverall);
+    const ft = (yacht.lengthOverall * 3.28084).toFixed(1);
     questions.push({
       "@type": "Question",
-      name: `How long is ${fullName}?`,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `The ${fullName} has a length overall (LOA) of ${yacht.lengthOverall} m (${(yacht.lengthOverall * 3.28084).toFixed(1)} ft).`,
-      },
+      name: t.lengthQ(fullName),
+      acceptedAnswer: { "@type": "Answer", text: t.lengthA(fullName, m, ft) },
     });
   }
 
   if (yacht.draft) {
+    const m = String(yacht.draft);
+    const ft = (yacht.draft * 3.28084).toFixed(1);
     questions.push({
       "@type": "Question",
-      name: `What is the draft of ${fullName}?`,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `The ${fullName} has a draft of ${yacht.draft} m (${(yacht.draft * 3.28084).toFixed(1)} ft).`,
-      },
+      name: t.draftQ(fullName),
+      acceptedAnswer: { "@type": "Answer", text: t.draftA(fullName, m, ft) },
     });
   }
 
   if (yacht.cabins) {
     questions.push({
       "@type": "Question",
-      name: `How many cabins does ${fullName} have?`,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `The ${fullName} has ${yacht.cabins} cabin${yacht.cabins > 1 ? "s" : ""}.`,
-      },
+      name: t.cabinsQ(fullName),
+      acceptedAnswer: { "@type": "Answer", text: t.cabinsA(fullName, yacht.cabins) },
     });
   }
 

--- a/tests/localized-seo.test.ts
+++ b/tests/localized-seo.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildLocaleAlternates,
+  generateWebsiteJsonLd,
+  generateYachtJsonLd,
+  generateBreadcrumbJsonLd,
+  generateFaqJsonLd,
+  getSiteUrl,
+} from "../lib/seo";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+
+describe("buildLocaleAlternates", () => {
+  it("generates en + fr alternates for a simple path", () => {
+    const result = buildLocaleAlternates("/yachts");
+    expect(result.canonical).toBe(`${SITE_URL}/en/yachts`);
+    expect(result.languages.en).toBe(`${SITE_URL}/en/yachts`);
+    expect(result.languages.fr).toBe(`${SITE_URL}/fr/yachts`);
+  });
+
+  it("handles root path", () => {
+    const result = buildLocaleAlternates("/");
+    expect(result.canonical).toBe(`${SITE_URL}/en/`);
+    expect(result.languages.en).toBe(`${SITE_URL}/en/`);
+    expect(result.languages.fr).toBe(`${SITE_URL}/fr/`);
+  });
+
+  it("strips existing /en or /fr prefix from path", () => {
+    const result = buildLocaleAlternates("/en/yachts/beneteau-first-27");
+    expect(result.canonical).toBe(`${SITE_URL}/en/yachts/beneteau-first-27`);
+    expect(result.languages.fr).toBe(`${SITE_URL}/fr/yachts/beneteau-first-27`);
+  });
+
+  it("strips /fr prefix too", () => {
+    const result = buildLocaleAlternates("/fr/yachts");
+    expect(result.canonical).toBe(`${SITE_URL}/en/yachts`);
+    expect(result.languages.en).toBe(`${SITE_URL}/en/yachts`);
+    expect(result.languages.fr).toBe(`${SITE_URL}/fr/yachts`);
+  });
+
+  it("handles deep paths", () => {
+    const result = buildLocaleAlternates("/compare/beneteau-first-27-vs-jeanneau-sun-odyssey-349");
+    expect(result.canonical).toBe(`${SITE_URL}/en/compare/beneteau-first-27-vs-jeanneau-sun-odyssey-349`);
+    expect(result.languages.en).toBe(`${SITE_URL}/en/compare/beneteau-first-27-vs-jeanneau-sun-odyssey-349`);
+    expect(result.languages.fr).toBe(`${SITE_URL}/fr/compare/beneteau-first-27-vs-jeanneau-sun-odyssey-349`);
+  });
+});
+
+describe("generateWebsiteJsonLd — locale aware", () => {
+  it("returns English defaults", () => {
+    const jsonLd = generateWebsiteJsonLd("en");
+    expect(jsonLd["@type"]).toBe("WebSite");
+    expect(jsonLd.url).toBe(`${SITE_URL}/en`);
+    expect(jsonLd.description).toBe(
+      "Comprehensive database of sailing yacht specifications with advanced search and comparison tools."
+    );
+    expect(jsonLd.potentialAction.target).toContain("/en/yachts");
+  });
+
+  it("returns French content", () => {
+    const jsonLd = generateWebsiteJsonLd("fr");
+    expect(jsonLd["@type"]).toBe("WebSite");
+    expect(jsonLd.url).toBe(`${SITE_URL}/fr`);
+    expect(jsonLd.description).toBe(
+      "Base de données complète de spécifications de voiliers avec recherche avancée et outils de comparaison."
+    );
+    expect(jsonLd.potentialAction.target).toContain("/fr/yachts");
+  });
+
+  it("defaults to en when no locale provided", () => {
+    const jsonLd = generateWebsiteJsonLd();
+    expect(jsonLd.url).toBe(`${SITE_URL}/en`);
+  });
+});
+
+describe("generateYachtJsonLd — locale aware", () => {
+  const sampleYacht = {
+    manufacturer: "Beneteau",
+    modelName: "First 27",
+    year: 2020,
+    slug: "beneteau-first-27",
+    lengthOverall: 8.2,
+    beam: 2.99,
+    draft: 1.6,
+    displacement: 1800,
+    hullMaterial: "GRP",
+    rigType: "Fractional Sloop",
+    cabins: 2,
+    description: null,
+    reviews: null,
+  };
+
+  it("generates English property names", () => {
+    const jsonLd = generateYachtJsonLd(sampleYacht, "en");
+    expect(jsonLd["@type"]).toBe("Product");
+    expect(jsonLd.url).toBe(`${SITE_URL}/en/yachts/beneteau-first-27`);
+
+    const propNames = jsonLd.additionalProperty!.map((p) => p.name);
+    expect(propNames).toContain("Length Overall");
+    expect(propNames).toContain("Beam");
+    expect(propNames).toContain("Draft");
+    expect(propNames).toContain("Displacement");
+    expect(propNames).toContain("Hull Material");
+    expect(propNames).toContain("Rig Type");
+    expect(propNames).toContain("Cabins");
+  });
+
+  it("generates French property names", () => {
+    const jsonLd = generateYachtJsonLd(sampleYacht, "fr");
+    expect(jsonLd.url).toBe(`${SITE_URL}/fr/yachts/beneteau-first-27`);
+
+    const propNames = jsonLd.additionalProperty!.map((p) => p.name);
+    expect(propNames).toContain("Longueur hors tout");
+    expect(propNames).toContain("Bau");
+    expect(propNames).toContain("Tirant d'eau");
+    expect(propNames).toContain("Déplacement");
+    expect(propNames).toContain("Matériau de coque");
+    expect(propNames).toContain("Type de gréement");
+    expect(propNames).toContain("Cabines");
+  });
+
+  it("uses French fallback description when yacht has no description", () => {
+    const jsonLd = generateYachtJsonLd(sampleYacht, "fr");
+    expect(jsonLd.description).toContain("spécifications et détails du voilier");
+  });
+
+  it("uses English fallback description when yacht has no description", () => {
+    const jsonLd = generateYachtJsonLd(sampleYacht, "en");
+    expect(jsonLd.description).toContain("sailing yacht specifications and details");
+  });
+
+  it("preserves actual description when provided", () => {
+    const yachtWithDesc = { ...sampleYacht, description: "A great racer-cruiser" };
+    const jsonLd = generateYachtJsonLd(yachtWithDesc, "en");
+    expect(jsonLd.description).toBe("A great racer-cruiser");
+  });
+});
+
+describe("generateBreadcrumbJsonLd — locale aware", () => {
+  it("generates locale-prefixed URLs", () => {
+    const jsonLd = generateBreadcrumbJsonLd(
+      [
+        { name: "Home", path: "/" },
+        { name: "Yachts", path: "/yachts" },
+        { name: "Beneteau First 27", path: "/yachts/beneteau-first-27" },
+      ],
+      "fr"
+    );
+
+    expect(jsonLd["@type"]).toBe("BreadcrumbList");
+    expect(jsonLd.itemListElement).toHaveLength(3);
+    expect(jsonLd.itemListElement[0].item).toBe(`${SITE_URL}/fr/`);
+    expect(jsonLd.itemListElement[1].item).toBe(`${SITE_URL}/fr/yachts`);
+    expect(jsonLd.itemListElement[2].item).toBe(
+      `${SITE_URL}/fr/yachts/beneteau-first-27`
+    );
+  });
+
+  it("uses English prefix when locale is en", () => {
+    const jsonLd = generateBreadcrumbJsonLd(
+      [{ name: "Home", path: "/" }],
+      "en"
+    );
+    expect(jsonLd.itemListElement[0].item).toBe(`${SITE_URL}/en/`);
+  });
+
+  it("omits locale prefix when no locale provided (backward compat)", () => {
+    const jsonLd = generateBreadcrumbJsonLd([{ name: "Home", path: "/" }]);
+    expect(jsonLd.itemListElement[0].item).toBe(`${SITE_URL}/`);
+  });
+});
+
+describe("generateFaqJsonLd — locale aware", () => {
+  const sampleYacht = {
+    manufacturer: "Beneteau",
+    modelName: "First 27",
+    displacement: 1800,
+    lengthOverall: 8.2,
+    draft: 1.6,
+    cabins: 2,
+    beam: 2.99,
+  };
+
+  it("generates English FAQ questions", () => {
+    const faq = generateFaqJsonLd(sampleYacht, "en");
+    expect(faq).not.toBeNull();
+    expect(faq!["@type"]).toBe("FAQPage");
+    const questions = faq!.mainEntity.map((q) => q.name);
+    expect(questions.some((q) => q.includes("How much does"))).toBe(true);
+    expect(questions.some((q) => q.includes("How long is"))).toBe(true);
+    expect(questions.some((q) => q.includes("draft of"))).toBe(true);
+    expect(questions.some((q) => q.includes("How many cabins"))).toBe(true);
+  });
+
+  it("generates French FAQ questions", () => {
+    const faq = generateFaqJsonLd(sampleYacht, "fr");
+    expect(faq).not.toBeNull();
+    expect(faq!["@type"]).toBe("FAQPage");
+    const questions = faq!.mainEntity.map((q) => q.name);
+    expect(questions.some((q) => q.includes("Combien pèse"))).toBe(true);
+    expect(questions.some((q) => q.includes("Quelle est la longueur"))).toBe(true);
+    expect(questions.some((q) => q.includes("tirant d'eau"))).toBe(true);
+    expect(questions.some((q) => q.includes("Combien de cabines"))).toBe(true);
+  });
+
+  it("generates French FAQ answers", () => {
+    const faq = generateFaqJsonLd(sampleYacht, "fr");
+    const answers = faq!.mainEntity.map((q) => q.acceptedAnswer.text);
+    expect(answers.some((a) => a.includes("déplacement"))).toBe(true);
+    expect(answers.some((a) => a.includes("longueur hors tout"))).toBe(true);
+    expect(answers.some((a) => a.includes("tirant d'eau"))).toBe(true);
+    expect(answers.some((a) => a.includes("cabine"))).toBe(true);
+  });
+
+  it("returns null when yacht has no relevant specs", () => {
+    const minimalYacht = {
+      manufacturer: "Unknown",
+      modelName: "Mystery",
+    };
+    const faq = generateFaqJsonLd(minimalYacht, "en");
+    expect(faq).toBeNull();
+  });
+});


### PR DESCRIPTION
- Add buildLocaleAlternates() helper for consistent hreflang tags across all pages
- All pages now have correct <link rel=alternate hreflang=en/fr> via alternates metadata
- Sitemap generators (pages, yachts, manufacturers, guides, compare, images) include /en/ and /fr/ variants
- generateWebsiteJsonLd() accepts locale param for French site description
- generateYachtJsonLd() translates property names (Longueur hors tout, Tirant d'eau, etc.)
- generateFaqJsonLd() generates fully translated French FAQ questions and answers
- generateBreadcrumbJsonLd() prefixes URLs with locale
- French RSS feed at /[locale]/feed.xml with French channel info
- French guides RSS at /[locale]/guides/feed.xml with French channel titles
- 20 unit tests covering hreflang alternates, localized JSON-LD, French property names, FAQ translations
