### PR TITLE
P15.2: Spec bars on yacht detail page

### DIFF
--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -27,6 +27,12 @@ import SourceProvenance from "@/components/SourceProvenance";
 import { ReviewSummary } from "@/components/ReviewSummary";
 import { ReviewSubmissionForm } from "@/components/ReviewSubmissionForm";
 import { CorrectionForm } from "@/components/CorrectionForm";
+import dynamic from "next/dynamic";
+
+const SpecBarsChart = dynamic(
+  () => import("@/components/spec-bars-chart").then((m) => ({ default: m.SpecBarsChart })),
+  { ssr: false, loading: () => null },
+);
 
 interface SpecGroup {
   [group: string]: Array<{
@@ -432,6 +438,19 @@ export default function YachtDetailClient() {
       </div>
 
 
+
+      {/* P15.2: Spec Bars Visualization */}
+      <SpecBarsChart
+        yachtSpecs={{
+          lengthOverall: yacht.lengthOverall,
+          beam: yacht.beam,
+          draft: yacht.draft,
+          displacement: yacht.displacement,
+          ballast: yacht.ballast,
+          sailAreaMain: yacht.sailAreaMain,
+          engineHp: yacht.engineHp,
+        }}
+      />
 
       {/* Source Provenance (P10.3) */}
       <SourceProvenance

--- a/app/api/yachts/size-class-stats/route.ts
+++ b/app/api/yachts/size-class-stats/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+import { unstable_cache } from 'next/cache';
+
+export const dynamic = 'force-dynamic';
+
+interface SpecStats {
+  min: number;
+  max: number;
+  avg: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  count: number;
+}
+
+interface SizeClassStats {
+  sizeClass: { min: number; max: number };
+  count: number;
+  specs: Record<string, SpecStats>;
+}
+
+const SPEC_COLUMNS = [
+  'length_overall',
+  'beam',
+  'draft',
+  'displacement',
+  'ballast',
+  'sail_area_main',
+  'engine_hp',
+] as const;
+
+async function computeSizeClassStats(loaMin: number, loaMax: number): Promise<SizeClassStats> {
+  const { rows } = await pool.query(
+    `SELECT
+      ${SPEC_COLUMNS.map(col => `
+        MIN(${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_min,
+        MAX(${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_max,
+        AVG(${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_avg,
+        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY ${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_p25,
+        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY ${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_p50,
+        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_p75,
+        COUNT(${col}) FILTER (WHERE ${col} IS NOT NULL) AS ${col}_count
+      `).join(', ')}
+    FROM yacht_models
+    WHERE length_overall BETWEEN $1 AND $2`,
+    [loaMin, loaMax],
+  );
+
+  const row = rows[0];
+  const specs: Record<string, SpecStats> = {};
+
+  for (const col of SPEC_COLUMNS) {
+    const count = Number(row[`${col}_count`]) || 0;
+    if (count > 0) {
+      specs[col] = {
+        min: Number(row[`${col}_min`]),
+        max: Number(row[`${col}_max`]),
+        avg: Number(Number(row[`${col}_avg`]).toFixed(2)),
+        p25: Number(Number(row[`${col}_p25`]).toFixed(2)),
+        p50: Number(Number(row[`${col}_p50`]).toFixed(2)),
+        p75: Number(Number(row[`${col}_p75`]).toFixed(2)),
+        count,
+      };
+    }
+  }
+
+  // Total count in size class
+  const countResult = await pool.query(
+    `SELECT COUNT(*) AS total FROM yacht_models WHERE length_overall BETWEEN $1 AND $2`,
+    [loaMin, loaMax],
+  );
+
+  return {
+    sizeClass: { min: loaMin, max: loaMax },
+    count: Number(countResult.rows[0].total),
+    specs,
+  };
+}
+
+function getCachedStats(loaMin: number, loaMax: number) {
+  return unstable_cache(
+    () => computeSizeClassStats(loaMin, loaMax),
+    [`size-class-stats:${loaMin}-${loaMax}`],
+    { tags: ['yachts'], revalidate: 300 },
+  )();
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const loa = parseFloat(searchParams.get('loa') || '');
+
+  if (!loa || loa <= 0) {
+    return NextResponse.json(
+      { error: 'loa parameter is required and must be positive' },
+      { status: 400 },
+    );
+  }
+
+  // Size class = ±20% of LOA
+  const loaMin = +(loa * 0.8).toFixed(2);
+  const loaMax = +(loa * 1.2).toFixed(2);
+
+  try {
+    const stats = await getCachedStats(loaMin, loaMax);
+    return NextResponse.json(stats);
+  } catch (err) {
+    console.error('Error computing size-class stats:', err);
+    return NextResponse.json(
+      { error: 'Failed to compute size-class statistics' },
+      { status: 500 },
+    );
+  }
+}

--- a/components/spec-bars-chart.tsx
+++ b/components/spec-bars-chart.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import React, { useMemo, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Cell,
+} from "recharts";
+
+interface SpecStats {
+  min: number;
+  max: number;
+  avg: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  count: number;
+}
+
+interface SizeClassStats {
+  sizeClass: { min: number; max: number };
+  count: number;
+  specs: Record<string, SpecStats>;
+}
+
+interface SpecBarEntry {
+  name: string;
+  rawLabel: string;
+  value: number;
+  min: number;
+  max: number;
+  avg: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  percentile: number;
+  unit: string;
+}
+
+/** Color based on percentile within size class */
+function getBarColor(percentile: number): string {
+  if (percentile < 30) return "#3b82f6"; // below avg — blue
+  if (percentile > 70) return "#10b981"; // above avg — green
+  return "#6366f1"; // average — indigo
+}
+
+function getCategoryLabel(percentile: number, t: (key: string) => string): string {
+  if (percentile < 30) return t("specBars.belowAverage");
+  if (percentile > 70) return t("specBars.aboveAverage");
+  return t("specBars.average");
+}
+
+interface SpecBarsChartProps {
+  /** Yacht's own numeric spec values */
+  yachtSpecs: {
+    lengthOverall: number | null;
+    beam: number | null;
+    draft: number | null;
+    displacement: number | null;
+    ballast: number | null;
+    sailAreaMain: number | null;
+    engineHp: number | null;
+  };
+}
+
+/** Map our spec keys to DB column names */
+const SPEC_CONFIG: Array<{
+  key: string;
+  dbKey: string;
+  unit: string;
+  decimals?: number;
+}> = [
+  { key: "lengthOverall", dbKey: "length_overall", unit: "m", decimals: 2 },
+  { key: "beam", dbKey: "beam", unit: "m", decimals: 2 },
+  { key: "draft", dbKey: "draft", unit: "m", decimals: 2 },
+  { key: "displacement", dbKey: "displacement", unit: "kg", decimals: 0 },
+  { key: "ballast", dbKey: "ballast", unit: "kg", decimals: 0 },
+  { key: "sailAreaMain", dbKey: "sail_area_main", unit: "m²", decimals: 1 },
+  { key: "engineHp", dbKey: "engine_hp", unit: "hp", decimals: 0 },
+];
+
+export function SpecBarsChart({ yachtSpecs }: SpecBarsChartProps) {
+  const t = useTranslations("YachtDetail");
+  const [stats, setStats] = useState<SizeClassStats | null>(null);
+  const [visible, setVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Determine LOA for API call
+  const loa = yachtSpecs.lengthOverall;
+  const [loaded, setLoaded] = useState(false);
+
+  // Intersection observer for scroll animation
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  // Fetch size-class stats
+  useEffect(() => {
+    if (!loa || loaded) return;
+    setLoaded(true);
+
+    fetch(`/api/yachts/size-class-stats?loa=${loa}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (data && !data.error) setStats(data);
+      })
+      .catch(() => {
+        // Silently fail — chart is non-critical
+      });
+  }, [loa, loaded]);
+
+  // Build chart data
+  const chartEntries = useMemo<SpecBarEntry[]>(() => {
+    if (!stats) return [];
+
+    const entries: SpecBarEntry[] = [];
+    for (const cfg of SPEC_CONFIG) {
+      const value = yachtSpecs[cfg.key as keyof typeof yachtSpecs] as number | null;
+      if (value === null || value === undefined) continue;
+
+      const specStats = stats.specs[cfg.dbKey];
+      if (!specStats || specStats.count < 3) continue;
+
+      // Calculate percentile: where this yacht sits in its size class
+      const range = specStats.max - specStats.min;
+      const percentile = range > 0
+        ? Math.round(((value - specStats.min) / range) * 100)
+        : 50;
+
+      entries.push({
+        name: t(`specBars.specs.${cfg.key}` as any),
+        rawLabel: cfg.key,
+        value,
+        min: specStats.min,
+        max: specStats.max,
+        avg: specStats.avg,
+        p25: specStats.p25,
+        p50: specStats.p50,
+        p75: specStats.p75,
+        percentile,
+        unit: cfg.unit,
+      });
+    }
+    return entries;
+  }, [stats, yachtSpecs, t]);
+
+  if (!stats || chartEntries.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="spec-bars-section mt-8" data-testid="spec-bars-section">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg sm:text-xl font-bold">{t("specBars.title")}</h2>
+        <span className="text-xs text-muted-foreground">
+          {t("specBars.sizeClass", {
+            min: stats.sizeClass.min.toFixed(1),
+            max: stats.sizeClass.max.toFixed(1),
+            count: stats.count,
+          })}
+        </span>
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-4">
+        {t("specBars.description")}
+      </p>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4 mb-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-[#3b82f6]" />
+          <span>{t("specBars.belowAverage")}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-[#6366f1]" />
+          <span>{t("specBars.average")}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-[#10b981]" />
+          <span>{t("specBars.aboveAverage")}</span>
+        </div>
+      </div>
+
+      {/* Individual spec bars */}
+      <div className="space-y-4">
+        {chartEntries.map((entry) => {
+          const range = entry.max - entry.min;
+          // Normalized value position (0-100)
+          const valuePos = range > 0 ? ((entry.value - entry.min) / range) * 100 : 50;
+          const avgPos = range > 0 ? ((entry.avg - entry.min) / range) * 100 : 50;
+
+          return (
+            <div key={entry.rawLabel} className="spec-bar-item">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm font-medium">{entry.name}</span>
+                <span className="text-sm font-semibold">
+                  {entry.value.toLocaleString(undefined, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 2,
+                  })} {entry.unit}
+                  <span className="ml-2 text-xs font-normal text-muted-foreground">
+                    ({getCategoryLabel(entry.percentile, t)})
+                  </span>
+                </span>
+              </div>
+              <div className="relative h-6 bg-gray-100 rounded-full overflow-hidden">
+                {/* Background range bar */}
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full h-2 bg-gray-200 rounded-full relative">
+                    {/* P25-P75 range indicator */}
+                    <div
+                      className="absolute h-full bg-gray-300 rounded-full"
+                      style={{
+                        left: `${range > 0 ? ((entry.p25 - entry.min) / range) * 100 : 25}%`,
+                        right: `${range > 0 ? 100 - ((entry.p75 - entry.min) / range) * 100 : 25}%`,
+                      }}
+                    />
+                    {/* Average line */}
+                    <div
+                      className="absolute h-full w-0.5 bg-gray-500"
+                      style={{ left: `${avgPos}%` }}
+                    />
+                  </div>
+                </div>
+                {/* Value marker — animated */}
+                <div
+                  className={`absolute top-0 h-full w-1.5 rounded-full transition-all duration-1000 ease-out ${visible ? 'opacity-100' : 'opacity-0'}`}
+                  style={{
+                    left: visible ? `${Math.max(0, Math.min(valuePos - 1, 98))}%` : '0%',
+                    backgroundColor: getBarColor(entry.percentile),
+                  }}
+                />
+              </div>
+              <div className="flex justify-between text-xs text-muted-foreground mt-0.5">
+                <span>{entry.min.toLocaleString()} {entry.unit}</span>
+                <span>{t("specBars.avg")}: {entry.avg.toLocaleString()} {entry.unit}</span>
+                <span>{entry.max.toLocaleString()} {entry.unit}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Accessible data table */}
+      <details className="mt-4">
+        <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+          {t("specBars.dataTableToggle")}
+        </summary>
+        <table className="mt-2 w-full text-xs border-collapse border border-border">
+          <thead>
+            <tr>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.spec")}</th>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.yachtValue")}</th>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.classMin")}</th>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.classAvg")}</th>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.classMax")}</th>
+              <th className="border border-border px-2 py-1 bg-muted text-left">{t("specBars.table.percentile")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chartEntries.map((entry) => (
+              <tr key={entry.rawLabel}>
+                <td className="border border-border px-2 py-1 font-medium">{entry.name}</td>
+                <td className="border border-border px-2 py-1">{entry.value.toLocaleString()} {entry.unit}</td>
+                <td className="border border-border px-2 py-1">{entry.min.toLocaleString()}</td>
+                <td className="border border-border px-2 py-1">{entry.avg.toLocaleString()}</td>
+                <td className="border border-border px-2 py-1">{entry.max.toLocaleString()}</td>
+                <td className="border border-border px-2 py-1">{entry.percentile}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -326,6 +326,33 @@
       "engineType": "Engine Type",
       "fuelCapacity": "Fuel Capacity",
       "waterCapacity": "Water Capacity"
+    },
+    "specBars": {
+      "title": "How It Compares",
+      "description": "See where this yacht's specs sit relative to similar-sized boats ({sizeClassRange}). Bars show the range across the size class, with your yacht's position highlighted.",
+      "sizeClass": "Size class: {min}–{max}m LOA ({count} yachts)",
+      "belowAverage": "Below average",
+      "average": "Average",
+      "aboveAverage": "Above average",
+      "avg": "Avg",
+      "dataTableToggle": "View data table (accessible)",
+      "specs": {
+        "lengthOverall": "Length Overall",
+        "beam": "Beam",
+        "draft": "Draft",
+        "displacement": "Displacement",
+        "ballast": "Ballast",
+        "sailAreaMain": "Sail Area",
+        "engineHp": "Engine Power"
+      },
+      "table": {
+        "spec": "Spec",
+        "yachtValue": "Yacht",
+        "classMin": "Class Min",
+        "classAvg": "Class Avg",
+        "classMax": "Class Max",
+        "percentile": "Percentile"
+      }
     }
   },
   "YachtDetailSub": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -326,6 +326,33 @@
       "engineType": "Type de moteur",
       "fuelCapacity": "Capacité carburant",
       "waterCapacity": "Capacité eau"
+    },
+    "specBars": {
+      "title": "Comparaison",
+      "description": "Voir où les caractéristiques de ce voilier se situent par rapport à des bateaux de taille similaire ({sizeClassRange}). Les barres montrent l'éventail de la classe de taille, avec la position de votre voilier mise en évidence.",
+      "sizeClass": "Catégorie de taille : LOA {min}–{max}m ({count} voiliers)",
+      "belowAverage": "Sous la moyenne",
+      "average": "Moyenne",
+      "aboveAverage": "Au-dessus de la moyenne",
+      "avg": "Moy.",
+      "dataTableToggle": "Voir le tableau de données (accessible)",
+      "specs": {
+        "lengthOverall": "Longueur hors tout",
+        "beam": "Bau",
+        "draft": "Tirant d'eau",
+        "displacement": "Déplacement",
+        "ballast": "Quille lest",
+        "sailAreaMain": "Surface de voilure",
+        "engineHp": "Puissance moteur"
+      },
+      "table": {
+        "spec": "Caractéristique",
+        "yachtValue": "Voilier",
+        "classMin": "Min catégorie",
+        "classAvg": "Moy. catégorie",
+        "classMax": "Max catégorie",
+        "percentile": "Percentile"
+      }
     }
   },
   "YachtDetailSub": {

--- a/tests/spec-bars.test.ts
+++ b/tests/spec-bars.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+
+// ─── Percentile & color logic (mirrors component logic) ────────────
+
+function getBarColor(percentile: number): string {
+  if (percentile < 30) return "#3b82f6";
+  if (percentile > 70) return "#10b981";
+  return "#6366f1";
+}
+
+function calculatePercentile(value: number, min: number, max: number): number {
+  const range = max - min;
+  if (range === 0) return 50;
+  return Math.round(((value - min) / range) * 100);
+}
+
+describe("Spec Bars — percentile calculation", () => {
+  it("returns 50 for equal min/max", () => {
+    expect(calculatePercentile(10, 10, 10)).toBe(50);
+  });
+
+  it("returns 0 when value equals min", () => {
+    expect(calculatePercentile(5, 5, 10)).toBe(0);
+  });
+
+  it("returns 100 when value equals max", () => {
+    expect(calculatePercentile(10, 5, 10)).toBe(100);
+  });
+
+  it("returns 50 when value is midpoint", () => {
+    expect(calculatePercentile(7.5, 5, 10)).toBe(50);
+  });
+
+  it("handles decimal values correctly", () => {
+    // 12.3 is 46% of the way from 10 to 15.6
+    const result = calculatePercentile(12.3, 10, 15.6);
+    expect(result).toBe(41); // (12.3-10)/(15.6-10) = 2.3/5.6 = 0.4107 -> 41
+  });
+
+  it("clamps to integer percentiles", () => {
+    const result = calculatePercentile(7.7, 5, 10);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+describe("Spec Bars — color coding", () => {
+  it("blue for below average (<30)", () => {
+    expect(getBarColor(0)).toBe("#3b82f6");
+    expect(getBarColor(29)).toBe("#3b82f6");
+  });
+
+  it("indigo for average range (30-70)", () => {
+    expect(getBarColor(30)).toBe("#6366f1");
+    expect(getBarColor(50)).toBe("#6366f1");
+    expect(getBarColor(70)).toBe("#6366f1");
+  });
+
+  it("green for above average (>70)", () => {
+    expect(getBarColor(71)).toBe("#10b981");
+    expect(getBarColor(100)).toBe("#10b981");
+  });
+});
+
+describe("Spec Bars — size class range calculation", () => {
+  it("computes ±20% of LOA correctly", () => {
+    const loa = 12;
+    const loaMin = +(loa * 0.8).toFixed(2);
+    const loaMax = +(loa * 1.2).toFixed(2);
+    expect(loaMin).toBe(9.6);
+    expect(loaMax).toBe(14.4);
+  });
+
+  it("handles small LOA values", () => {
+    const loa = 6;
+    const loaMin = +(loa * 0.8).toFixed(2);
+    const loaMax = +(loa * 1.2).toFixed(2);
+    expect(loaMin).toBe(4.8);
+    expect(loaMax).toBe(7.2);
+  });
+
+  it("handles large LOA values", () => {
+    const loa = 25;
+    const loaMin = +(loa * 0.8).toFixed(2);
+    const loaMax = +(loa * 1.2).toFixed(2);
+    expect(loaMin).toBe(20);
+    expect(loaMax).toBe(30);
+  });
+});
+
+describe("Spec Bars — spec filtering logic", () => {
+  // Simulates the filtering logic from the component
+  const SPEC_CONFIG = [
+    { key: "lengthOverall", dbKey: "length_overall", unit: "m" },
+    { key: "beam", dbKey: "beam", unit: "m" },
+    { key: "draft", dbKey: "draft", unit: "m" },
+    { key: "displacement", dbKey: "displacement", unit: "kg" },
+    { key: "ballast", dbKey: "ballast", unit: "kg" },
+    { key: "sailAreaMain", dbKey: "sail_area_main", unit: "m²" },
+    { key: "engineHp", dbKey: "engine_hp", unit: "hp" },
+  ];
+
+  it("only includes specs where yacht has data AND stats are available", () => {
+    const yachtSpecs = {
+      lengthOverall: 12,
+      beam: 4,
+      draft: null,
+      displacement: 8000,
+      ballast: null,
+      sailAreaMain: 80,
+      engineHp: 40,
+    };
+
+    const stats = {
+      length_overall: { min: 10, max: 15, avg: 12.5, p25: 11, p50: 12, p75: 13, count: 20 },
+      beam: { min: 3, max: 5, avg: 4, p25: 3.5, p50: 4, p75: 4.5, count: 20 },
+      displacement: { min: 5000, max: 12000, avg: 8000, p25: 6500, p50: 7500, p75: 9500, count: 18 },
+      sail_area_main: { min: 50, max: 120, avg: 85, p25: 70, p50: 82, p75: 95, count: 15 },
+      engine_hp: { min: 20, max: 75, avg: 40, p25: 30, p50: 40, p75: 55, count: 12 },
+    };
+
+    const entries = SPEC_CONFIG.filter((cfg) => {
+      const value = yachtSpecs[cfg.key as keyof typeof yachtSpecs];
+      if (value === null || value === undefined) return false;
+      const specStats = stats[cfg.dbKey as keyof typeof stats];
+      if (!specStats || specStats.count < 3) return false;
+      return true;
+    });
+
+    expect(entries).toHaveLength(5); // all except draft and ballast
+    expect(entries.map((e) => e.key)).toEqual([
+      "lengthOverall", "beam", "displacement", "sailAreaMain", "engineHp",
+    ]);
+  });
+
+  it("excludes specs with fewer than 3 data points", () => {
+    const yachtSpecs = { lengthOverall: 12, beam: null, draft: null, displacement: null, ballast: null, sailAreaMain: null, engineHp: null };
+    const stats = {
+      length_overall: { min: 10, max: 15, avg: 12.5, p25: 11, p50: 12, p75: 13, count: 2 }, // too few
+    };
+
+    const entries = SPEC_CONFIG.filter((cfg) => {
+      const value = yachtSpecs[cfg.key as keyof typeof yachtSpecs];
+      if (value === null || value === undefined) return false;
+      const specStats = stats[cfg.dbKey as keyof typeof stats];
+      if (!specStats || specStats.count < 3) return false;
+      return true;
+    });
+
+    expect(entries).toHaveLength(0);
+  });
+});
+
+describe("Spec Bars — API endpoint validation", () => {
+  it("LOA parameter is required", () => {
+    const url = new URL("http://localhost/api/yachts/size-class-stats");
+    const loa = url.searchParams.get("loa");
+    expect(loa).toBeNull();
+  });
+
+  it("LOA must be positive", () => {
+    const loa = parseFloat("-5");
+    expect(loa <= 0).toBe(true);
+  });
+
+  it("valid LOA computes correct size class", () => {
+    const loa = parseFloat("12.5");
+    expect(loa).toBeGreaterThan(0);
+    const loaMin = +(loa * 0.8).toFixed(2);
+    const loaMax = +(loa * 1.2).toFixed(2);
+    expect(loaMin).toBe(10);
+    expect(loaMax).toBe(15);
+  });
+});


### PR DESCRIPTION
## Summary
Adds interactive spec bar visualizations to the yacht detail page showing where each yacht sits relative to its size class.

### Changes
- **New API**: `/api/yachts/size-class-stats` — computes min/max/avg/percentile stats for yachts within ±20% LOA
- **New component**: `SpecBarsChart` — animated horizontal bars with color-coded ranges
  - Blue: below average (<30th percentile)
  - Indigo: average (30-70th percentile)  
  - Green: above average (>70th percentile)
- **Scroll animation**: bars animate into view using IntersectionObserver
- **Accessibility**: data table behind `<details>` toggle for screen readers
- **Performance**: dynamically imported, no SSR bundle bloat
- **i18n**: full English + French translations
- **Tests**: 17 unit tests for percentile, color, range, and filtering logic

Closes #244