### PR TITLE
feat(compare): add yacht toggle controls and integrate radar chart into canonical pages

### DIFF
--- a/app/[locale]/compare/[slugA]-vs-[slugB]/CanonicalCompareClient.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/CanonicalCompareClient.tsx
@@ -4,6 +4,11 @@ import dynamic from "next/dynamic";
 import type { YachtComparisonData } from "@/lib/compare-canonical";
 import { CompareMonetization } from "@/app/components/CompareMonetization";
 
+const ComparisonRadarChart = dynamic(
+  () => import("@/components/comparison-radar-chart").then(m => ({ default: m.ComparisonRadarChart })),
+  { ssr: false, loading: () => null },
+);
+
 const ComparisonBarCharts = dynamic(
   () => import("@/components/comparison-bar-charts").then(m => ({ default: m.ComparisonBarCharts })),
   { ssr: false, loading: () => null },
@@ -71,7 +76,10 @@ export function CanonicalCompareClient({ yachtA, yachtB }: CanonicalCompareClien
 
   return (
     <div className="max-w-5xl mx-auto mt-12">
-      <ComparisonBarCharts yachts={specYachts} />
+      <ComparisonRadarChart yachts={specYachts} />
+      <div className="mt-8">
+        <ComparisonBarCharts yachts={specYachts} />
+      </div>
       <div className="mt-8">
         <CompareMonetization yachts={monetizationYachts} />
       </div>

--- a/components/comparison-radar-chart.tsx
+++ b/components/comparison-radar-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import {
   RadarChart,
@@ -60,15 +60,21 @@ function normalise(value: number, min: number, max: number): number {
 /**
  * Build chart data: one entry per spec axis.
  * Each entry has { spec: translatedLabel, yacht_0: normalisedValue, … }.
+ *
+ * Visibility filtering: only visible yachts are used for min/max calculation,
+ * so the scale adapts to the visible subset.
  */
 function buildChartData(
   yachts: YachtSpecData[],
   labels: Record<string, string>,
+  visibleIndices: Set<number>,
 ): ChartEntry[] {
-  // Compute min/max per spec
+  const visibleYachts = yachts.filter((_, i) => visibleIndices.has(i));
+
+  // Compute min/max per spec across visible yachts only
   const ranges: Record<string, { min: number; max: number }> = {};
   for (const key of RADAR_SPEC_KEYS) {
-    const values = yachts
+    const values = visibleYachts
       .map((y) => y[key])
       .filter((v): v is number => v !== null && v !== undefined);
     if (values.length === 0) continue;
@@ -84,6 +90,10 @@ function buildChartData(
       spec: labels[key as string] || (key as string),
     };
     yachts.forEach((yacht, i) => {
+      if (!visibleIndices.has(i)) {
+        entry[`yacht_${i}`] = 0;
+        return;
+      }
       const raw = yacht[key] as number | null | undefined;
       entry[`yacht_${i}`] =
         raw !== null && raw !== undefined
@@ -96,6 +106,25 @@ function buildChartData(
 
 export function ComparisonRadarChart({ yachts }: ComparisonRadarChartProps) {
   const t = useTranslations("Compare");
+
+  // Visibility state: track which yachts are visible (all start visible)
+  const [visibleSet, setVisibleSet] = useState<Set<number>>(
+    () => new Set(yachts.map((_, i) => i)),
+  );
+
+  const toggleYacht = useCallback((index: number) => {
+    setVisibleSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        // Don't allow hiding all yachts — must have at least 1 visible
+        if (next.size <= 1) return prev;
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  }, []);
 
   const labels = useMemo(
     () => ({
@@ -110,7 +139,10 @@ export function ComparisonRadarChart({ yachts }: ComparisonRadarChartProps) {
     [t],
   );
 
-  const chartData = useMemo(() => buildChartData(yachts, labels), [yachts, labels]);
+  const chartData = useMemo(
+    () => buildChartData(yachts, labels, visibleSet),
+    [yachts, labels, visibleSet],
+  );
 
   if (yachts.length < 2 || chartData.length < 3) return null;
 
@@ -122,6 +154,43 @@ export function ComparisonRadarChart({ yachts }: ComparisonRadarChartProps) {
         </h3>
         <span className="text-xs text-gray-500">{t("radar.scaleNote")}</span>
       </div>
+
+      {/* Yacht toggle buttons */}
+      <div className="flex flex-wrap gap-2 mb-3">
+        {yachts.map((yacht, i) => {
+          const isVisible = visibleSet.has(i);
+          const color = CHART_COLORS[i % CHART_COLORS.length];
+          return (
+            <button
+              key={yacht.id}
+              onClick={() => toggleYacht(i)}
+              className={`
+                inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium
+                transition-all duration-200 border
+                ${
+                  isVisible
+                    ? "border-transparent text-white shadow-sm"
+                    : "border-gray-300 text-gray-500 bg-white hover:bg-gray-50"
+                }
+              `}
+              style={
+                isVisible
+                  ? { backgroundColor: color, opacity: 1 }
+                  : { opacity: 0.7 }
+              }
+              aria-pressed={isVisible}
+              aria-label={`${isVisible ? t("radar.hide") : t("radar.show")} ${yacht.manufacturer} ${yacht.modelName}`}
+            >
+              <span
+                className={`w-2.5 h-2.5 rounded-full ${isVisible ? "bg-white" : ""}`}
+                style={!isVisible ? { backgroundColor: color } : undefined}
+              />
+              {yacht.manufacturer} {yacht.modelName}
+            </button>
+          );
+        })}
+      </div>
+
       <div className="bg-white rounded-xl border border-gray-200 p-4">
         <ResponsiveContainer width="100%" height={380}>
           <RadarChart cx="50%" cy="50%" outerRadius="75%" data={chartData}>
@@ -136,17 +205,21 @@ export function ComparisonRadarChart({ yachts }: ComparisonRadarChartProps) {
               tick={{ fontSize: 10, fill: "#9ca3af" }}
               tickCount={5}
             />
-            {yachts.map((yacht, i) => (
-              <Radar
-                key={yacht.id}
-                name={`${yacht.manufacturer} ${yacht.modelName}`}
-                dataKey={`yacht_${i}`}
-                stroke={CHART_COLORS[i % CHART_COLORS.length]}
-                fill={CHART_COLORS[i % CHART_COLORS.length]}
-                fillOpacity={0.15}
-                strokeWidth={2}
-              />
-            ))}
+            {yachts.map((yacht, i) => {
+              const isVisible = visibleSet.has(i);
+              return (
+                <Radar
+                  key={yacht.id}
+                  name={`${yacht.manufacturer} ${yacht.modelName}`}
+                  dataKey={`yacht_${i}`}
+                  stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                  fill={CHART_COLORS[i % CHART_COLORS.length]}
+                  fillOpacity={isVisible ? 0.15 : 0}
+                  strokeWidth={isVisible ? 2 : 0}
+                  strokeOpacity={isVisible ? 1 : 0}
+                />
+              );
+            })}
             <Legend />
             <Tooltip
               contentStyle={{
@@ -187,7 +260,7 @@ export function ComparisonRadarChart({ yachts }: ComparisonRadarChartProps) {
                 </td>
                 {yachts.map((_, i) => (
                   <td key={i} className="border border-gray-200 px-2 py-1">
-                    {row[`yacht_${i}`]}
+                    {visibleSet.has(i) ? row[`yacht_${i}`] : "—"}
                   </td>
                 ))}
               </tr>

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,44 +1,36 @@
 # Sailing Yachts Builder Session Summary
 
-**Date:** 2026-05-06
-**Issue worked on:** #244 / PR #245 + #246 - P15.2: Spec bars on yacht detail page
+**Date:** 2026-05-07
+**Issue worked on:** #250 / PR #251 - P15.4: Length distribution chart on yacht listing page
 
 ## What was implemented
-- **New API endpoint**: `/api/size-class-stats?loa=X` — computes min/max/avg/percentile stats for yachts within ±20% of given LOA. Uses PostgreSQL PERCENTILE_CONT for accurate percentile calculations. Cached with unstable_cache (5 min TTL).
-- **SpecBarsChart component**: Animated horizontal bar visualizations on yacht detail page
-  - Shows where each spec (LOA, beam, draft, displacement, ballast, sail area, engine HP) sits relative to its size class
-  - Color-coded: blue (<30th percentile), indigo (30-70th), green (>70th)
-  - Scroll animation via IntersectionObserver
+- **New API endpoint**: `/api/length-distribution` — returns 10 histogram bins (0-6m through 25m+) with yacht counts per bin. Uses SQL CASE expression for binning. Cached with unstable_cache (5 min TTL).
+- **LengthDistributionChart component**: Recharts bar chart on `/yachts` page
+  - Shows length distribution of all 201 yachts across 10 bins
+  - Highlights bins matching current lengthMin/lengthMax filter range (blue) vs dimmed (gray)
+  - Lazy-loaded via IntersectionObserver + next/dynamic (no SSR bundle impact)
   - Accessible data table behind `<details>` toggle
-  - Dynamically imported (no SSR bundle impact)
   - Full i18n (English + French)
-- **17 unit tests**: percentile calculation, color coding, size class range, spec filtering, API validation
+- **10 unit tests**: bin index calculation, boundary values, filter highlighting, response shape validation
 
 ## Build/Test Results
 - **Typecheck**: ✅ Pass
 - **Build**: ✅ Pass
-- **Vitest tests**: ✅ 17/17 pass
+- **Vitest tests**: ✅ 10/10 pass
 - **CI**: ✅ All checks pass (Lint, TypeScript, Build, Performance Budgets)
 
 ## Deploy Status
-- **PR #245**: ✅ Merged (squash) — initial implementation
-- **PR #246**: ✅ Merged (squash) — fix API route collision
+- **PR #251**: ✅ Merged (squash)
 - **Vercel**: ✅ Production deployed
-
-## Issue Found and Fixed Post-Deploy
-- `/api/yachts/size-class-stats` was caught by Vercel's `/api/yachts/[slug]` dynamic route (404)
-- **Fix**: Moved endpoint to `/api/size-class-stats` to avoid collision
-- Deployed as PR #246
 
 ## Live Verification Results
 - **/**: ✅ OK
-- **/yachts**: ✅ OK
+- **/yachts**: ✅ OK (69821 bytes, distribution references found in HTML)
 - **/search**: ✅ OK
 - **/compare**: ✅ OK
-- **/yachts/bavaria-c42-2021**: ✅ OK
 - **API /api/yachts**: ✅ 201 yachts
-- **API /api/size-class-stats?loa=12.5**: ✅ 118 yachts, 7 specs with percentile data
-- **spec-bars-section present in HTML**: ✅ Confirmed
+- **API /api/length-distribution**: ✅ 10 bins, 201 total yachts
+  - Distribution: 0-6m(1), 6-8m(6), 8-10m(26), 10-12m(46), 12-14m(55), 14-16m(32), 16-18m(16), 18-20m(10), 20-25m(7), 25m+(2)
 
 ## Next Recommended Task
-- **P15.3 — Side-by-side bar charts on compare detail**: Add grouped bar charts below the comparison table on `/compare/[slugA]-vs-[slugB]` pages
+- **P15.5 — Manufacturer fleet overview charts**: On `/manufacturers/[slug]` pages, add chart showing manufacturer's yacht lineup by size with year of introduction

--- a/memory/dreaming/deep/2026-05-07.md
+++ b/memory/dreaming/deep/2026-05-07.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/light/2026-05-07.md
+++ b/memory/dreaming/light/2026-05-07.md
@@ -1,0 +1,3 @@
+# Light Sleep
+
+- No notable updates.

--- a/memory/dreaming/rem/2026-05-07.md
+++ b/memory/dreaming/rem/2026-05-07.md
@@ -1,0 +1,7 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- No strong candidate truths surfaced.

--- a/messages/en.json
+++ b/messages/en.json
@@ -456,7 +456,9 @@
     "radar": {
       "title": "Spec Comparison",
       "scaleNote": "Values normalized 0–100 relative to selected yachts",
-      "dataTableToggle": "Show data table"
+      "dataTableToggle": "Show data table",
+      "show": "Show",
+      "hide": "Hide"
     },
     "barCharts": {
       "specTitle": "Spec Comparison",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -456,7 +456,9 @@
     "radar": {
       "title": "Comparaison des spécifications",
       "scaleNote": "Valeurs normalisées de 0 à 100 par rapport aux yachts sélectionnés",
-      "dataTableToggle": "Afficher le tableau de données"
+      "dataTableToggle": "Afficher le tableau de données",
+      "show": "Afficher",
+      "hide": "Masquer"
     },
     "barCharts": {
       "specTitle": "Comparaison des spécifications",

--- a/tests/comparison-radar.test.ts
+++ b/tests/comparison-radar.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the comparison radar chart normalization logic.
  *
- * Covers: normalise function, buildChartData function, edge cases.
+ * Covers: normalise function, buildChartData function, toggle logic, edge cases.
  */
 import { describe, it, expect } from "vitest";
 
@@ -42,10 +42,13 @@ interface ChartEntry {
 function buildChartData(
   yachts: YachtSpecData[],
   labels: Record<string, string>,
+  visibleIndices: Set<number>,
 ): ChartEntry[] {
+  const visibleYachts = yachts.filter((_, i) => visibleIndices.has(i));
+
   const ranges: Record<string, { min: number; max: number }> = {};
   for (const key of RADAR_SPEC_KEYS) {
-    const values = yachts
+    const values = visibleYachts
       .map((y) => y[key])
       .filter((v): v is number => v !== null && v !== undefined);
     if (values.length === 0) continue;
@@ -61,6 +64,10 @@ function buildChartData(
       spec: labels[key as string] || (key as string),
     };
     yachts.forEach((yacht, i) => {
+      if (!visibleIndices.has(i)) {
+        entry[`yacht_${i}`] = 0;
+        return;
+      }
       const raw = yacht[key] as number | null | undefined;
       entry[`yacht_${i}`] =
         raw !== null && raw !== undefined
@@ -70,6 +77,44 @@ function buildChartData(
     return entry;
   });
 }
+
+// Shared test fixtures
+const labels: Record<string, string> = {
+  lengthOverall: "Length Overall",
+  beam: "Beam",
+  draft: "Draft",
+  displacement: "Displacement",
+  ballast: "Ballast",
+  sailAreaMain: "Sail Area",
+  engineHp: "Engine HP",
+};
+
+const yachts: YachtSpecData[] = [
+  {
+    id: 1,
+    manufacturer: "Beneteau",
+    modelName: "Oceanis 40.1",
+    lengthOverall: 12.43,
+    beam: 3.99,
+    draft: 2.4,
+    displacement: 8300,
+    ballast: 2500,
+    sailAreaMain: 74,
+    engineHp: 45,
+  },
+  {
+    id: 2,
+    manufacturer: "Jeanneau",
+    modelName: "Sun Odyssey 440",
+    lengthOverall: 13.39,
+    beam: 4.29,
+    draft: 2.24,
+    displacement: 9300,
+    ballast: 2800,
+    sailAreaMain: 80,
+    engineHp: 54,
+  },
+];
 
 describe("Radar chart normalise function", () => {
   it("returns 100 for max value", () => {
@@ -102,50 +147,13 @@ describe("Radar chart normalise function", () => {
 });
 
 describe("buildChartData", () => {
-  const labels: Record<string, string> = {
-    lengthOverall: "Length Overall",
-    beam: "Beam",
-    draft: "Draft",
-    displacement: "Displacement",
-    ballast: "Ballast",
-    sailAreaMain: "Sail Area",
-    engineHp: "Engine HP",
-  };
-
-  const yachts: YachtSpecData[] = [
-    {
-      id: 1,
-      manufacturer: "Beneteau",
-      modelName: "Oceanis 40.1",
-      lengthOverall: 12.43,
-      beam: 3.99,
-      draft: 2.4,
-      displacement: 8300,
-      ballast: 2500,
-      sailAreaMain: 74,
-      engineHp: 45,
-    },
-    {
-      id: 2,
-      manufacturer: "Jeanneau",
-      modelName: "Sun Odyssey 440",
-      lengthOverall: 13.39,
-      beam: 4.29,
-      draft: 2.24,
-      displacement: 9300,
-      ballast: 2800,
-      sailAreaMain: 80,
-      engineHp: 54,
-    },
-  ];
-
   it("generates one entry per spec key that has data", () => {
-    const data = buildChartData(yachts, labels);
+    const data = buildChartData(yachts, labels, new Set([0, 1]));
     expect(data).toHaveLength(RADAR_SPEC_KEYS.length);
   });
 
   it("uses translated labels for spec names", () => {
-    const data = buildChartData(yachts, labels);
+    const data = buildChartData(yachts, labels, new Set([0, 1]));
     const specNames = data.map((d) => d.spec);
     expect(specNames).toContain("Length Overall");
     expect(specNames).toContain("Beam");
@@ -153,7 +161,7 @@ describe("buildChartData", () => {
   });
 
   it("normalises min to 0 and max to 100", () => {
-    const data = buildChartData(yachts, labels);
+    const data = buildChartData(yachts, labels, new Set([0, 1]));
     const loaEntry = data.find((d) => d.spec === "Length Overall")!;
     // Beneteau 12.43 is min → 0, Jeanneau 13.39 is max → 100
     expect(loaEntry["yacht_0"]).toBe(0);
@@ -161,7 +169,7 @@ describe("buildChartData", () => {
   });
 
   it("normalises intermediate values correctly", () => {
-    const data = buildChartData(yachts, labels);
+    const data = buildChartData(yachts, labels, new Set([0, 1]));
     const dispEntry = data.find((d) => d.spec === "Displacement")!;
     // Beneteau 8300 is min → 0, Jeanneau 9300 is max → 100
     expect(dispEntry["yacht_0"]).toBe(0);
@@ -180,7 +188,7 @@ describe("buildChartData", () => {
         beam: null,
       },
     ];
-    const data = buildChartData(yachtWithNull, labels);
+    const data = buildChartData(yachtWithNull, labels, new Set([0, 1]));
     // LOA: 10 vs 20 → 0 vs 100
     const loaEntry = data.find((d) => d.spec === "Length Overall")!;
     expect(loaEntry["yacht_0"]).toBe(0);
@@ -195,13 +203,13 @@ describe("buildChartData", () => {
       { ...yachts[0], engineHp: null },
       { ...yachts[1], engineHp: null },
     ];
-    const data = buildChartData(yachtNoHp, labels);
+    const data = buildChartData(yachtNoHp, labels, new Set([0, 1]));
     const specNames = data.map((d) => d.spec);
     expect(specNames).not.toContain("Engine HP");
   });
 
   it("handles single yacht gracefully", () => {
-    const data = buildChartData([yachts[0]], labels);
+    const data = buildChartData([yachts[0]], labels, new Set([0]));
     // All values should be 50 (min === max)
     for (const entry of data) {
       expect(entry["yacht_0"]).toBe(50);
@@ -224,11 +232,73 @@ describe("buildChartData", () => {
         engineHp: 42,
       },
     ];
-    const data = buildChartData(threeYachts, labels);
+    const data = buildChartData(threeYachts, labels, new Set([0, 1, 2]));
     const loaEntry = data.find((d) => d.spec === "Length Overall")!;
     expect(Object.keys(loaEntry)).toContain("yacht_0");
     expect(Object.keys(loaEntry)).toContain("yacht_1");
     expect(Object.keys(loaEntry)).toContain("yacht_2");
+  });
+});
+
+describe("Radar chart toggle visibility", () => {
+  const threeYachts: YachtSpecData[] = [
+    ...yachts,
+    {
+      id: 3,
+      manufacturer: "Hanse",
+      modelName: "418",
+      lengthOverall: 12.4,
+      beam: 3.95,
+      draft: 2.1,
+      displacement: 8700,
+      ballast: 2600,
+      sailAreaMain: 72,
+      engineHp: 42,
+    },
+  ];
+
+  it("hiding a yacht sets its values to 0", () => {
+    // Hide yacht at index 1 (Jeanneau)
+    const data = buildChartData(threeYachts, labels, new Set([0, 2]));
+    const loaEntry = data.find((d) => d.spec === "Length Overall")!;
+    // Hidden yacht should have 0
+    expect(loaEntry["yacht_1"]).toBe(0);
+    // Visible yachts should have normalized values
+    expect(loaEntry["yacht_0"]).toBeGreaterThanOrEqual(0);
+    expect(loaEntry["yacht_2"]).toBeGreaterThanOrEqual(0);
+  });
+
+  it("recalculates normalization with only visible yachts", () => {
+    // Only yacht 0 visible → all 50 (single visible = min === max)
+    const data = buildChartData(yachts, labels, new Set([0]));
+    const loaEntry = data.find((d) => d.spec === "Length Overall")!;
+    expect(loaEntry["yacht_0"]).toBe(50);
+    // Hidden yacht gets 0
+    expect(loaEntry["yacht_1"]).toBe(0);
+  });
+
+  it("showing all yachts works same as full set", () => {
+    const allVisible = buildChartData(yachts, labels, new Set([0, 1]));
+    const defaultCall = buildChartData(yachts, labels, new Set([0, 1]));
+    expect(allVisible).toEqual(defaultCall);
+  });
+
+  it("with 3 yachts, hiding the middle one still shows others", () => {
+    const data = buildChartData(threeYachts, labels, new Set([0, 2]));
+    expect(data).toHaveLength(RADAR_SPEC_KEYS.length);
+
+    const loaEntry = data.find((d) => d.spec === "Length Overall")!;
+    // Beneteau 12.43 and Hanse 12.4 → very close, one 0 one 100
+    expect(loaEntry["yacht_1"]).toBe(0); // hidden
+    expect(typeof loaEntry["yacht_0"]).toBe("number");
+    expect(typeof loaEntry["yacht_2"]).toBe("number");
+  });
+
+  it("empty visible set returns no data (defensive)", () => {
+    // This shouldn't happen in practice due to min-1-visible guard,
+    // but verify function handles it gracefully
+    const data = buildChartData(yachts, labels, new Set());
+    expect(data).toHaveLength(0);
   });
 });
 
@@ -239,6 +309,8 @@ describe("Radar chart i18n keys", () => {
     expect(en.Compare.radar.title).toBe("Spec Comparison");
     expect(en.Compare.radar.scaleNote).toBeDefined();
     expect(en.Compare.radar.dataTableToggle).toBeDefined();
+    expect(en.Compare.radar.show).toBe("Show");
+    expect(en.Compare.radar.hide).toBe("Hide");
   });
 
   it("fr.json has radar keys in Compare namespace", async () => {
@@ -247,6 +319,8 @@ describe("Radar chart i18n keys", () => {
     expect(fr.Compare.radar.title).toBe("Comparaison des spécifications");
     expect(fr.Compare.radar.scaleNote).toBeDefined();
     expect(fr.Compare.radar.dataTableToggle).toBeDefined();
+    expect(fr.Compare.radar.show).toBe("Afficher");
+    expect(fr.Compare.radar.hide).toBe("Masquer");
   });
 
   it("en and fr have identical radar key structure", async () => {


### PR DESCRIPTION
## Summary
Closes #252

Completes P15.1 — Spec comparison radar chart enhancements:

### Changes
- **Yacht visibility toggles**: Color-coded buttons above the radar chart let users show/hide individual yachts. Guard prevents hiding all yachts (min 1 must remain visible).
- **Dynamic normalization**: When yachts are hidden, normalization recalculates based on visible subset only.
- **Canonical compare integration**: Radar chart now renders on `/compare/[slugA]-vs-[slugB]` pages via CanonicalCompareClient (was only on interactive CompareClient).
- **i18n**: Added `radar.show` / `radar.hide` keys in en.json and fr.json.
- **Accessible data table**: Shows '—' for hidden yachts.

### Tests
- 22 tests pass (was 17 — added 5 new toggle visibility tests)
- Covers: hiding yacht sets values to 0, recalculates normalization, all-visible matches default, empty set defensive case, 3-yacht scenarios
- i18n key structure validation for en + fr

### Verification
- [x] Typecheck passes
- [x] Build passes
- [x] Vitest: 22/22