### PR TITLE
fix: update stale test paths after i18n refactor (closes #256)

### DIFF
--- a/tests/form-accessibility.test.ts
+++ b/tests/form-accessibility.test.ts
@@ -128,12 +128,13 @@ describe("P13.4: Form accessibility & error handling", () => {
   // ── SearchClient ──
   describe("SearchClient", () => {
     const component = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/search/SearchClient.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/search/SearchClient.tsx"),
       "utf-8",
     );
 
     it("search input has aria-label", () => {
-      expect(component).toContain('aria-label="Search yachts"');
+      // After i18n refactor, the search heading is used as aria-label
+      expect(component).toContain('aria-label={t("heading")}');
     });
 
     it("autocomplete suggestions have role=listbox", () => {
@@ -141,7 +142,8 @@ describe("P13.4: Form accessibility & error handling", () => {
     });
 
     it("autocomplete suggestions have aria-label", () => {
-      expect(component).toContain('aria-label="Search suggestions"');
+      // After i18n refactor, aria-label uses translation key
+      expect(component).toContain('aria-label={t("suggestions.label")}');
     });
 
     it("results region has aria-live", () => {
@@ -160,7 +162,7 @@ describe("P13.4: Form accessibility & error handling", () => {
   // ── CompareClient ──
   describe("CompareClient picker search", () => {
     const component = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/compare/CompareClient.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/compare/CompareClient.tsx"),
       "utf-8",
     );
 
@@ -177,7 +179,7 @@ describe("P13.4: Form accessibility & error handling", () => {
   // ── YachtsClient ──
   describe("YachtsClient results accessibility", () => {
     const component = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/yachts/YachtsClient.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/yachts/YachtsClient.tsx"),
       "utf-8",
     );
 

--- a/tests/keyboard-navigation.test.ts
+++ b/tests/keyboard-navigation.test.ts
@@ -76,7 +76,7 @@ describe("P13.3: Keyboard navigation enhancement", () => {
   // ── Mobile menu keyboard support ──
   describe("Mobile menu keyboard support", () => {
     const mobileMenu = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/MobileMenuKeyboard.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/ClientNav.tsx"),
       "utf-8",
     );
 
@@ -111,12 +111,12 @@ describe("P13.3: Keyboard navigation enhancement", () => {
   // ── Layout keyboard accessibility ──
   describe("Layout keyboard accessibility", () => {
     const layout = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/layout.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/layout.tsx"),
       "utf-8",
     );
 
     it("includes mobile menu component", () => {
-      expect(layout).toContain("MobileMenuKeyboard");
+      expect(layout).toContain("ClientNav");
     });
 
     it("has skip-to-content link", () => {
@@ -128,7 +128,7 @@ describe("P13.3: Keyboard navigation enhancement", () => {
   // ── YachtsClient modal keyboard support ──
   describe("YachtsClient modal keyboard support", () => {
     const yachtsClient = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/yachts/YachtsClient.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/yachts/YachtsClient.tsx"),
       "utf-8",
     );
 
@@ -241,7 +241,7 @@ describe("P13.3: Keyboard navigation enhancement", () => {
   // ── CompareClient keyboard support ──
   describe("CompareClient keyboard support", () => {
     const compare = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/compare/CompareClient.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/compare/CompareClient.tsx"),
       "utf-8",
     );
 

--- a/tests/landmark-structure.test.ts
+++ b/tests/landmark-structure.test.ts
@@ -18,7 +18,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
   // ── Skip-to-content link ──
   describe("Skip-to-content link", () => {
     const mainLayout = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/layout.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/layout.tsx"),
       "utf-8"
     );
 
@@ -41,7 +41,12 @@ describe("P13.2: Skip navigation & landmark structure", () => {
   // ── ARIA Landmarks ──
   describe("ARIA landmarks", () => {
     const mainLayout = fs.readFileSync(
-      path.join(PROJECT_ROOT, "app/(main)/layout.tsx"),
+      path.join(PROJECT_ROOT, "app/[locale]/layout.tsx"),
+      "utf-8"
+    );
+    // Mobile menu ARIA attributes are in ClientNav.tsx (extracted during i18n refactor)
+    const clientNav = fs.readFileSync(
+      path.join(PROJECT_ROOT, "app/[locale]/ClientNav.tsx"),
       "utf-8"
     );
 
@@ -63,12 +68,12 @@ describe("P13.2: Skip navigation & landmark structure", () => {
     });
 
     it("mobile menu panel has role='navigation' and aria-label", () => {
-      expect(mainLayout).toContain('role="navigation"');
-      expect(mainLayout).toContain('aria-label="Mobile navigation"');
+      expect(clientNav).toContain('role="navigation"');
+      expect(clientNav).toContain('aria-label="Mobile navigation"');
     });
 
     it("mobile menu button has aria-controls attribute", () => {
-      expect(mainLayout).toContain('aria-controls="mobile-menu-panel"');
+      expect(clientNav).toContain('aria-controls="mobile-menu-panel"');
     });
   });
 
@@ -162,35 +167,35 @@ describe("P13.2: Skip navigation & landmark structure", () => {
 
     it("home page has proper heading hierarchy", () => {
       const result = checkLinearHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/page.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/page.tsx")
       );
       expect(result.valid, result.error).toBe(true);
     });
 
     it("guides listing page has proper heading hierarchy", () => {
       const result = checkLinearHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/guides/page.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/guides/page.tsx")
       );
       expect(result.valid, result.error).toBe(true);
     });
 
     it("glossary page has proper heading hierarchy", () => {
       const result = checkLinearHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/glossary/page.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/glossary/page.tsx")
       );
       expect(result.valid, result.error).toBe(true);
     });
 
     it("manufacturers page has proper heading hierarchy", () => {
       const result = checkLinearHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/manufacturers/page.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/manufacturers/page.tsx")
       );
       expect(result.valid, result.error).toBe(true);
     });
 
     it("links page has proper heading hierarchy", () => {
       const headings = getHeadings(
-        path.join(PROJECT_ROOT, "app/(main)/links/page.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/links/page.tsx")
       );
       expect(headings.length).toBeGreaterThan(0);
       expect(headings[0].level).toBe(1);
@@ -201,7 +206,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
       // so linear file order doesn't match DOM order. Check that all heading levels exist
       // and there's an h1.
       const result = checkHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/yachts/YachtsClient.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/yachts/YachtsClient.tsx")
       );
       expect(result.valid).toBe(true);
       // Verify heading levels: should have h1, h2, h3
@@ -213,14 +218,14 @@ describe("P13.2: Skip navigation & landmark structure", () => {
 
     it("search client has proper heading hierarchy", () => {
       const result = checkLinearHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/search/SearchClient.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/search/SearchClient.tsx")
       );
       expect(result.valid, result.error).toBe(true);
     });
 
     it("compare client has h1 elements", () => {
       const result = checkHeadingHierarchy(
-        path.join(PROJECT_ROOT, "app/(main)/compare/CompareClient.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/compare/CompareClient.tsx")
       );
       expect(result.valid).toBe(true);
     });
@@ -229,7 +234,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
       const result = checkHeadingHierarchy(
         path.join(
           PROJECT_ROOT,
-          "app/(main)/yachts/[slug]/YachtDetailClient.tsx"
+          "app/[locale]/yachts/[slug]/YachtDetailClient.tsx"
         )
       );
       expect(result.valid).toBe(true);
@@ -242,7 +247,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
       const result = checkLinearHeadingHierarchy(
         path.join(
           PROJECT_ROOT,
-          "app/(main)/favorites/FavoritesClient.tsx"
+          "app/[locale]/favorites/FavoritesClient.tsx"
         )
       );
       expect(result.valid, result.error).toBe(true);
@@ -258,12 +263,12 @@ describe("P13.2: Skip navigation & landmark structure", () => {
     }
 
     const pages = [
-      { name: "home", path: "app/(main)/page.tsx" },
-      { name: "guides listing", path: "app/(main)/guides/page.tsx" },
-      { name: "glossary listing", path: "app/(main)/glossary/page.tsx" },
-      { name: "manufacturers", path: "app/(main)/manufacturers/page.tsx" },
-      { name: "links", path: "app/(main)/links/page.tsx" },
-      { name: "favorites", path: "app/(main)/favorites/FavoritesClient.tsx" },
+      { name: "home", path: "app/[locale]/page.tsx" },
+      { name: "guides listing", path: "app/[locale]/guides/page.tsx" },
+      { name: "glossary listing", path: "app/[locale]/glossary/page.tsx" },
+      { name: "manufacturers", path: "app/[locale]/manufacturers/page.tsx" },
+      { name: "links", path: "app/[locale]/links/page.tsx" },
+      { name: "favorites", path: "app/[locale]/favorites/FavoritesClient.tsx" },
     ];
 
     for (const page of pages) {
@@ -275,7 +280,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
     // Client components that conditionally render h1 (e.g. print vs screen)
     it("compare client has h1 elements (print + screen)", () => {
       const count = countH1(
-        path.join(PROJECT_ROOT, "app/(main)/compare/CompareClient.tsx")
+        path.join(PROJECT_ROOT, "app/[locale]/compare/CompareClient.tsx")
       );
       expect(count).toBeGreaterThanOrEqual(1);
     });
@@ -284,7 +289,7 @@ describe("P13.2: Skip navigation & landmark structure", () => {
       const count = countH1(
         path.join(
           PROJECT_ROOT,
-          "app/(main)/yachts/[slug]/YachtDetailClient.tsx"
+          "app/[locale]/yachts/[slug]/YachtDetailClient.tsx"
         )
       );
       expect(count).toBeGreaterThanOrEqual(1);

--- a/tests/reduced-motion-responsive-a11y.test.ts
+++ b/tests/reduced-motion-responsive-a11y.test.ts
@@ -157,7 +157,7 @@ describe("P13.6: Touch targets — CSS rules", () => {
 // ── Screen reader patterns ──
 describe("P13.6: Screen reader patterns — public pages", () => {
   describe("Home page", () => {
-    const homePage = readFile("app/(main)/page.tsx");
+    const homePage = readFile("app/[locale]/page.tsx");
 
     it("has semantic structure with headings", () => {
       expect(homePage).toMatch(/<h[1-3]/);
@@ -170,7 +170,7 @@ describe("P13.6: Screen reader patterns — public pages", () => {
   });
 
   describe("Yachts listing page", () => {
-    const yachtsPage = readFile("app/(main)/yachts/page.tsx");
+    const yachtsPage = readFile("app/[locale]/yachts/page.tsx");
 
     it("exports metadata or has a heading", () => {
       expect(yachtsPage).toMatch(/metadata|<h1|heading/);
@@ -178,7 +178,7 @@ describe("P13.6: Screen reader patterns — public pages", () => {
   });
 
   describe("YachtsClient component", () => {
-    const yachtsClient = readFile("app/(main)/yachts/YachtsClient.tsx");
+    const yachtsClient = readFile("app/[locale]/yachts/YachtsClient.tsx");
 
     it("has aria-live region for search results", () => {
       expect(yachtsClient).toContain("aria-live");
@@ -195,7 +195,7 @@ describe("P13.6: Screen reader patterns — public pages", () => {
   });
 
   describe("Search page", () => {
-    const searchClient = readFile("app/(main)/search/SearchClient.tsx");
+    const searchClient = readFile("app/[locale]/search/SearchClient.tsx");
 
     it("search input has accessible label", () => {
       expect(searchClient).toMatch(/aria-label|<label/);
@@ -215,7 +215,7 @@ describe("P13.6: Screen reader patterns — public pages", () => {
   });
 
   describe("Compare page", () => {
-    const compareClient = readFile("app/(main)/compare/CompareClient.tsx");
+    const compareClient = readFile("app/[locale]/compare/CompareClient.tsx");
 
     it("has accessible labels for picker inputs", () => {
       expect(compareClient).toMatch(/aria-label|<label/);
@@ -268,7 +268,7 @@ describe("P13.6: Screen reader patterns — public pages", () => {
 // ── Responsive accessibility checks ──
 describe("P13.6: Responsive accessibility — layout & components", () => {
   describe("Main layout", () => {
-    const layout = readFile("app/(main)/layout.tsx");
+    const layout = readFile("app/[locale]/layout.tsx");
 
     it("has skip-to-content link", () => {
       expect(layout).toContain('href="#main-content"');
@@ -292,13 +292,13 @@ describe("P13.6: Responsive accessibility — layout & components", () => {
 
     it("footer links have accessible text", () => {
       expect(layout).toMatch(
-        /3DPUT|Sailboats\.fr/,
+        /footer.builtBy3dput|footer.builtBySailboats/,
       );
     });
   });
 
   describe("Mobile menu responsive behavior", () => {
-    const mobileMenu = readFile("app/(main)/MobileMenuKeyboard.tsx");
+    const mobileMenu = readFile("app/[locale]/ClientNav.tsx");
 
     it("is hidden on desktop (md:hidden)", () => {
       expect(mobileMenu).toContain("md:hidden");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ import path from "path";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    exclude: [
+      // Standalone runner tests (use custom main(), not vitest describe/test)
+      "tests/partner-offers.test.ts",
+      "tests/price-normalization-unit.test.ts",
+      // Playwright E2E tests (use @playwright/test, not vitest)
+      "tests/api-contracts.test.ts",
+    ],
     environment: "node",
   },
   resolve: {


### PR DESCRIPTION
## Summary
Fixes #256 — 7 test suites were failing under `npx vitest run`.

### Changes
1. **Stale path updates** (4 files): Replaced `app/(main)/` → `app/[locale]/` references that broke when Phase 14 i18n refactor moved files
2. **Component rename**: Updated `MobileMenuKeyboard` → `ClientNav` references
3. **i18n string updates**: Updated hardcoded `aria-label` assertions to match i18n translation keys (`{t("...")}\)
4. **Vitest config exclusions**: Excluded 3 non-vitest test files:
   - `partner-offers.test.ts` — standalone runner (no vitest describe/test blocks)
   - `price-normalization-unit.test.ts` — standalone runner
   - `api-contracts.test.ts` — Playwright test (uses @playwright/test)

### Results
- **Before**: 7 failed | 14 passed | 629 tests
- **After**: 0 failed | 18 passed | 774 tests ✅
- Typecheck: ✅ Pass
- Build: ✅ Pass