### PR TITLE
feat: enhanced manufacturer listing with country filter and sort (closes #260)

### DIFF
--- a/app/[locale]/manufacturers/page.tsx
+++ b/app/[locale]/manufacturers/page.tsx
@@ -12,6 +12,7 @@ import {
   getSiteUrl,
   buildLocaleAlternates,
 } from "@/lib/seo";
+import ManufacturerListingClient from "@/components/manufacturer-listing-client";
 
 // ISR: Revalidate manufacturers list every hour
 export const revalidate = 3600;
@@ -119,47 +120,29 @@ export default async function ManufacturersPage({ params }: ManufacturersListing
         </nav>
 
         <section className="rounded-2xl border border-border bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 sm:p-8">
-          <div className="text-center max-w-3xl mx-auto">
+          <div className="max-w-3xl mx-auto text-center mb-6">
             <h1 className="text-3xl font-bold text-gray-900 mb-4">
               {t("listing.title")}
             </h1>
-            <p className="text-lg text-gray-600 mb-8">
+            <p className="text-lg text-gray-600">
               {t("listing.description")}
             </p>
-            
-            {manufacturers.length === 0 ? (
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
-                <div className="text-center">
-                  <div className="text-yellow-800 mb-2">
-                    {t("listing.emptyTitle")}
-                  </div>
-                  <div className="text-sm text-yellow-600">
-                    {t("listing.emptySubtitle")}
-                  </div>
+          </div>
+
+          {manufacturers.length === 0 ? (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+              <div className="text-center">
+                <div className="text-yellow-800 mb-2">
+                  {t("listing.emptyTitle")}
+                </div>
+                <div className="text-sm text-yellow-600">
+                  {t("listing.emptySubtitle")}
                 </div>
               </div>
-            ) : (
-              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-                {manufacturers.map((manufacturer: any) => (
-                  <Link
-                    key={manufacturer.name}
-                    href={`/${locale}/manufacturers/${slugify(manufacturer.name)}`}
-                    className="block bg-white rounded-lg p-4 hover:bg-blue-50 transition border border-gray-100"
-                  >
-                    <div className="font-semibold text-gray-900">{manufacturer.name}</div>
-                    <div className="text-sm text-gray-500 mt-1">
-                      {t("listing.models", { count: manufacturer.yachtCount })}
-                    </div>
-                    {manufacturer.country && (
-                      <div className="text-xs text-gray-400 mt-1">
-                        {manufacturer.country}{manufacturer.foundedYear ? ` · ${t("listing.foundedYear", { year: manufacturer.foundedYear })}` : ""}
-                      </div>
-                    )}
-                  </Link>
-                ))}
-              </div>
-            )}
-          </div>
+            </div>
+          ) : (
+            <ManufacturerListingClient manufacturers={manufacturers} locale={locale} />
+          )}
         </section>
       </div>
     </>

--- a/components/manufacturer-listing-client.tsx
+++ b/components/manufacturer-listing-client.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { slugify } from "@/lib/utils/slugify";
+import type { ManufacturerSummary } from "@/lib/manufacturers";
+
+// Country code to flag emoji mapping
+const COUNTRY_FLAGS: Record<string, string> = {
+  Austria: "🇦🇹",
+  Denmark: "🇩🇰",
+  Finland: "🇫🇮",
+  France: "🇫🇷",
+  Germany: "🇩🇪",
+  Italy: "🇮🇹",
+  Netherlands: "🇳🇱",
+  Norway: "🇳🇴",
+  Poland: "🇵🇱",
+  Slovenia: "🇸🇮",
+  Sweden: "🇸🇪",
+  "United Kingdom": "🇬🇧",
+  "United States": "🇺🇸",
+};
+
+type SortKey = "name" | "yachtCount" | "foundedYear";
+type SortOrder = "asc" | "desc";
+
+interface ManufacturerListingClientProps {
+  manufacturers: ManufacturerSummary[];
+  locale: string;
+}
+
+export default function ManufacturerListingClient({
+  manufacturers,
+  locale,
+}: ManufacturerListingClientProps) {
+  const t = useTranslations("Manufacturers");
+  const [countryFilter, setCountryFilter] = useState<string>("all");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+
+  // Derive unique countries from data
+  const countries = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of manufacturers) {
+      if (m.country) set.add(m.country);
+    }
+    return Array.from(set).sort();
+  }, [manufacturers]);
+
+  // Filter and sort
+  const filtered = useMemo(() => {
+    let list = manufacturers;
+
+    if (countryFilter !== "all") {
+      list = list.filter((m) => m.country === countryFilter);
+    }
+
+    list = [...list].sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "yachtCount":
+          cmp = a.yachtCount - b.yachtCount;
+          break;
+        case "foundedYear": {
+          const aYear = a.foundedYear ?? 9999;
+          const bYear = b.foundedYear ?? 9999;
+          cmp = aYear - bYear;
+          break;
+        }
+      }
+      return sortOrder === "asc" ? cmp : -cmp;
+    });
+
+    return list;
+  }, [manufacturers, countryFilter, sortKey, sortOrder]);
+
+  function handleSortChange(newKey: SortKey) {
+    if (newKey === sortKey) {
+      setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(newKey);
+      setSortOrder(newKey === "name" ? "asc" : "desc"); // default desc for count/year
+    }
+  }
+
+  function getSortIndicator(key: SortKey) {
+    if (sortKey !== key) return "";
+    return sortOrder === "asc" ? " ↑" : " ↓";
+  }
+
+  function getDescription(m: ManufacturerSummary): string | null {
+    if (locale === "fr" && m.descriptionFr) return m.descriptionFr;
+    return m.description ?? null;
+  }
+
+  return (
+    <>
+      {/* Filters & Sort Bar */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        {/* Country Filter */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="country-filter" className="text-sm font-medium text-gray-700">
+            {t("listing.country")}:
+          </label>
+          <select
+            id="country-filter"
+            value={countryFilter}
+            onChange={(e) => setCountryFilter(e.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-sky-500 focus:ring-1 focus:ring-sky-500"
+          >
+            <option value="all">
+              {t("listing.allCountries")}
+            </option>
+            {countries.map((c) => (
+              <option key={c} value={c}>
+                {COUNTRY_FLAGS[c] ?? ""} {c}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Sort Buttons */}
+        <div className="flex items-center gap-1 ml-auto">
+          <span className="text-sm font-medium text-gray-700 mr-1">
+            {t("listing.sortBy")}:
+          </span>
+          {(
+            [
+              ["name", t("listing.sortName")],
+              ["yachtCount", t("listing.sortYachtCount")],
+              ["foundedYear", t("listing.sortFoundedYear")],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => handleSortChange(key as SortKey)}
+              className={`px-3 py-1.5 text-sm rounded-md border transition ${
+                sortKey === key
+                  ? "bg-sky-600 text-white border-sky-600"
+                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              }`}
+            >
+              {label}
+              {getSortIndicator(key as SortKey)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Results count */}
+      <div className="text-sm text-gray-500 mb-4">
+        {t("listing.resultsCount", {
+          filtered: filtered.length,
+          total: manufacturers.length,
+        })}
+      </div>
+
+      {/* Cards Grid */}
+      {filtered.length === 0 ? (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+          <div className="text-center">
+            <div className="text-yellow-800 mb-2">
+              {t("listing.noResults")}
+            </div>
+            <button
+              onClick={() => setCountryFilter("all")}
+              className="text-sm text-sky-600 hover:underline"
+            >
+              {t("listing.clearFilter")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {filtered.map((m) => {
+            const desc = getDescription(m);
+            return (
+              <Link
+                key={m.id}
+                href={`/${locale}/manufacturers/${slugify(m.name)}`}
+                className="block bg-white rounded-xl p-5 hover:bg-blue-50 hover:shadow-md transition border border-gray-100 group"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="font-semibold text-gray-900 group-hover:text-sky-700 transition">
+                    {m.name}
+                  </div>
+                  {m.country && (
+                    <span className="text-xl shrink-0" title={m.country}>
+                      {COUNTRY_FLAGS[m.country] ?? ""}
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3 mt-2 text-sm text-gray-500">
+                  <span className="inline-flex items-center gap-1">
+                    <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                    </svg>
+                    {t("listing.models", { count: m.yachtCount })}
+                  </span>
+                  {m.foundedYear && (
+                    <span className="inline-flex items-center gap-1">
+                      <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                      </svg>
+                      {t("listing.foundedYear", { year: m.foundedYear })}
+                    </span>
+                  )}
+                </div>
+
+                {desc && (
+                  <p className="mt-2 text-xs text-gray-400 line-clamp-2">
+                    {desc}
+                  </p>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -492,7 +492,15 @@
       "emptySubtitle": "This page is using ISR (Incremental Static Regeneration) and will show live data on production.",
       "country": "Country",
       "founded": "Founded",
-      "foundedYear": "Est. {year}"
+      "foundedYear": "Est. {year}",
+      "allCountries": "All Countries",
+      "sortBy": "Sort by",
+      "sortName": "Name",
+      "sortYachtCount": "Models",
+      "sortFoundedYear": "Founded",
+      "resultsCount": "{filtered} of {total} manufacturers",
+      "noResults": "No manufacturers match this filter.",
+      "clearFilter": "Clear filter"
     },
     "detail": {
       "profileLabel": "Manufacturer Profile",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -492,7 +492,15 @@
       "emptySubtitle": "Cette page utilise l'ISR (régénération statique incrémentale) et affichera les données en direct en production.",
       "country": "Pays",
       "founded": "Fondé",
-      "foundedYear": "Depuis {year}"
+      "foundedYear": "Depuis {year}",
+      "allCountries": "Tous les pays",
+      "sortBy": "Trier par",
+      "sortName": "Nom",
+      "sortYachtCount": "Modèles",
+      "sortFoundedYear": "Fondé",
+      "resultsCount": "{filtered} sur {total} constructeurs",
+      "noResults": "Aucun constructeur ne correspond à ce filtre.",
+      "clearFilter": "Effacer le filtre"
     },
     "detail": {
       "profileLabel": "Profil du constructeur",

--- a/tests/manufacturer-listing.test.ts
+++ b/tests/manufacturer-listing.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import type { ManufacturerSummary } from "@/lib/manufacturers";
+
+// Extract the sorting/filtering logic as pure functions for testing
+// (These mirror the logic in ManufacturerListingClient)
+
+type SortKey = "name" | "yachtCount" | "foundedYear";
+type SortOrder = "asc" | "desc";
+
+function filterByCountry(
+  manufacturers: ManufacturerSummary[],
+  country: string
+): ManufacturerSummary[] {
+  if (country === "all") return manufacturers;
+  return manufacturers.filter((m) => m.country === country);
+}
+
+function sortManufacturers(
+  manufacturers: ManufacturerSummary[],
+  sortKey: SortKey,
+  sortOrder: SortOrder
+): ManufacturerSummary[] {
+  return [...manufacturers].sort((a, b) => {
+    let cmp = 0;
+    switch (sortKey) {
+      case "name":
+        cmp = a.name.localeCompare(b.name);
+        break;
+      case "yachtCount":
+        cmp = a.yachtCount - b.yachtCount;
+        break;
+      case "foundedYear": {
+        const aYear = a.foundedYear ?? 9999;
+        const bYear = b.foundedYear ?? 9999;
+        cmp = aYear - bYear;
+        break;
+      }
+    }
+    return sortOrder === "asc" ? cmp : -cmp;
+  });
+}
+
+function getUniqueCountries(manufacturers: ManufacturerSummary[]): string[] {
+  const set = new Set<string>();
+  for (const m of manufacturers) {
+    if (m.country) set.add(m.country);
+  }
+  return Array.from(set).sort();
+}
+
+function getDescription(
+  m: ManufacturerSummary,
+  locale: string
+): string | null {
+  if (locale === "fr" && m.descriptionFr) return m.descriptionFr;
+  return m.description ?? null;
+}
+
+const MOCK: ManufacturerSummary[] = [
+  {
+    id: 1,
+    name: "Beneteau",
+    slug: "beneteau",
+    country: "France",
+    foundedYear: 1884,
+    description: "French sailing yacht manufacturer",
+    descriptionFr: "Constructeur français",
+    yachtCount: 12,
+  },
+  {
+    id: 2,
+    name: "Hanse Yachts",
+    slug: "hanse-yachts",
+    country: "Germany",
+    foundedYear: 1990,
+    description: "German yacht builder",
+    descriptionFr: null,
+    yachtCount: 8,
+  },
+  {
+    id: 3,
+    name: "Jeanneau",
+    slug: "jeanneau",
+    country: "France",
+    foundedYear: 1957,
+    description: "Another French builder",
+    descriptionFr: "Un autre constructeur",
+    yachtCount: 15,
+  },
+  {
+    id: 4,
+    name: "X-Yachts",
+    slug: "x-yachts",
+    country: "Denmark",
+    foundedYear: 1979,
+    description: null,
+    descriptionFr: null,
+    yachtCount: 5,
+  },
+];
+
+describe("Manufacturer listing — filter logic", () => {
+  it("returns all manufacturers when country is 'all'", () => {
+    const result = filterByCountry(MOCK, "all");
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters to a single country", () => {
+    const result = filterByCountry(MOCK, "France");
+    expect(result).toHaveLength(2);
+    expect(result.every((m) => m.country === "France")).toBe(true);
+    expect(result.map((m) => m.name)).toEqual(["Beneteau", "Jeanneau"]);
+  });
+
+  it("returns empty array for non-existent country", () => {
+    const result = filterByCountry(MOCK, "Japan");
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("Manufacturer listing — sort logic", () => {
+  it("sorts by name ascending (default)", () => {
+    const result = sortManufacturers(MOCK, "name", "asc");
+    expect(result.map((m) => m.name)).toEqual([
+      "Beneteau",
+      "Hanse Yachts",
+      "Jeanneau",
+      "X-Yachts",
+    ]);
+  });
+
+  it("sorts by name descending", () => {
+    const result = sortManufacturers(MOCK, "name", "desc");
+    expect(result[0].name).toBe("X-Yachts");
+    expect(result[3].name).toBe("Beneteau");
+  });
+
+  it("sorts by yachtCount descending (highest first)", () => {
+    const result = sortManufacturers(MOCK, "yachtCount", "desc");
+    expect(result[0].name).toBe("Jeanneau"); // 15
+    expect(result[1].name).toBe("Beneteau"); // 12
+    expect(result[2].name).toBe("Hanse Yachts"); // 8
+    expect(result[3].name).toBe("X-Yachts"); // 5
+  });
+
+  it("sorts by yachtCount ascending (lowest first)", () => {
+    const result = sortManufacturers(MOCK, "yachtCount", "asc");
+    expect(result[0].name).toBe("X-Yachts"); // 5
+    expect(result[3].name).toBe("Jeanneau"); // 15
+  });
+
+  it("sorts by foundedYear ascending (oldest first)", () => {
+    const result = sortManufacturers(MOCK, "foundedYear", "asc");
+    expect(result[0].name).toBe("Beneteau"); // 1884
+    expect(result[1].name).toBe("Jeanneau"); // 1957
+    expect(result[2].name).toBe("X-Yachts"); // 1979
+    expect(result[3].name).toBe("Hanse Yachts"); // 1990
+  });
+
+  it("sorts by foundedYear descending (newest first)", () => {
+    const result = sortManufacturers(MOCK, "foundedYear", "desc");
+    expect(result[0].name).toBe("Hanse Yachts"); // 1990
+    expect(result[3].name).toBe("Beneteau"); // 1884
+  });
+
+  it("handles null foundedYear as 9999 (sorted last in asc)", () => {
+    const withNull: ManufacturerSummary[] = [
+      { ...MOCK[0], foundedYear: null },
+      { ...MOCK[1] },
+    ];
+    const result = sortManufacturers(withNull, "foundedYear", "asc");
+    expect(result[0].name).toBe("Hanse Yachts"); // 1990
+    expect(result[1].name).toBe("Beneteau"); // null → 9999
+  });
+});
+
+describe("Manufacturer listing — country extraction", () => {
+  it("extracts unique countries sorted alphabetically", () => {
+    const countries = getUniqueCountries(MOCK);
+    expect(countries).toEqual(["Denmark", "France", "Germany"]);
+  });
+
+  it("excludes null countries", () => {
+    const data: ManufacturerSummary[] = [
+      { ...MOCK[0], country: null },
+      { ...MOCK[1] },
+    ];
+    const countries = getUniqueCountries(data);
+    expect(countries).toEqual(["Germany"]);
+  });
+});
+
+describe("Manufacturer listing — description locale logic", () => {
+  it("returns French description when locale is fr and descriptionFr exists", () => {
+    expect(getDescription(MOCK[0], "fr")).toBe("Constructeur français");
+  });
+
+  it("falls back to English description when locale is fr but descriptionFr is null", () => {
+    expect(getDescription(MOCK[1], "fr")).toBe("German yacht builder");
+  });
+
+  it("returns English description for en locale", () => {
+    expect(getDescription(MOCK[0], "en")).toBe("French sailing yacht manufacturer");
+  });
+
+  it("returns null when both descriptions are null", () => {
+    expect(getDescription(MOCK[3], "en")).toBeNull();
+    expect(getDescription(MOCK[3], "fr")).toBeNull();
+  });
+});
+
+describe("Manufacturer listing — combined filter + sort", () => {
+  it("filters then sorts", () => {
+    const filtered = filterByCountry(MOCK, "France");
+    const sorted = sortManufacturers(filtered, "yachtCount", "desc");
+    expect(sorted).toHaveLength(2);
+    expect(sorted[0].name).toBe("Jeanneau"); // 15
+    expect(sorted[1].name).toBe("Beneteau"); // 12
+  });
+
+  it("filtering to empty then sorting returns empty", () => {
+    const filtered = filterByCountry(MOCK, "Japan");
+    const sorted = sortManufacturers(filtered, "name", "asc");
+    expect(sorted).toHaveLength(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
     exclude: [
       // Standalone runner tests (use custom main(), not vitest describe/test)
       "tests/partner-offers.test.ts",


### PR DESCRIPTION
- Add client component with interactive country filter and multi-key sorting
- Display country flags, founding year, yacht count, and description on cards
- Sort by name, yacht count, or founded year (toggle asc/desc)
- Filter by country dropdown with flag emojis
- Show results count and empty state with clear filter action
- Locale-aware descriptions (French when available)
- Add 18 unit tests for filter/sort/description logic
- Update vitest config to include .tsx test files
- Add i18n keys for en and fr
