### PR TITLE
feat: enhance manufacturer detail page with country flags, about section, and related manufacturers (closes #262)

### DIFF
--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -13,7 +13,9 @@ import {
 import {
   getManufacturerBySlug,
   getYachtsByManufacturerId,
+  getRelatedManufacturers,
 } from "@/lib/manufacturers";
+import { getCountryFlag } from "@/lib/utils/country-flags";
 import { getSpotlightByManufacturerId } from "@/lib/manufacturer-spotlights";
 import { ManufacturerComparisons } from "./ManufacturerComparisons";
 import dynamic from "next/dynamic";
@@ -30,12 +32,13 @@ async function getManufacturerData(slug: string) {
       const manufacturer = await getManufacturerBySlug(slug);
       if (!manufacturer) return null;
 
-      const [yachts, spotlight] = await Promise.all([
+      const [yachts, spotlight, related] = await Promise.all([
         getYachtsByManufacturerId(manufacturer.id),
         getSpotlightByManufacturerId(manufacturer.id),
+        getRelatedManufacturers(manufacturer.id, manufacturer.country),
       ]);
 
-      return { manufacturer, yachts, spotlight };
+      return { manufacturer, yachts, spotlight, related };
     },
     [`manufacturer:${slug}`],
     { tags: [`manufacturer:${slug}`, "manufacturers"], revalidate: 3600 }
@@ -116,7 +119,7 @@ export default async function ManufacturerPage({
     notFound();
   }
 
-  const { manufacturer, yachts, spotlight } = data;
+  const { manufacturer, yachts, spotlight, related } = data;
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
@@ -215,7 +218,9 @@ export default async function ManufacturerPage({
             <div className="rounded-xl border border-border bg-white/80 p-4">
               <div className="text-sm text-muted-foreground">{t("detail.country")}</div>
               <div className="mt-1 text-lg font-semibold">
-                {manufacturer.country || "—"}
+                {manufacturer.country
+                  ? <>{getCountryFlag(manufacturer.country)} {manufacturer.country}</>
+                  : "—"}
               </div>
             </div>
             <div className="rounded-xl border border-border bg-white/80 p-4">
@@ -391,6 +396,57 @@ export default async function ManufacturerPage({
             </div>
           )}
         </section>
+
+
+        {/* About section */}
+        {((locale === "fr" && manufacturer.descriptionFr) || manufacturer.description) && (
+          <section className="mt-10 sm:mt-12">
+            <h2 className="text-2xl font-bold">{t("detail.aboutBrand", { name: manufacturer.name })}</h2>
+            <div className="mt-4 max-w-3xl text-muted-foreground leading-relaxed whitespace-pre-line">
+              {locale === "fr" && manufacturer.descriptionFr
+                ? manufacturer.descriptionFr
+                : manufacturer.description}
+            </div>
+            {manufacturer.websiteUrl && (
+              <a
+                href={manufacturer.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-sky-700 hover:text-sky-900 transition-colors"
+              >
+                {t("detail.visitWebsite")}
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+          </section>
+        )}
+
+        {/* Related manufacturers */}
+        {related.length > 0 && (
+          <section className="mt-10 sm:mt-12">
+            <h2 className="text-2xl font-bold">{t("detail.relatedManufacturers.title")}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("detail.relatedManufacturers.subtitle", { country: manufacturer.country ?? "" })}
+            </p>
+            <div className="mt-6 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+              {related.map((rel) => (
+                <Link
+                  key={rel.id}
+                  href={`/manufacturers/${rel.slug}`}
+                  className="rounded-xl border border-border bg-card p-4 hover:border-sky-200 hover:shadow-sm transition-all text-center"
+                >
+                  <div className="text-2xl">{getCountryFlag(rel.country)}</div>
+                  <div className="mt-2 text-sm font-semibold leading-tight">{rel.name}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {t("detail.relatedManufacturers.yachtCount", { count: rel.yachtCount })}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* P15.5 — Fleet overview chart */}
         <ManufacturerFleetChart yachts={yachts} manufacturerName={manufacturer.name} />

--- a/components/manufacturer-listing-client.tsx
+++ b/components/manufacturer-listing-client.tsx
@@ -1,36 +1,16 @@
 "use client";
-
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { slugify } from "@/lib/utils/slugify";
 import type { ManufacturerSummary } from "@/lib/manufacturers";
-
-// Country code to flag emoji mapping
-const COUNTRY_FLAGS: Record<string, string> = {
-  Austria: "🇦🇹",
-  Denmark: "🇩🇰",
-  Finland: "🇫🇮",
-  France: "🇫🇷",
-  Germany: "🇩🇪",
-  Italy: "🇮🇹",
-  Netherlands: "🇳🇱",
-  Norway: "🇳🇴",
-  Poland: "🇵🇱",
-  Slovenia: "🇸🇮",
-  Sweden: "🇸🇪",
-  "United Kingdom": "🇬🇧",
-  "United States": "🇺🇸",
-};
-
+import { COUNTRY_FLAGS } from "@/lib/utils/country-flags";
 type SortKey = "name" | "yachtCount" | "foundedYear";
 type SortOrder = "asc" | "desc";
-
 interface ManufacturerListingClientProps {
   manufacturers: ManufacturerSummary[];
   locale: string;
 }
-
 export default function ManufacturerListingClient({
   manufacturers,
   locale,
@@ -39,7 +19,6 @@ export default function ManufacturerListingClient({
   const [countryFilter, setCountryFilter] = useState<string>("all");
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
-
   // Derive unique countries from data
   const countries = useMemo(() => {
     const set = new Set<string>();
@@ -48,15 +27,12 @@ export default function ManufacturerListingClient({
     }
     return Array.from(set).sort();
   }, [manufacturers]);
-
   // Filter and sort
   const filtered = useMemo(() => {
     let list = manufacturers;
-
     if (countryFilter !== "all") {
       list = list.filter((m) => m.country === countryFilter);
     }
-
     list = [...list].sort((a, b) => {
       let cmp = 0;
       switch (sortKey) {
@@ -75,10 +51,8 @@ export default function ManufacturerListingClient({
       }
       return sortOrder === "asc" ? cmp : -cmp;
     });
-
     return list;
   }, [manufacturers, countryFilter, sortKey, sortOrder]);
-
   function handleSortChange(newKey: SortKey) {
     if (newKey === sortKey) {
       setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -87,17 +61,14 @@ export default function ManufacturerListingClient({
       setSortOrder(newKey === "name" ? "asc" : "desc"); // default desc for count/year
     }
   }
-
   function getSortIndicator(key: SortKey) {
     if (sortKey !== key) return "";
     return sortOrder === "asc" ? " ↑" : " ↓";
   }
-
   function getDescription(m: ManufacturerSummary): string | null {
     if (locale === "fr" && m.descriptionFr) return m.descriptionFr;
     return m.description ?? null;
   }
-
   return (
     <>
       {/* Filters & Sort Bar */}
@@ -123,7 +94,6 @@ export default function ManufacturerListingClient({
             ))}
           </select>
         </div>
-
         {/* Sort Buttons */}
         <div className="flex items-center gap-1 ml-auto">
           <span className="text-sm font-medium text-gray-700 mr-1">
@@ -151,7 +121,6 @@ export default function ManufacturerListingClient({
           ))}
         </div>
       </div>
-
       {/* Results count */}
       <div className="text-sm text-gray-500 mb-4">
         {t("listing.resultsCount", {
@@ -159,7 +128,6 @@ export default function ManufacturerListingClient({
           total: manufacturers.length,
         })}
       </div>
-
       {/* Cards Grid */}
       {filtered.length === 0 ? (
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
@@ -195,7 +163,6 @@ export default function ManufacturerListingClient({
                     </span>
                   )}
                 </div>
-
                 <div className="flex items-center gap-3 mt-2 text-sm text-gray-500">
                   <span className="inline-flex items-center gap-1">
                     <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -212,7 +179,6 @@ export default function ManufacturerListingClient({
                     </span>
                   )}
                 </div>
-
                 {desc && (
                   <p className="mt-2 text-xs text-gray-400 line-clamp-2">
                     {desc}

--- a/lib/manufacturers.ts
+++ b/lib/manufacturers.ts
@@ -168,3 +168,54 @@ export async function getYachtsByManufacturerId(
     primaryImage: primaryImageByYachtId.get(row.yacht.id) || null,
   }));
 }
+
+/**
+ * Get related manufacturers — same country, excluding the current one.
+ */
+export async function getRelatedManufacturers(
+  manufacturerId: number,
+  country: string | null,
+  limit = 6,
+): Promise<ManufacturerSummary[]> {
+  if (!country) return [];
+
+  const rows = await db
+    .select({
+      id: manufacturers.id,
+      name: manufacturers.name,
+      country: manufacturers.country,
+      foundedYear: manufacturers.foundedYear,
+      description: manufacturers.description,
+      descriptionFr: manufacturers.descriptionFr,
+      yachtCount: count(yachtModels.id),
+    })
+    .from(manufacturers)
+    .leftJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(eq(manufacturers.country, country))
+    .groupBy(
+      manufacturers.id,
+      manufacturers.name,
+      manufacturers.country,
+      manufacturers.foundedYear,
+      manufacturers.description,
+      manufacturers.descriptionFr,
+    )
+    .orderBy(desc(count(yachtModels.id)))
+    .limit(limit + 1);
+
+  type RelatedRow = (typeof rows)[number];
+
+  return rows
+    .filter((row: RelatedRow) => row.id !== manufacturerId)
+    .slice(0, limit)
+    .map((row: RelatedRow) => ({
+      id: row.id,
+      name: row.name,
+      slug: slugify(row.name),
+      country: row.country,
+      foundedYear: row.foundedYear,
+      description: row.description,
+      descriptionFr: row.descriptionFr,
+      yachtCount: Number(row.yachtCount ?? 0),
+    }));
+}

--- a/lib/utils/country-flags.ts
+++ b/lib/utils/country-flags.ts
@@ -1,0 +1,28 @@
+/**
+ * Country name to flag emoji mapping.
+ * Shared between manufacturer listing and detail pages.
+ */
+export const COUNTRY_FLAGS: Record<string, string> = {
+  Austria: "🇦🇹",
+  Denmark: "🇩🇰",
+  Finland: "🇫🇮",
+  France: "🇫🇷",
+  Germany: "🇩🇪",
+  Italy: "🇮🇹",
+  Netherlands: "🇳🇱",
+  Norway: "🇳🇴",
+  Poland: "🇵🇱",
+  Slovenia: "🇸🇮",
+  Sweden: "🇸🇪",
+  "United Kingdom": "🇬🇧",
+  "United States": "🇺🇸",
+};
+
+/**
+ * Get the flag emoji for a country name.
+ * Returns the flag emoji if found, otherwise an empty string.
+ */
+export function getCountryFlag(country: string | null): string {
+  if (!country) return "";
+  return COUNTRY_FLAGS[country] ?? "";
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -534,6 +534,12 @@
         "title": "Read our {name} spotlight",
         "descriptionFallback": "Go deeper on {name}'s history, brand positioning, major milestones, and notable yacht models.",
         "openSpotlight": "Open spotlight →"
+      },
+      "aboutBrand": "About {name}",
+      "relatedManufacturers": {
+        "title": "Related Manufacturers",
+        "subtitle": "Other yacht builders from {country}",
+        "yachtCount": "{count, plural, one {# yacht} other {# yachts}}"
       }
     },
     "spotlight": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -534,6 +534,12 @@
         "title": "Lire notre spotlight {name}",
         "descriptionFallback": "Explorez l'histoire de {name}, son positionnement de marque, ses jalons majeurs et ses modèles de yacht remarquables.",
         "openSpotlight": "Ouvrir le spotlight →"
+      },
+      "aboutBrand": "À propos de {name}",
+      "relatedManufacturers": {
+        "title": "Constructeurs associés",
+        "subtitle": "Autres constructeurs de yachts en {country}",
+        "yachtCount": "{count, plural, one {# yacht} other {# yachts}}"
       }
     },
     "spotlight": {

--- a/tests/country-flags.test.ts
+++ b/tests/country-flags.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getCountryFlag, COUNTRY_FLAGS } from "../lib/utils/country-flags";
+
+describe("country-flags", () => {
+  describe("getCountryFlag", () => {
+    it("returns correct flag for France", () => {
+      expect(getCountryFlag("France")).toBe("🇫🇷");
+    });
+
+    it("returns correct flag for United States", () => {
+      expect(getCountryFlag("United States")).toBe("🇺🇸");
+    });
+
+    it("returns empty string for null", () => {
+      expect(getCountryFlag(null)).toBe("");
+    });
+
+    it("returns empty string for unknown country", () => {
+      expect(getCountryFlag("Atlantis")).toBe("");
+    });
+
+    it("all expected countries have flags", () => {
+      const countries = [
+        "Austria", "Denmark", "Finland", "France", "Germany",
+        "Italy", "Netherlands", "Norway", "Poland", "Slovenia",
+        "Sweden", "United Kingdom", "United States",
+      ];
+      for (const c of countries) {
+        expect(COUNTRY_FLAGS[c]).toBeDefined();
+        expect(COUNTRY_FLAGS[c]).toBeTruthy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Add shared country flag utility (lib/utils/country-flags.ts)
- Show country flag emoji next to country name in detail page
- Add 'About {Brand}' section with rich description
- Add related manufacturers section (same country, up to 6)
- Refactor manufacturer-listing-client to use shared flag utility
- Add getRelatedManufacturers query to lib/manufacturers.ts
- Add i18n keys for en and fr (aboutBrand, relatedManufacturers)
- Add 5 unit tests for country flag utility
