### PR TITLE
feat: add manufacturer logos with Clearbit API and SVG fallback (closes #264)

### DIFF
--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { getCountryFlag } from "@/lib/utils/country-flags";
 import { getSpotlightByManufacturerId } from "@/lib/manufacturer-spotlights";
 import { ManufacturerComparisons } from "./ManufacturerComparisons";
+import ManufacturerLogo from "@/components/manufacturer-logo";
 import dynamic from "next/dynamic";
 
 const ManufacturerFleetChart = dynamic(() => import("@/components/manufacturer-fleet-chart"), { ssr: false });
@@ -193,9 +194,12 @@ export default async function ManufacturerPage({
           </p>
           <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">
-                {manufacturer.name} {t("detail.yachtsSuffix")}
-              </h1>
+              <div className="flex items-center gap-4">
+                <ManufacturerLogo name={manufacturer.name} logoUrl={manufacturer.logoUrl} size={64} />
+                <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">
+                  {manufacturer.name} {t("detail.yachtsSuffix")}
+                </h1>
+              </div>
               <p className="mt-4 max-w-3xl text-muted-foreground leading-relaxed">
                 {(locale === "fr" && manufacturer.descriptionFr ? manufacturer.descriptionFr : manufacturer.description) ||
                   t("detail.descriptionFallback", { name: manufacturer.name, count: manufacturer.yachtCount })}
@@ -437,7 +441,8 @@ export default async function ManufacturerPage({
                   href={`/manufacturers/${rel.slug}`}
                   className="rounded-xl border border-border bg-card p-4 hover:border-sky-200 hover:shadow-sm transition-all text-center"
                 >
-                  <div className="text-2xl">{getCountryFlag(rel.country)}</div>
+                  <div className="flex justify-center"><ManufacturerLogo name={rel.name} logoUrl={rel.logoUrl} size={36} /></div>
+                  {rel.country && <div className="text-lg mt-1">{getCountryFlag(rel.country)}</div>}
                   <div className="mt-2 text-sm font-semibold leading-tight">{rel.name}</div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {t("detail.relatedManufacturers.yachtCount", { count: rel.yachtCount })}

--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -12,6 +12,7 @@ import { PriceTierDetail } from "@/app/components/PriceTierBadge";
 import { PriceInsightBlock } from "@/app/components/PriceInsightBlock";
 import { calculatePriceTier } from "@/lib/price-tier";
 import { slugify } from "@/lib/utils/slugify";
+import ManufacturerLogo from "@/components/manufacturer-logo";
 import { SimilarYachts } from "./SimilarYachts";
 import { SameSizeAlternatives } from "./SameSizeAlternatives";
 import { RelatedManufacturers } from "./RelatedManufacturers";
@@ -46,6 +47,7 @@ interface YachtData {
   id: number;
   manufacturer: string;
   manufacturerId: number | null;
+  manufacturerLogoUrl: string | null;
   modelName: string;
   year: number;
   slug: string;
@@ -317,9 +319,12 @@ export default function YachtDetailClient() {
           <div className="flex items-center gap-2 mb-2">
             <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel aria-hidden="true" />
           </div>
-          <p className="text-base sm:text-lg text-muted-foreground mb-4">
-            {t("builtBy", { manufacturer: yacht.manufacturer })}
-          </p>
+          <div className="flex items-center gap-3 mb-4">
+            <ManufacturerLogo name={yacht.manufacturer} logoUrl={yacht.manufacturerLogoUrl ?? null} size={32} />
+            <p className="text-base sm:text-lg text-muted-foreground">
+              {t("builtBy", { manufacturer: yacht.manufacturer })}
+            </p>
+          </div>
           {yacht.description && (
             <p className="text-muted-foreground mb-4 leading-relaxed text-sm sm:text-base">
               {yacht.description}

--- a/app/api/yachts/[slug]/route.ts
+++ b/app/api/yachts/[slug]/route.ts
@@ -38,7 +38,7 @@ export async function GET(
         const result = await getYachtDetailData(slug);
         if (!result) return null;
 
-        const { yacht, manufacturer, specsByGroup, images, reviews } = result;
+        const { yacht, manufacturer, manufacturerLogoUrl, specsByGroup, images, reviews } = result;
 
         // Rebuild specsByGroup with numeric values properly parsed
         const parsedSpecsByGroup: Record<
@@ -87,6 +87,7 @@ export async function GET(
           id: yacht.id,
           manufacturerId: yacht.manufacturerId,
           manufacturer: manufacturer,
+          manufacturerLogoUrl: manufacturerLogoUrl,
           modelName: yacht.modelName,
           year: yacht.year,
           slug: yacht.slug,

--- a/components/manufacturer-listing-client.tsx
+++ b/components/manufacturer-listing-client.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { slugify } from "@/lib/utils/slugify";
 import type { ManufacturerSummary } from "@/lib/manufacturers";
+import ManufacturerLogo from "./manufacturer-logo";
 import { COUNTRY_FLAGS } from "@/lib/utils/country-flags";
 type SortKey = "name" | "yachtCount" | "foundedYear";
 type SortOrder = "asc" | "desc";
@@ -153,15 +154,20 @@ export default function ManufacturerListingClient({
                 href={`/${locale}/manufacturers/${slugify(m.name)}`}
                 className="block bg-white rounded-xl p-5 hover:bg-blue-50 hover:shadow-md transition border border-gray-100 group"
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="font-semibold text-gray-900 group-hover:text-sky-700 transition">
-                    {m.name}
-                  </div>
+                <div className="flex items-start gap-3">
+                  <ManufacturerLogo name={m.name} logoUrl={m.logoUrl} size={40} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="font-semibold text-gray-900 group-hover:text-sky-700 transition">
+                        {m.name}
+                      </div>
                   {m.country && (
                     <span className="text-xl shrink-0" title={m.country}>
                       {COUNTRY_FLAGS[m.country] ?? ""}
                     </span>
                   )}
+                    </div>
+                  </div>
                 </div>
                 <div className="flex items-center gap-3 mt-2 text-sm text-gray-500">
                   <span className="inline-flex items-center gap-1">

--- a/components/manufacturer-logo.tsx
+++ b/components/manufacturer-logo.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Image from "next/image";
+
+interface ManufacturerLogoProps {
+  name: string;
+  logoUrl: string | null;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Reusable manufacturer logo component with SVG initial fallback.
+ * Uses next/image for optimization when logo_url is available,
+ * otherwise renders a colored circle with the brand initial.
+ */
+export default function ManufacturerLogo({
+  name,
+  logoUrl,
+  size = 40,
+  className = "",
+}: ManufacturerLogoProps) {
+  const initial = name.charAt(0).toUpperCase();
+  // Deterministic color from name
+  const hue = hashStringToHue(name);
+
+  if (logoUrl) {
+    return (
+      <div
+        className={`relative shrink-0 overflow-hidden rounded-lg bg-gray-50 ${className}`}
+        style={{ width: size, height: size }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={logoUrl}
+          alt={`${name} logo`}
+          width={size}
+          height={size}
+          className="h-full w-full object-contain p-1"
+          loading="lazy"
+          onError={(e) => {
+            // Replace with fallback on error
+            const target = e.currentTarget;
+            const fallback = target.nextElementSibling as HTMLElement;
+            if (fallback) {
+              target.style.display = "none";
+              fallback.style.display = "flex";
+            }
+          }}
+        />
+        {/* Hidden fallback, shown on img error */}
+        <div
+          className="absolute inset-0 items-center justify-center text-white font-bold"
+          style={{
+            display: "none",
+            backgroundColor: `hsl(${hue}, 55%, 45%)`,
+            fontSize: size * 0.45,
+          }}
+        >
+          {initial}
+        </div>
+      </div>
+    );
+  }
+
+  // No logo URL — render SVG initial fallback
+  return (
+    <div
+      className={`shrink-0 rounded-lg flex items-center justify-center text-white font-bold ${className}`}
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: `hsl(${hue}, 55%, 45%)`,
+        fontSize: size * 0.45,
+      }}
+      aria-label={`${name} logo`}
+    >
+      {initial}
+    </div>
+  );
+}
+
+/** Deterministic hue from string (0-360) */
+function hashStringToHue(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+}

--- a/lib/manufacturers.ts
+++ b/lib/manufacturers.ts
@@ -4,6 +4,7 @@ import { db, images, manufacturers, yachtModels } from "@/lib/db";
 import { slugify } from "@/lib/utils/slugify";
 
 export interface ManufacturerSummary {
+  logoUrl: string | null;
   id: number;
   name: string;
   slug: string;
@@ -16,7 +17,6 @@ export interface ManufacturerSummary {
 
 export interface ManufacturerDetail extends ManufacturerSummary {
   websiteUrl: string | null;
-  logoUrl: string | null;
 }
 
 export interface ManufacturerYachtCard {
@@ -53,6 +53,7 @@ export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[
       foundedYear: manufacturers.foundedYear,
       description: manufacturers.description,
       descriptionFr: manufacturers.descriptionFr,
+      logoUrl: manufacturers.logoUrl,
       yachtCount: count(yachtModels.id),
     })
     .from(manufacturers)
@@ -64,6 +65,7 @@ export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[
       manufacturers.foundedYear,
       manufacturers.description,
       manufacturers.descriptionFr,
+      manufacturers.logoUrl,
     )
     .orderBy(asc(manufacturers.name));
 
@@ -77,6 +79,7 @@ export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[
     foundedYear: row.foundedYear,
     description: row.description,
     descriptionFr: row.descriptionFr,
+    logoUrl: row.logoUrl,
     yachtCount: Number(row.yachtCount ?? 0),
   }));
 }
@@ -187,6 +190,7 @@ export async function getRelatedManufacturers(
       foundedYear: manufacturers.foundedYear,
       description: manufacturers.description,
       descriptionFr: manufacturers.descriptionFr,
+      logoUrl: manufacturers.logoUrl,
       yachtCount: count(yachtModels.id),
     })
     .from(manufacturers)
@@ -199,6 +203,7 @@ export async function getRelatedManufacturers(
       manufacturers.foundedYear,
       manufacturers.description,
       manufacturers.descriptionFr,
+      manufacturers.logoUrl,
     )
     .orderBy(desc(count(yachtModels.id)))
     .limit(limit + 1);
@@ -216,6 +221,7 @@ export async function getRelatedManufacturers(
       foundedYear: row.foundedYear,
       description: row.description,
       descriptionFr: row.descriptionFr,
+      logoUrl: row.logoUrl,
       yachtCount: Number(row.yachtCount ?? 0),
     }));
 }

--- a/lib/yachts.ts
+++ b/lib/yachts.ts
@@ -4,6 +4,7 @@ import { eq, inArray, desc, asc, sql, count, isNotNull } from "drizzle-orm";
 export interface YachtDetailData {
   yacht: typeof yachtModels.$inferSelect;
   manufacturer: string;
+  manufacturerLogoUrl: string | null;
   images: Array<{
     url: string;
     caption: string | null;
@@ -196,6 +197,7 @@ export async function getYachtDetailData(slug: string): Promise<YachtDetailData 
     .select({
       yacht: yachtModels,
       manufacturer: manufacturers.name,
+      manufacturerLogoUrl: manufacturers.logoUrl,
     })
     .from(yachtModels)
     .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
@@ -204,7 +206,7 @@ export async function getYachtDetailData(slug: string): Promise<YachtDetailData 
 
   if (yachtResult.length === 0) return null;
 
-  const { yacht, manufacturer } = yachtResult[0];
+  const { yacht, manufacturer, manufacturerLogoUrl } = yachtResult[0];
 
   // Fetch all spec values with category info
   const specs = await db
@@ -279,6 +281,7 @@ export async function getYachtDetailData(slug: string): Promise<YachtDetailData 
   return {
     yacht,
     manufacturer: manufacturer || "Unknown",
+    manufacturerLogoUrl: manufacturerLogoUrl || null,
     images: yachtImages.map((img: typeof images.$inferSelect) => ({
       url: img.url,
       caption: img.caption,

--- a/memory/.dreams/events.jsonl
+++ b/memory/.dreams/events.jsonl
@@ -47,3 +47,6 @@
 {"type":"memory.dream.completed","timestamp":"2026-05-08T01:43:51.822Z","phase":"light","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/light/2026-05-08.md","lineCount":1,"storageMode":"separate"}
 {"type":"memory.dream.completed","timestamp":"2026-05-08T01:43:51.822Z","phase":"rem","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/rem/2026-05-08.md","lineCount":5,"storageMode":"separate"}
 {"type":"memory.dream.completed","timestamp":"2026-05-08T01:43:51.822Z","phase":"deep","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/deep/2026-05-08.md","lineCount":2,"storageMode":"separate"}
+{"type":"memory.dream.completed","timestamp":"2026-05-10T01:08:58.920Z","phase":"light","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/light/2026-05-10.md","lineCount":1,"storageMode":"separate"}
+{"type":"memory.dream.completed","timestamp":"2026-05-10T01:08:58.920Z","phase":"rem","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/rem/2026-05-10.md","lineCount":5,"storageMode":"separate"}
+{"type":"memory.dream.completed","timestamp":"2026-05-10T01:08:58.920Z","phase":"deep","reportPath":"/root/.openclaw/workspace/sailing-yachts/memory/dreaming/deep/2026-05-10.md","lineCount":2,"storageMode":"separate"}

--- a/memory/dreaming/deep/2026-05-09.md
+++ b/memory/dreaming/deep/2026-05-09.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-05-10.md
+++ b/memory/dreaming/deep/2026-05-10.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/light/2026-05-09.md
+++ b/memory/dreaming/light/2026-05-09.md
@@ -1,0 +1,3 @@
+# Light Sleep
+
+- No notable updates.

--- a/memory/dreaming/light/2026-05-10.md
+++ b/memory/dreaming/light/2026-05-10.md
@@ -1,0 +1,3 @@
+# Light Sleep
+
+- No notable updates.

--- a/memory/dreaming/rem/2026-05-09.md
+++ b/memory/dreaming/rem/2026-05-09.md
@@ -1,0 +1,7 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- No strong candidate truths surfaced.

--- a/memory/dreaming/rem/2026-05-10.md
+++ b/memory/dreaming/rem/2026-05-10.md
@@ -1,0 +1,7 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- No strong candidate truths surfaced.

--- a/scripts/seed-manufacturer-logos.ts
+++ b/scripts/seed-manufacturer-logos.ts
@@ -1,0 +1,127 @@
+/**
+ * P16.2 — Seed manufacturer logo URLs
+ *
+ * Uses Clearbit Logo API for most manufacturers, with manual overrides
+ * for brands where Clearbit returns poor results or the website domain
+ * doesn't match the brand name well.
+ *
+ * Run: npx tsx scripts/seed-manufacturer-logos.ts
+ */
+
+import { neon } from "@neondatabase/serverless";
+
+// Build logo URL mapping: manufacturer name -> logo URL
+// Clearbit format: https://logo.clearbit.com/{domain}
+const LOGO_OVERRIDES: Record<string, string> = {
+  // Manual overrides where Clearbit domain doesn't work well
+  "Allures Yachting": "https://logo.clearbit.com/allures-yachting.com",
+  "Amel": "https://logo.clearbit.com/amel.fr",
+  "Arcona Yachts": "https://logo.clearbit.com/arconayachts.se",
+  "Bavaria Yachts": "https://logo.clearbit.com/bavariayachts.com",
+  "Beneteau": "https://logo.clearbit.com/beneteau.com",
+  "Bowman Yachts": "https://logo.clearbit.com/bowmanyachts.com",
+  "CNB": "https://logo.clearbit.com/cnb.fr",
+  "Catalina Yachts": "https://logo.clearbit.com/catalinayachts.com",
+  "Contest Yachts": "https://logo.clearbit.com/contestyachts.com",
+  "Dehler": "https://logo.clearbit.com/dehler.com",
+  "Delphia Yachts": "https://logo.clearbit.com/delphiayachts.pl",
+  "Dragonfly Trimarans": "https://logo.clearbit.com/dkboats.com",
+  "Dufour Yachts": "https://logo.clearbit.com/dufour-yachts.com",
+  "Elan Yachts": "https://logo.clearbit.com/elan-yachts.com",
+  "Feeling": "https://logo.clearbit.com/feeling-yachts.com",
+  "Garcia Yachting": "https://logo.clearbit.com/garcia-yachting.com",
+  "Grand Soleil": "https://logo.clearbit.com/grandsoleil.net",
+  "Hallberg-Rassy": "https://logo.clearbit.com/hallberg-rassy.com",
+  "Hanse Yachts": "https://logo.clearbit.com/hanseyachts.com",
+  "Hunter Yachts": "https://logo.clearbit.com/hunteryachts.com",
+  "Island Packet": "https://logo.clearbit.com/islandpacket.com",
+  "J/Boats": "https://logo.clearbit.com/jboats.com",
+  "Jeanneau": "https://logo.clearbit.com/jeanneau.com",
+  "Lagoon": "https://logo.clearbit.com/lagoon-catamarans.com",
+  "Moody Yachts": "https://logo.clearbit.com/moody-yachts.com",
+  "Mylius": "https://logo.clearbit.com/mylius.it",
+  "Najad": "https://logo.clearbit.com/najad.com",
+  "Neel Trimarans": "https://logo.clearbit.com/neel-trimarans.com",
+  "Oyster Yachts": "https://logo.clearbit.com/oysteryachts.com",
+  "RM Yachts": "https://logo.clearbit.com/rmyachts.fr",
+  "Saffier Yachts": "https://logo.clearbit.com/saffieryachts.com",
+  "Sirius Yachts": "https://logo.clearbit.com/sirius-yachts.com",
+  "Solaris Yachts": "https://logo.clearbit.com/solarisyachts.it",
+  "Sunbeam Yachts": "https://logo.clearbit.com/sunbeam-yachts.at",
+  "Swan (Nautor)": "https://logo.clearbit.com/nautorgroup.com",
+  "Tartan Yachts": "https://logo.clearbit.com/tartanyachts.com",
+  "Wally": "https://logo.clearbit.com/wally.com",
+  "Wauquiez": "https://logo.clearbit.com/wauquiez.com",
+  "X-Yachts": "https://logo.clearbit.com/x-yachts.com",
+  // These manufacturers have no website; leave logo_url null (fallback will handle)
+  "Hatteland": null as any,
+  "SaBoat (Grand Soleil)": "https://logo.clearbit.com/grandsoleil.net",
+  "Vancouver (Northshore)": null as any,
+};
+
+function getLogoUrl(name: string, websiteUrl: string | null): string | null {
+  if (LOGO_OVERRIDES[name] !== undefined) {
+    return LOGO_OVERRIDES[name];
+  }
+  // Fallback: derive from website URL
+  if (websiteUrl) {
+    try {
+      const domain = new URL(websiteUrl).hostname;
+      return `https://logo.clearbit.com/${domain}`;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL not set");
+    process.exit(1);
+  }
+
+  const sql = neon(databaseUrl);
+
+  // Get all manufacturers
+  const manufacturers = await sql`
+    SELECT id, name, website_url, logo_url
+    FROM manufacturers
+    ORDER BY name
+  `;
+
+  console.log(`Found ${manufacturers.length} manufacturers`);
+
+  let updated = 0;
+  let skipped = 0;
+  let cleared = 0;
+
+  for (const m of manufacturers) {
+    const logoUrl = getLogoUrl(m.name, m.website_url);
+
+    if (logoUrl) {
+      await sql`
+        UPDATE manufacturers
+        SET logo_url = ${logoUrl}
+        WHERE id = ${m.id}
+      `;
+      console.log(`  ✅ ${m.name}: ${logoUrl}`);
+      updated++;
+    } else if (m.logo_url) {
+      // Has existing logo but we can't determine one — keep it
+      console.log(`  ⏭️  ${m.name}: keeping existing ${m.logo_url}`);
+      skipped++;
+    } else {
+      console.log(`  ⬜ ${m.name}: no logo available (will use fallback)`);
+      cleared++;
+    }
+  }
+
+  console.log(`\nDone: ${updated} updated, ${skipped} kept, ${cleared} without logo`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/tests/manufacturer-logo.test.ts
+++ b/tests/manufacturer-logo.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Tests for ManufacturerLogo component logic.
+ * Tests the deterministic hash function and fallback behavior.
+ */
+
+// Replicate the hash function from the component
+function hashStringToHue(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+}
+
+function getInitial(name: string): string {
+  return name.charAt(0).toUpperCase();
+}
+
+function getFallbackBgColor(name: string): string {
+  const hue = hashStringToHue(name);
+  return `hsl(${hue}, 55%, 45%)`;
+}
+
+describe("ManufacturerLogo — logic", () => {
+  describe("hashStringToHue", () => {
+    it("returns a value between 0 and 360", () => {
+      for (const name of ["Beneteau", "Jeanneau", "X-Yachts", "J/Boats"]) {
+        const hue = hashStringToHue(name);
+        expect(hue).toBeGreaterThanOrEqual(0);
+        expect(hue).toBeLessThan(360);
+      }
+    });
+
+    it("is deterministic — same input always gives same output", () => {
+      expect(hashStringToHue("Beneteau")).toBe(hashStringToHue("Beneteau"));
+      expect(hashStringToHue("Hallberg-Rassy")).toBe(hashStringToHue("Hallberg-Rassy"));
+    });
+
+    it("gives different hues for different manufacturers", () => {
+      const hue1 = hashStringToHue("Beneteau");
+      const hue2 = hashStringToHue("Jeanneau");
+      expect(hue1).not.toBe(hue2);
+    });
+  });
+
+  describe("getInitial", () => {
+    it("returns first character uppercased", () => {
+      expect(getInitial("Beneteau")).toBe("B");
+      expect(getInitial("beneteau")).toBe("B");
+    });
+
+    it("handles special characters", () => {
+      expect(getInitial("J/Boats")).toBe("J");
+      expect(getInitial("X-Yachts")).toBe("X");
+    });
+  });
+
+  describe("getFallbackBgColor", () => {
+    it("returns valid hsl color string", () => {
+      const color = getFallbackBgColor("Beneteau");
+      expect(color).toMatch(/^hsl\(\d+, 55%, 45%\)$/);
+    });
+
+    it("is consistent across calls", () => {
+      expect(getFallbackBgColor("Test")).toBe(getFallbackBgColor("Test"));
+    });
+
+    it("gives different colors for different names", () => {
+      expect(getFallbackBgColor("A")).not.toBe(getFallbackBgColor("B"));
+    });
+  });
+
+  describe("Logo URL construction", () => {
+    it("constructs Clearbit URL from domain", () => {
+      const domain = "beneteau.com";
+      const logoUrl = `https://logo.clearbit.com/${domain}`;
+      expect(logoUrl).toBe("https://logo.clearbit.com/beneteau.com");
+    });
+
+    it("extracts domain from website URL", () => {
+      const websiteUrl = "https://www.bavariayachts.com";
+      const domain = new URL(websiteUrl).hostname;
+      expect(domain).toBe("www.bavariayachts.com");
+      const logoUrl = `https://logo.clearbit.com/${domain}`;
+      expect(logoUrl).toBe("https://logo.clearbit.com/www.bavariayachts.com");
+    });
+  });
+
+  describe("Logo coverage", () => {
+    const MANUFACTURERS_WITH_LOGOS = [
+      "Allures Yachting", "Amel", "Arcona Yachts", "Bavaria Yachts",
+      "Beneteau", "Bowman Yachts", "CNB", "Catalina Yachts",
+      "Contest Yachts", "Dehler", "Delphia Yachts", "Dragonfly Trimarans",
+      "Dufour Yachts", "Elan Yachts", "Feeling", "Garcia Yachting",
+      "Grand Soleil", "Hallberg-Rassy", "Hanse Yachts", "Hunter Yachts",
+      "Island Packet", "J/Boats", "Jeanneau", "Lagoon",
+      "Moody Yachts", "Mylius", "Najad", "Neel Trimarans",
+      "Oyster Yachts", "RM Yachts", "Saffier Yachts", "Sirius Yachts",
+      "Solaris Yachts", "Sunbeam Yachts", "Swan (Nautor)", "Tartan Yachts",
+      "Wally", "Wauquiez", "X-Yachts", "SaBoat (Grand Soleil)",
+    ];
+
+    const MANUFACTURERS_WITHOUT_LOGOS = ["Hatteland", "Vancouver (Northshore)"];
+
+    it("covers 40 of 42 manufacturers with logo URLs", () => {
+      expect(MANUFACTURERS_WITH_LOGOS.length).toBe(40);
+      expect(MANUFACTURERS_WITHOUT_LOGOS.length).toBe(2);
+    });
+
+    it("fallback initial works for all manufacturers", () => {
+      const allManufacturers = [...MANUFACTURERS_WITH_LOGOS, ...MANUFACTURERS_WITHOUT_LOGOS];
+      for (const name of allManufacturers) {
+        const initial = getInitial(name);
+        expect(initial.length).toBe(1);
+        expect(initial).toMatch(/[A-Z]/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Add ManufacturerLogo component with Clearbit logo API + initial fallback
- Seed logo URLs for 40/42 manufacturers via seed-manufacturer-logos.ts
- Display logos on manufacturer listing page (card grid)
- Display logo on manufacturer detail page (header + related manufacturers)
- Display logo on yacht detail page (next to manufacturer name)
- Add manufacturerLogoUrl to yacht API response
- Add logoUrl to ManufacturerSummary and related queries
- 12 unit tests for logo logic (hash, initial, color, coverage)
