### PR TITLE
feat: P17.2 — Yacht Use Case tags & filter

### DIFF
--- a/app/[locale]/yachts/YachtsClient.tsx
+++ b/app/[locale]/yachts/YachtsClient.tsx
@@ -8,15 +8,17 @@ import CompletenessBadge from '@/components/CompletenessBadge';
 import { calculateCompletenessScore } from '@/lib/completeness';
 import { FILTER_PRESETS, detectActivePreset, type FilterPreset } from '@/lib/filter-presets';
 import type { YachtsListingResult, FilterOptions, YachtListItem } from '@/lib/yachts';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { assignUseCaseTags, USE_CASE_TAG_IDS, type UseCaseTagId } from '@/lib/use-case-tags';
+import { UseCaseBadgeGroup } from '@/components/use-case-badge';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 const LengthDistributionChart = dynamic(() => import('@/components/length-distribution-chart'), { ssr: false, loading: () => null });
 const RangeSlider = dynamic(() => import('@/app/components/RangeSlider'), { ssr: false, loading: () => null });
 
-// Use the shared type from lib/yachts
-type Yacht = YachtListItem;
+// Use the shared type from lib/yachts — extended with optional useCaseTags from API
+type Yacht = YachtListItem & { useCaseTags?: UseCaseTagId[] };
 
 // ─── Data-driven range definitions ───────────────────────────────────
 const RANGE_FILTERS = [
@@ -73,6 +75,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
   const rigType = searchParams.get('filters[rigType]') ?? undefined;
   const keelType = searchParams.get('filters[keelType]') ?? undefined;
   const hullMaterial = searchParams.get('filters[hullMaterial]') ?? undefined;
+  const useCaseFilter = searchParams.get('filters[useCase]') ?? undefined;
 
   // Active filter count for badge (count non-empty filter params)
   const activeFilterCount = Array.from(searchParams.keys()).filter(k => k.startsWith('filters[') && searchParams.get(k)).length;
@@ -85,6 +88,26 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
   const currentKey = filterKey(searchParams);
   const lastFetchedKey = useRef<string>(initialData ? 'initial' : '');
   const abortRef = useRef<AbortController | null>(null);
+
+  // Compute tags for yachts that don't have them from the API (client-side fallback)
+  const yachtsWithTags = useMemo(() =>
+    yachts.map(y => ({
+      ...y,
+      useCaseTags: y.useCaseTags ?? assignUseCaseTags({
+        lengthOverall: y.lengthOverall ?? null,
+        beam: y.beam ?? null,
+        draft: y.draft ?? null,
+        displacement: y.displacement ?? null,
+        ballast: y.ballast ?? null,
+        sailAreaMain: y.sailAreaMain ?? null,
+        cabins: y.cabins ?? null,
+        berths: y.berths ?? null,
+        rigType: y.rigType ?? null,
+        keelType: y.keelType ?? null,
+      }),
+    })),
+    [yachts]
+  );
 
   // Fetch manufacturers list (once, only if not provided via SSR)
   useEffect(() => {
@@ -124,6 +147,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
     if (rigType) q.set('filters[rigType]', rigType);
     if (keelType) q.set('filters[keelType]', keelType);
     if (hullMaterial) q.set('filters[hullMaterial]', hullMaterial);
+    if (useCaseFilter) q.set('filters[useCase]', useCaseFilter);
 
     // Pass all range filter params from URL to API
     for (const rf of RANGE_FILTERS) {
@@ -309,6 +333,26 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
             {t('filters.activeCount', { count: activeFilterCount })}
           </span>
         )}
+      </div>
+
+      {/* Use Case Tag filter */}
+      <div className="mb-6">
+        <h3 className="text-sm font-medium mb-2" id="filter-usecase-heading">{t('filters.useCase')}</h3>
+        <ul className="space-y-1 max-h-56 overflow-y-auto" role="radiogroup" aria-labelledby="filter-usecase-heading">
+          {USE_CASE_TAG_IDS.map(tagId => (
+            <li key={tagId}>
+              <label className="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="form-checkbox rounded"
+                  checked={useCaseFilter === tagId}
+                  onChange={() => setFilter('useCase', useCaseFilter === tagId ? null : tagId)}
+                />
+                <span className="ml-2 text-sm">{t(`useCaseTags.${tagId}.label`)}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
       </div>
 
       {/* Manufacturer filter */}
@@ -499,7 +543,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
             ) : (
               <>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6" role="region" aria-label="Yacht listings" aria-live="polite">
-                  {yachts.map(yacht => (
+                  {yachtsWithTags.map(yacht => (
                     <div key={yacht.id} className="border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow relative">
                       <div className="flex items-start justify-between gap-2">
                         <h3 className="font-bold text-lg leading-tight">
@@ -526,6 +570,12 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
                         })} />
                         <CompletenessBadge score={calculateCompletenessScore(yacht)} />
                       </div>
+                      {/* Use case tags */}
+                      {yacht.useCaseTags && yacht.useCaseTags.length > 0 && (
+                        <div className="mt-2">
+                          <UseCaseBadgeGroup tagIds={yacht.useCaseTags} />
+                        </div>
+                      )}
                       <dl className="mt-3 text-sm">
                         <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.length')}</dt><dd className="font-medium">{format(yacht.lengthOverall)} m</dd></div>
                         <div className="flex justify-between py-0.5"><dt className="text-gray-500">{t('specs.beam')}</dt><dd className="font-medium">{format(yacht.beam)} m</dd></div>

--- a/app/[locale]/yachts/tags/page.tsx
+++ b/app/[locale]/yachts/tags/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { getSiteUrl, buildLocaleAlternates } from '@/lib/seo';
+import { USE_CASE_TAG_IDS, USE_CASE_TAG_META, assignUseCaseTags, type UseCaseTagId } from '@/lib/use-case-tags';
+import { UseCaseBadge } from '@/components/use-case-badge';
+import { pool } from '@/lib/db';
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Yachts' });
+
+  return {
+    title: t('useCaseTagsPage.meta.title'),
+    description: t('useCaseTagsPage.meta.description'),
+    alternates: buildLocaleAlternates('/yachts/tags'),
+  };
+}
+
+export default async function UseCaseTagsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Yachts' });
+
+  // Count yachts per tag for stats
+  const result = await pool.query(
+    `SELECT id, length_overall, beam, draft, displacement, ballast, sail_area_main, rig_type, keel_type, cabins, berths FROM yacht_models`
+  );
+
+  const tagCounts: Record<string, number> = {};
+  for (const tagId of USE_CASE_TAG_IDS) {
+    tagCounts[tagId] = 0;
+  }
+  for (const row of result.rows) {
+    const tags = assignUseCaseTags({
+      lengthOverall: row.length_overall ?? null,
+      beam: row.beam ?? null,
+      draft: row.draft ?? null,
+      displacement: row.displacement ?? null,
+      ballast: row.ballast ?? null,
+      sailAreaMain: row.sail_area_main ?? null,
+      cabins: row.cabins ?? null,
+      berths: row.berths ?? null,
+      rigType: row.rig_type ?? null,
+      keelType: row.keel_type ?? null,
+    });
+    for (const tag of tags) {
+      tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+    }
+  }
+
+  const totalYachts = result.rows.length;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
+        <h1 className="text-3xl sm:text-4xl font-bold mb-4">{t('useCaseTagsPage.heading')}</h1>
+        <p className="text-gray-600 text-lg mb-8">{t('useCaseTagsPage.intro')}</p>
+
+        <div className="space-y-8">
+          {USE_CASE_TAG_IDS.map(tagId => {
+            const meta = USE_CASE_TAG_META[tagId];
+            const count = tagCounts[tagId] || 0;
+            return (
+              <div key={tagId} className="bg-white rounded-xl shadow-sm border p-6">
+                <div className="flex items-center gap-3 mb-3">
+                  <UseCaseBadge tagId={tagId} size="md" />
+                  <span className="text-sm text-gray-500">
+                    {t('useCaseTagsPage.yachtCount', { count })}
+                  </span>
+                </div>
+                <h2 className="text-xl font-semibold mb-2">{t(`useCaseTags.${tagId}.label`)}</h2>
+                <p className="text-gray-700 leading-relaxed">{t(`useCaseTags.${tagId}.description`)}</p>
+                <div className="mt-4 pt-4 border-t border-gray-100">
+                  <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">
+                    {t('useCaseTagsPage.criteria')}
+                  </h3>
+                  <p className="text-sm text-gray-600">{t(`useCaseTags.${tagId}.criteria`)}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-8 pt-8 border-t border-gray-200 text-center">
+          <p className="text-sm text-gray-500 mb-4">
+            {t('useCaseTagsPage.disclaimer', { total: totalYachts })}
+          </p>
+          <a
+            href="/yachts"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors"
+          >
+            {t('useCaseTagsPage.browseAll')}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/yachts/route.ts
+++ b/app/api/yachts/route.ts
@@ -1,12 +1,16 @@
 import { NextResponse } from 'next/server';
 import { pool } from '@/lib/db';
 import { cached, CACHE_TTL, CACHE_TAGS } from '@/lib/api-cache';
+import { assignUseCaseTags, type UseCaseTagId } from '@/lib/use-case-tags';
 
 export const dynamic = 'force-dynamic';
 
 // ─── Lightweight field sets ──────────────────────────────────────────
 const LIST_FIELDS = 'y.id, y.model_name, y.slug, y.year, y.length_overall, y.beam, y.draft, y.displacement, y.rig_type, y.keel_type, y.hull_material, y.cabins, y.manufacturer_id, m.name as manufacturer_name';
 const ALL_FIELDS = 'y.*, m.name as manufacturer_name';
+
+// ─── Fields needed for tag computation (used when useCase filter active) ──
+const TAG_FIELDS = 'y.id, y.model_name, y.slug, y.year, y.length_overall, y.beam, y.draft, y.displacement, y.ballast, y.sail_area_main, y.rig_type, y.keel_type, y.hull_material, y.cabins, y.berths, y.manufacturer_id, m.name as manufacturer_name';
 
 // ─── Cached: distinct filter options (changes rarely) ────────────────
 const getCachedFilterOptions = cached(
@@ -52,6 +56,22 @@ function addRangeFilter(
   }
 }
 
+// ─── Compute tags for a DB row ───────────────────────────────────────
+function computeTagsForRow(row: any): UseCaseTagId[] {
+  return assignUseCaseTags({
+    lengthOverall: row.length_overall ?? null,
+    beam: row.beam ?? null,
+    draft: row.draft ?? null,
+    displacement: row.displacement ?? null,
+    ballast: row.ballast ?? null,
+    sailAreaMain: row.sail_area_main ?? null,
+    cabins: row.cabins ?? null,
+    berths: row.berths ?? null,
+    rigType: row.rig_type ?? null,
+    keelType: row.keel_type ?? null,
+  });
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -60,6 +80,10 @@ export async function GET(request: Request) {
     const sortBy = searchParams.get('sort') || 'id';
     const sortOrder = searchParams.get('order') === 'desc' ? 'DESC' : 'ASC';
     const view = searchParams.get('view') || 'full'; // 'list' for lighter payload
+
+    // Use-case tag filter (computed in memory from spec heuristics)
+    const useCaseFilter = searchParams.get('filters[useCase]') as UseCaseTagId | null;
+    const validUseCaseFilter = useCaseFilter && ['bluewater-cruiser', 'weekend-sailor', 'racing', 'liveaboard', 'family-cruiser', 'light-wind-performer'].includes(useCaseFilter) ? useCaseFilter : null;
 
     // Build WHERE clauses
     const conditions: string[] = [];
@@ -95,18 +119,69 @@ export async function GET(request: Request) {
     addRangeFilter(searchParams, 'filters[cabinsMin]', 'filters[cabinsMax]', 'y.cabins', conditions, params, paramIdx, 'int');
     addRangeFilter(searchParams, 'filters[berthsMin]', 'filters[berthsMax]', 'y.berths', conditions, params, paramIdx, 'int');
 
-    // Keep backward compat for old single-bound filters
-    const cabinsMinLegacy = parseInt(searchParams.get('filters[cabinsMin]') || '', 10);
-    if (!isNaN(cabinsMinLegacy) && !searchParams.has('filters[cabinsMax]')) {
-      // Already handled by addRangeFilter above if cabinsMin exists
-    }
-
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
     // Validate sort column
     const allowedSorts = ['id', 'model_name', 'year', 'length_overall', 'beam', 'draft', 'displacement', 'ballast', 'sail_area_main', 'cabins', 'berths', 'heads', 'engine_hp'];
     const safeSort = allowedSorts.includes(sortBy) ? sortBy : 'id';
 
+    // When useCase filter is active, we need to fetch all matching rows,
+    // compute tags, filter in memory, then paginate.
+    if (validUseCaseFilter) {
+      // Fetch all rows matching other criteria (no LIMIT/OFFSET)
+      const fields = TAG_FIELDS;
+      const [dataResult, distinct] = await Promise.all([
+        pool.query(
+          `SELECT ${fields} FROM yacht_models y LEFT JOIN manufacturers m ON y.manufacturer_id = m.id ${whereClause} ORDER BY y.${safeSort} ${sortOrder}`,
+          params,
+        ),
+        getCachedFilterOptions(),
+      ]);
+
+      // Compute tags and filter
+      const tagged = dataResult.rows.map((row: any) => ({
+        row,
+        tags: computeTagsForRow(row),
+      })).filter(item => item.tags.includes(validUseCaseFilter));
+
+      const total = tagged.length;
+      const offset = (page - 1) * limit;
+      const paged = tagged.slice(offset, offset + limit);
+
+      // Map to response shape (always use full mapping since we fetched TAG_FIELDS)
+      const yachts = paged.map(({ row, tags }) => ({
+        id: row.id,
+        manufacturer: row.manufacturer_name ?? '',
+        modelName: row.model_name,
+        year: row.year ?? undefined,
+        slug: row.slug ?? undefined,
+        lengthOverall: row.length_overall ?? undefined,
+        beam: row.beam ?? undefined,
+        draft: row.draft ?? undefined,
+        displacement: row.displacement ?? undefined,
+        ballast: row.ballast ?? undefined,
+        sailAreaMain: row.sail_area_main ?? undefined,
+        rigType: row.rig_type ?? undefined,
+        keelType: row.keel_type ?? undefined,
+        hullMaterial: row.hull_material ?? undefined,
+        cabins: row.cabins ?? undefined,
+        berths: row.berths ?? undefined,
+        useCaseTags: tags,
+      }));
+
+      const response = NextResponse.json({
+        yachts,
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+        distinct,
+      });
+      response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=120');
+      return response;
+    }
+
+    // ── Normal path (no useCase filter) ──
     const offset = (page - 1) * limit;
     const fields = view === 'list' ? LIST_FIELDS : ALL_FIELDS;
 

--- a/components/use-case-badge.tsx
+++ b/components/use-case-badge.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { USE_CASE_TAG_META, type UseCaseTagId } from '@/lib/use-case-tags';
+import { useTranslations } from 'next-intl';
+
+interface UseCaseBadgeProps {
+  tagId: UseCaseTagId;
+  size?: 'sm' | 'md';
+}
+
+export function UseCaseBadge({ tagId, size = 'sm' }: UseCaseBadgeProps) {
+  const t = useTranslations('Yachts.useCaseTags');
+  const meta = USE_CASE_TAG_META[tagId];
+  if (!meta) return null;
+
+  const sizeClasses = size === 'sm'
+    ? 'text-xs px-1.5 py-0.5'
+    : 'text-sm px-2.5 py-1';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border font-medium ${meta.color} ${meta.textColor} ${meta.borderColor} ${sizeClasses}`}
+      title={t(`${tagId}.description`)}
+    >
+      {t(`${tagId}.label`)}
+    </span>
+  );
+}
+
+interface UseCaseBadgeGroupProps {
+  tagIds: UseCaseTagId[];
+  size?: 'sm' | 'md';
+  max?: number;
+}
+
+export function UseCaseBadgeGroup({ tagIds, size = 'sm', max = 3 }: UseCaseBadgeGroupProps) {
+  if (!tagIds || tagIds.length === 0) return null;
+
+  const visible = tagIds.slice(0, max);
+  const remaining = tagIds.length - max;
+
+  return (
+    <div className="flex flex-wrap gap-1" role="list" aria-label="Use case tags">
+      {visible.map(id => (
+        <span key={id} role="listitem">
+          <UseCaseBadge tagId={id} size={size} />
+        </span>
+      ))}
+      {remaining > 0 && (
+        <span className={`inline-flex items-center rounded-full border font-medium bg-gray-100 text-gray-600 border-gray-200 ${size === 'sm' ? 'text-xs px-1.5 py-0.5' : 'text-sm px-2.5 py-1'}`}>
+          +{remaining}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/lib/use-case-tags.ts
+++ b/lib/use-case-tags.ts
@@ -1,0 +1,231 @@
+/**
+ * Use-case tag assignment for sailing yachts.
+ *
+ * Tags are assigned purely from spec heuristics (no human curation needed).
+ * Each yacht can have zero or more tags. Tags are computed at runtime from
+ * the raw spec data so no DB migration is required.
+ *
+ * Tag IDs are stable strings used for filtering & URLs.
+ * Display labels come from i18n messages (Yachts.useCaseTags.*).
+ */
+
+// ─── Tag definitions ─────────────────────────────────────────────────
+
+export const USE_CASE_TAG_IDS = [
+  'bluewater-cruiser',
+  'weekend-sailor',
+  'racing',
+  'liveaboard',
+  'family-cruiser',
+  'light-wind-performer',
+] as const;
+
+export type UseCaseTagId = (typeof USE_CASE_TAG_IDS)[number];
+
+export interface UseCaseTagMeta {
+  id: UseCaseTagId;
+  color: string;        // Tailwind bg class
+  textColor: string;    // Tailwind text class
+  borderColor: string;  // Tailwind border class
+}
+
+export const USE_CASE_TAG_META: Record<UseCaseTagId, UseCaseTagMeta> = {
+  'bluewater-cruiser': {
+    id: 'bluewater-cruiser',
+    color: 'bg-blue-100',
+    textColor: 'text-blue-800',
+    borderColor: 'border-blue-200',
+  },
+  'weekend-sailor': {
+    id: 'weekend-sailor',
+    color: 'bg-green-100',
+    textColor: 'text-green-800',
+    borderColor: 'border-green-200',
+  },
+  racing: {
+    id: 'racing',
+    color: 'bg-red-100',
+    textColor: 'text-red-800',
+    borderColor: 'border-red-200',
+  },
+  liveaboard: {
+    id: 'liveaboard',
+    color: 'bg-purple-100',
+    textColor: 'text-purple-800',
+    borderColor: 'border-purple-200',
+  },
+  'family-cruiser': {
+    id: 'family-cruiser',
+    color: 'bg-amber-100',
+    textColor: 'text-amber-800',
+    borderColor: 'border-amber-200',
+  },
+  'light-wind-performer': {
+    id: 'light-wind-performer',
+    color: 'bg-cyan-100',
+    textColor: 'text-cyan-800',
+    borderColor: 'border-cyan-200',
+  },
+};
+
+// ─── Input type (subset of yacht spec fields) ────────────────────────
+
+export interface YachtSpecForTags {
+  lengthOverall: number | null;   // meters
+  beam: number | null;            // meters
+  draft: number | null;           // meters
+  displacement: number | null;    // kg
+  ballast: number | null;         // kg
+  sailAreaMain: number | null;    // m²
+  cabins: number | null;
+  berths: number | null;
+  rigType: string | null;
+  keelType: string | null;
+}
+
+// ─── Thresholds (tweakable) ──────────────────────────────────────────
+
+const THRESHOLDS = {
+  // Bluewater: heavy, long, deep keel
+  bluewater: {
+    minLOA: 10.5,          // ~35ft
+    minDisplacement: 5000, // 5 tonnes
+    minBallastRatio: 0.30, // 30% ballast ratio
+  },
+  // Racing: light, high SA/D, fin keel
+  racing: {
+    maxDLRatio: 200,       // D/L ratio (low = light)
+    minSADRatio: 18,       // SA/D ratio (high = powered up)
+  },
+  // Liveaboard: big, many cabins/berths
+  liveaboard: {
+    minLOA: 11,            // ~36ft
+    minCabins: 3,
+  },
+  // Family cruiser: moderate size, multiple cabins
+  family: {
+    minLOA: 9,             // ~30ft
+    maxLOA: 14,            // ~46ft
+    minCabins: 2,
+  },
+  // Weekend sailor: small, simple
+  weekend: {
+    maxLOA: 10,            // ~33ft
+  },
+  // Light wind performer: high SA/D, light
+  lightWind: {
+    minSADRatio: 17,
+    maxDisplacement: 6000,
+  },
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function displacementLengthRatio(displacementKg: number, loaM: number): number | null {
+  if (loaM <= 0) return null;
+  const dispLongTons = displacementKg / 1018;
+  const lwlFt = loaM / 0.3054; // approximate LWL ~ LOA for this heuristic
+  const denom = Math.pow(lwlFt / 100, 3);
+  if (denom === 0) return null;
+  return dispLongTons / denom;
+}
+
+function sailAreaDisplacementRatio(sailAreaM2: number, displacementKg: number): number | null {
+  if (displacementKg <= 0) return null;
+  const dispLongTons = displacementKg / 1018;
+  return sailAreaM2 / Math.pow(dispLongTons, 2 / 3);
+}
+
+function ballastRatio(ballastKg: number, displacementKg: number): number | null {
+  if (displacementKg <= 0) return null;
+  return ballastKg / displacementKg;
+}
+
+// ─── Tag assignment ──────────────────────────────────────────────────
+
+/**
+ * Assign use-case tags to a yacht based on its specs.
+ *
+ * Tags are intentionally overlapping — a yacht can be both a
+ * "bluewater-cruiser" and a "liveaboard". Order is deterministic
+ * (matches USE_CASE_TAG_IDS) so tests are stable.
+ */
+export function assignUseCaseTags(spec: YachtSpecForTags): UseCaseTagId[] {
+  const tags: UseCaseTagId[] = [];
+
+  const loa = spec.lengthOverall;
+  const disp = spec.displacement;
+  const ballast = spec.ballast;
+  const sailArea = spec.sailAreaMain;
+  const cabins = spec.cabins;
+
+  // ── Bluewater Cruiser ──
+  // Heavier displacement, longer hull, high ballast ratio for stability
+  if (loa != null && disp != null) {
+    const meetsLOA = loa >= THRESHOLDS.bluewater.minLOA;
+    const meetsDisp = disp >= THRESHOLDS.bluewater.minDisplacement;
+    const br = ballast != null && disp > 0 ? ballastRatio(ballast, disp) : null;
+    const meetsBallast = br != null ? br >= THRESHOLDS.bluewater.minBallastRatio : false;
+    // Need at least LOA + displacement, plus either ballast data or deep keel hint
+    if (meetsLOA && meetsDisp && (meetsBallast || (spec.keelType && /fin|long|full/i.test(spec.keelType)))) {
+      tags.push('bluewater-cruiser');
+    }
+  }
+
+  // ── Weekend Sailor ──
+  // Compact yachts, easy to handle short-handed
+  if (loa != null && loa <= THRESHOLDS.weekend.maxLOA) {
+    // Don't tag if it's also bluewater (those are serious cruisers)
+    if (!tags.includes('bluewater-cruiser')) {
+      tags.push('weekend-sailor');
+    }
+  }
+
+  // ── Racing ──
+  // Light for its length (low D/L) and high sail area (high SA/D)
+  if (disp != null && loa != null && sailArea != null) {
+    const dl = displacementLengthRatio(disp, loa);
+    const sad = sailAreaDisplacementRatio(sailArea, disp);
+    if (dl != null && sad != null && dl <= THRESHOLDS.racing.maxDLRatio && sad >= THRESHOLDS.racing.minSADRatio) {
+      tags.push('racing');
+    }
+  }
+
+  // ── Liveaboard ──
+  // Large with multiple cabins — meant for extended living aboard
+  if (loa != null && cabins != null) {
+    if (loa >= THRESHOLDS.liveaboard.minLOA && cabins >= THRESHOLDS.liveaboard.minCabins) {
+      tags.push('liveaboard');
+    }
+  }
+
+  // ── Family Cruiser ──
+  // Moderate size with at least 2 cabins
+  if (loa != null && cabins != null) {
+    if (
+      loa >= THRESHOLDS.family.minLOA &&
+      loa <= THRESHOLDS.family.maxLOA &&
+      cabins >= THRESHOLDS.family.minCabins
+    ) {
+      tags.push('family-cruiser');
+    }
+  }
+
+  // ── Light Wind Performer ──
+  // High sail area relative to weight — performs well in light air
+  if (sailArea != null && disp != null) {
+    const sad = sailAreaDisplacementRatio(sailArea, disp);
+    if (sad != null && sad >= THRESHOLDS.lightWind.minSADRatio && disp <= THRESHOLDS.lightWind.maxDisplacement) {
+      tags.push('light-wind-performer');
+    }
+  }
+
+  return tags;
+}
+
+/**
+ * Get the list of all available tag IDs for filter UI.
+ */
+export function getAllTagIds(): readonly UseCaseTagId[] {
+  return USE_CASE_TAG_IDS;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -156,7 +156,8 @@
         "cabinsMax": "Maximum cabins",
         "berthsMin": "Minimum berths",
         "berthsMax": "Maximum berths"
-      }
+      },
+      "useCase": "Use Case"
     },
     "presets": {
       "label": "Quick filter presets",
@@ -220,6 +221,50 @@
       "dataTableToggle": "View data table",
       "colRange": "Length Range",
       "colCount": "Number of Yachts"
+    },
+    "useCaseTags": {
+      "bluewater-cruiser": {
+        "label": "Bluewater Cruiser",
+        "description": "Ocean-ready yachts with heavy displacement, high ballast ratio, and robust construction designed for long-distance offshore passages and transoceanic voyages.",
+        "criteria": "LOA ≥ 10.5m (35ft), displacement ≥ 5,000 kg, ballast ratio ≥ 30%, or proven keel type (fin/long/full)."
+      },
+      "weekend-sailor": {
+        "label": "Weekend Sailor",
+        "description": "Compact, easy-to-handle yachts ideal for short coastal trips and weekend cruising. Light enough for a small crew to manage comfortably.",
+        "criteria": "LOA ≤ 10m (33ft). Excludes yachts also tagged as Bluewater Cruisers."
+      },
+      "racing": {
+        "label": "Racing",
+        "description": "Light and powerful yachts with low displacement-to-length ratios and high sail area, optimized for speed and competitive sailing.",
+        "criteria": "Displacement/Length ratio ≤ 200, Sail Area/Displacement ratio ≥ 18."
+      },
+      "liveaboard": {
+        "label": "Liveaboard",
+        "description": "Spacious yachts with multiple cabins designed for extended living aboard. Plenty of room for provisions, personal belongings, and comfortable long-term cruising.",
+        "criteria": "LOA ≥ 11m (36ft), 3 or more cabins."
+      },
+      "family-cruiser": {
+        "label": "Family Cruiser",
+        "description": "Moderate-size yachts with generous accommodation and forgiving handling characteristics, perfect for family sailing holidays with children.",
+        "criteria": "LOA 9–14m (30–46ft), 2 or more cabins."
+      },
+      "light-wind-performer": {
+        "label": "Light Wind Performer",
+        "description": "Yachts with generous sail plans relative to their weight, excelling in light air conditions where other boats struggle to move.",
+        "criteria": "Sail Area/Displacement ratio ≥ 17, displacement ≤ 6,000 kg."
+      }
+    },
+    "useCaseTagsPage": {
+      "meta": {
+        "title": "Yacht Use Case Categories — Sailing Yacht Info",
+        "description": "Understand how yachts are categorized by sailing use case — bluewater, racing, family cruising, and more."
+      },
+      "heading": "Yacht Use Case Categories",
+      "intro": "Every yacht in our database is automatically tagged based on its specifications. These tags help you quickly find yachts suited to your sailing goals. A single yacht may have multiple tags if its specs fit several use cases.",
+      "yachtCount": "{count, plural, one {# yacht} other {# yachts}}",
+      "criteria": "Tagging Criteria",
+      "disclaimer": "Tags are assigned automatically from {total} yachts based on spec-based heuristics. They are a starting point for research, not a definitive classification. Always verify a yacht's suitability for your specific needs.",
+      "browseAll": "Browse All Yachts"
     }
   },
   "Search": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -156,7 +156,8 @@
         "cabinsMax": "Cabines maximum",
         "berthsMin": "Couchettes minimum",
         "berthsMax": "Couchettes maximum"
-      }
+      },
+      "useCase": "Usage"
     },
     "presets": {
       "label": "Filtres rapides",
@@ -220,6 +221,50 @@
       "dataTableToggle": "Voir le tableau de données",
       "colRange": "Tranche de longueur",
       "colCount": "Nombre de voiliers"
+    },
+    "useCaseTags": {
+      "bluewater-cruiser": {
+        "label": "Croiseur Hauturier",
+        "description": "Yachts prêts pour l’océan avec un déplacement important, un ratio de lest élevé et une construction robuste, conçus pour les traversées au long cours et les voyages transocéaniques.",
+        "criteria": "LOA ≥ 10,5 m (35 pi), déplacement ≥ 5 000 kg, ratio de lest ≥ 30 %, ou type de quille éprouvée (quillard/aillee/longue)."
+      },
+      "weekend-sailor": {
+        "label": "Sortie Week-end",
+        "description": "Yachts compacts et faciles à manier, idéaux pour les sorties côtières et la croisière du week-end. Assez légers pour être gérés par un équipage réduit.",
+        "criteria": "LOA ≤ 10 m (33 pi). Exclut les yachts également étiquetés Croiseur Hauturier."
+      },
+      "racing": {
+        "label": "Course",
+        "description": "Yachts légers et puissants avec un faible ratio déplacement/longueur et une grande surface de voilure, optimisés pour la vitesse et la régate.",
+        "criteria": "Ratio Déplacement/Longueur ≤ 200, Ratio Surface de voilure/Déplacement ≥ 18."
+      },
+      "liveaboard": {
+        "label": "Vie à Bord",
+        "description": "Yachts spacieux avec plusieurs cabines, conçus pour la vie à bord prolongée. Espace suffisant pour les provisions, les effets personnels et une croisière confortable à long terme.",
+        "criteria": "LOA ≥ 11 m (36 pi), 3 cabines ou plus."
+      },
+      "family-cruiser": {
+        "label": "Croiseur Familial",
+        "description": "Yachts de taille modérée offrant un logement généreux et des caractéristiques de conduite indulgentes, parfaits pour les vacances en voilier en famille avec des enfants.",
+        "criteria": "LOA 9–14 m (30–46 pi), 2 cabines ou plus."
+      },
+      "light-wind-performer": {
+        "label": "Performant Petits Vent",
+        "description": "Yachts dotés d’un plan de voilure généreux par rapport à leur poids, excellents dans les conditions de vent léger où d’autres bateaux peinent à avancer.",
+        "criteria": "Ratio Surface de voilure/Déplacement ≥ 17, déplacement ≤ 6 000 kg."
+      }
+    },
+    "useCaseTagsPage": {
+      "meta": {
+        "title": "Catégories d’Usage des Yachts — Sailing Yacht Info",
+        "description": "Comprenez comment les yachts sont classés par type de navigation — hauturier, course, croisière familiale et plus encore."
+      },
+      "heading": "Catégories d’Usage des Yachts",
+      "intro": "Chaque yacht de notre base de données est automatiquement étiqueté en fonction de ses caractéristiques techniques. Ces tags vous aident à trouver rapidement les yachts adaptés à vos objectifs de navigation. Un même yacht peut avoir plusieurs tags si ses spécifications correspondent à plusieurs usages.",
+      "yachtCount": "{count, plural, one {# yacht} other {# yachts}}",
+      "criteria": "Critères d’étiquetage",
+      "disclaimer": "Les tags sont attribués automatiquement parmi {total} yachts à partir d’heuristiques basées sur les spécifications. Ils constituent un point de départ pour la recherche, et non une classification définitive. Vérifiez toujours l’adéquation d’un yacht à vos besoins spécifiques.",
+      "browseAll": "Parcourir Tous les Yachts"
     }
   },
   "Search": {

--- a/tests/use-case-tags.test.ts
+++ b/tests/use-case-tags.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assignUseCaseTags,
+  getAllTagIds,
+  USE_CASE_TAG_IDS,
+  USE_CASE_TAG_META,
+  type YachtSpecForTags,
+} from '@/lib/use-case-tags';
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+const baseSpec: YachtSpecForTags = {
+  lengthOverall: null,
+  beam: null,
+  draft: null,
+  displacement: null,
+  ballast: null,
+  sailAreaMain: null,
+  cabins: null,
+  berths: null,
+  rigType: null,
+  keelType: null,
+};
+
+// ─── Bluewater Cruiser ───────────────────────────────────────────────
+
+describe('Bluewater Cruiser tag', () => {
+  it('assigns bluewater-cruiser for heavy, long yacht with high ballast ratio', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 12,       // 12m ≈ 39ft — above 10.5m threshold
+      displacement: 8000,      // 8t — above 5000kg threshold
+      ballast: 3000,           // ballast ratio = 3000/8000 = 37.5% — above 30%
+      keelType: 'Fin keel',
+    });
+    expect(tags).toContain('bluewater-cruiser');
+  });
+
+  it('assigns bluewater-cruiser for long heavy yacht with proven keel type even without high ballast ratio', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 14,       // 14m
+      displacement: 12000,     // 12t
+      ballast: 2000,           // ballast ratio = 16.7% — below 30%...
+      keelType: 'Long keel',   // ...but keel type matches
+    });
+    expect(tags).toContain('bluewater-cruiser');
+  });
+
+  it('does NOT assign bluewater-cruiser for short yachts', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 8,        // 8m — below 10.5m
+      displacement: 3000,
+      ballast: 1500,
+      keelType: 'Fin keel',
+    });
+    expect(tags).not.toContain('bluewater-cruiser');
+  });
+
+  it('does NOT assign bluewater-cruiser for light yachts', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 12,
+      displacement: 3000,      // below 5000kg
+      ballast: 1500,
+      keelType: 'Fin keel',
+    });
+    expect(tags).not.toContain('bluewater-cruiser');
+  });
+});
+
+// ─── Weekend Sailor ──────────────────────────────────────────────────
+
+describe('Weekend Sailor tag', () => {
+  it('assigns weekend-sailor for compact yachts under 10m', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 8,        // 8m — under 10m
+      displacement: 2000,
+    });
+    expect(tags).toContain('weekend-sailor');
+  });
+
+  it('does NOT assign weekend-sailor for yachts > 10m', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 10.5,
+      displacement: 4000,
+    });
+    expect(tags).not.toContain('weekend-sailor');
+  });
+
+  it('does NOT assign weekend-sailor if already a bluewater cruiser', () => {
+    // 10.5m is under 10m? No, 10.5 > 10. Let's make a yacht that meets both bluewater
+    // but has LOA < 10m — impossible since bluewater needs ≥ 10.5m.
+    // So the exclusion only matters for edge cases. Test with null displacement.
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 9,
+      displacement: null,      // can't be bluewater without displacement
+    });
+    expect(tags).toContain('weekend-sailor');
+  });
+});
+
+// ─── Racing ──────────────────────────────────────────────────────────
+
+describe('Racing tag', () => {
+  it('assigns racing for light yacht with high SA/D', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 10.5,
+      displacement: 2800,      // light
+      sailAreaMain: 65,        // high sail area
+      ballast: 800,
+      cabins: 2,
+    });
+    // D/L should be low, SA/D should be high
+    expect(tags).toContain('racing');
+  });
+
+  it('does NOT assign racing for heavy displacement yachts', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 12,
+      displacement: 12000,     // very heavy
+      sailAreaMain: 80,        // moderate sail area for that weight
+    });
+    expect(tags).not.toContain('racing');
+  });
+
+  it('does NOT assign racing when sail area is missing', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 10.5,
+      displacement: 2500,
+      sailAreaMain: null,      // no sail area data
+    });
+    expect(tags).not.toContain('racing');
+  });
+});
+
+// ─── Liveaboard ──────────────────────────────────────────────────────
+
+describe('Liveaboard tag', () => {
+  it('assigns liveaboard for large yacht with 3+ cabins', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 13,       // 13m ≈ 43ft — above 11m
+      cabins: 4,
+      displacement: 10000,
+    });
+    expect(tags).toContain('liveaboard');
+  });
+
+  it('does NOT assign liveaboard for yachts with fewer than 3 cabins', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 13,
+      cabins: 2,
+    });
+    expect(tags).not.toContain('liveaboard');
+  });
+
+  it('does NOT assign liveaboard for yachts under 11m', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 10,       // under 11m
+      cabins: 3,
+    });
+    expect(tags).not.toContain('liveaboard');
+  });
+});
+
+// ─── Family Cruiser ──────────────────────────────────────────────────
+
+describe('Family Cruiser tag', () => {
+  it('assigns family-cruiser for moderate-size yacht with 2+ cabins', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 11,       // 11m — in 9-14m range
+      cabins: 3,
+      displacement: 6000,
+    });
+    expect(tags).toContain('family-cruiser');
+  });
+
+  it('does NOT assign family-cruiser for yachts under 9m', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 8,
+      cabins: 2,
+    });
+    expect(tags).not.toContain('family-cruiser');
+  });
+
+  it('does NOT assign family-cruiser for yachts over 14m', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 16,       // above 14m
+      cabins: 4,
+    });
+    expect(tags).not.toContain('family-cruiser');
+  });
+
+  it('does NOT assign family-cruiser for yachts with only 1 cabin', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 11,
+      cabins: 1,
+    });
+    expect(tags).not.toContain('family-cruiser');
+  });
+});
+
+// ─── Light Wind Performer ────────────────────────────────────────────
+
+describe('Light Wind Performer tag', () => {
+  it('assigns light-wind-performer for yacht with high SA/D and low displacement', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 9,
+      displacement: 3500,      // under 6000kg
+      sailAreaMain: 55,        // high for that weight
+      cabins: 2,
+    });
+    expect(tags).toContain('light-wind-performer');
+  });
+
+  it('does NOT assign light-wind-performer for heavy yachts', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 12,
+      displacement: 9000,      // over 6000kg
+      sailAreaMain: 100,
+    });
+    expect(tags).not.toContain('light-wind-performer');
+  });
+});
+
+// ─── Multi-tag assignments ───────────────────────────────────────────
+
+describe('Multi-tag assignments', () => {
+  it('a large family cruiser can also be liveaboard', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 13,       // in family range (9-14)
+      cabins: 4,               // meets both family (2+) and liveaboard (3+)
+      displacement: 9000,
+      ballast: 3500,           // 38.9% — meets bluewater
+      keelType: 'Fin keel',
+    });
+    expect(tags).toContain('family-cruiser');
+    expect(tags).toContain('liveaboard');
+    expect(tags).toContain('bluewater-cruiser');
+  });
+
+  it('a small racer can also be a weekend sailor', () => {
+    const tags = assignUseCaseTags({
+      ...baseSpec,
+      lengthOverall: 8,        // under 10m
+      displacement: 2000,
+      sailAreaMain: 45,
+      cabins: 1,
+    });
+    // Weekend sailor: LOA < 10 ✓, not bluewater ✓
+    // Racing: depends on ratios
+    expect(tags).toContain('weekend-sailor');
+  });
+
+  it('returns empty array for yacht with no spec data', () => {
+    const tags = assignUseCaseTags(baseSpec);
+    expect(tags).toEqual([]);
+  });
+});
+
+// ─── Exports & metadata ──────────────────────────────────────────────
+
+describe('Tag metadata', () => {
+  it('exports all 6 tag IDs', () => {
+    expect(USE_CASE_TAG_IDS).toHaveLength(6);
+    expect(USE_CASE_TAG_IDS).toContain('bluewater-cruiser');
+    expect(USE_CASE_TAG_IDS).toContain('weekend-sailor');
+    expect(USE_CASE_TAG_IDS).toContain('racing');
+    expect(USE_CASE_TAG_IDS).toContain('liveaboard');
+    expect(USE_CASE_TAG_IDS).toContain('family-cruiser');
+    expect(USE_CASE_TAG_IDS).toContain('light-wind-performer');
+  });
+
+  it('each tag has color metadata', () => {
+    for (const tagId of USE_CASE_TAG_IDS) {
+      const meta = USE_CASE_TAG_META[tagId as keyof typeof USE_CASE_TAG_META];
+      expect(meta).toBeDefined();
+      expect(meta.color).toBeTruthy();
+      expect(meta.textColor).toBeTruthy();
+      expect(meta.borderColor).toBeTruthy();
+    }
+  });
+
+  it('getAllTagIds returns the same as USE_CASE_TAG_IDS', () => {
+    expect(getAllTagIds()).toEqual(USE_CASE_TAG_IDS);
+  });
+});


### PR DESCRIPTION
Closes #268

### What's included

**Tag Assignment Heuristic** (6 categories from spec heuristics):
- Bluewater Cruiser, Weekend Sailor, Racing, Liveaboard, Family Cruiser, Light Wind Performer

**Colored Badges on Yacht Cards** | **Use Case Filter** | **Tag Reference Page** (/yachts/tags)

**25 unit tests** | **Full i18n (en + fr)** | **API filter support**