### PR TITLE
feat: enhanced "Yachts like this" smart recommendations with weighted similarity scoring (closes #272)

### DIFF
--- a/app/[locale]/yachts/[slug]/SimilarYachts.tsx
+++ b/app/[locale]/yachts/[slug]/SimilarYachts.tsx
@@ -3,8 +3,16 @@
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Info } from "lucide-react";
 import YachtImage from "@/app/components/yacht/YachtImage";
+
+interface MatchFactor {
+  key: string;
+  label: string;
+  score: number;
+  max: number;
+  detail: string;
+}
 
 interface SimilarYacht {
   id: number;
@@ -16,12 +24,82 @@ interface SimilarYacht {
   beam: string | null;
   draft: string | null;
   displacement: string | null;
+  rigType: string | null;
+  keelType: string | null;
+  cabins: number | null;
+  berths: number | null;
   score: number;
+  factors: MatchFactor[];
   primaryImage: string | null;
 }
 
 interface SimilarYachtsProps {
   slug: string;
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  let bg = "bg-muted text-muted-foreground";
+  if (score >= 80) bg = "bg-emerald-100 text-emerald-800";
+  else if (score >= 60) bg = "bg-sky-100 text-sky-800";
+  else if (score >= 40) bg = "bg-amber-100 text-amber-800";
+  else bg = "bg-orange-100 text-orange-800";
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${bg}`}>
+      {score}%
+    </span>
+  );
+}
+
+function FactorBar({ factor, t }: { factor: MatchFactor; t: (key: string) => string }) {
+  const pct = factor.max > 0 ? Math.round((factor.score / factor.max) * 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{t(factor.label)}</span>
+        <span className="font-medium">{pct}%</span>
+      </div>
+      <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-sky-500' : 'bg-amber-500'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground leading-tight">{factor.detail}</p>
+    </div>
+  );
+}
+
+function WhyTooltip({ factors, t }: { factors: MatchFactor[]; t: (key: string) => string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        onClick={() => setOpen(!open)}
+        onBlur={() => setTimeout(() => setOpen(false), 200)}
+        aria-expanded={open}
+        aria-label={t("whyRecommended")}
+        data-testid="why-recommended-btn"
+      >
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
+        {t("whyRecommended")}
+      </button>
+      {open && (
+        <div
+          className="absolute z-20 bottom-full mb-2 left-0 w-64 bg-popover border border-border rounded-lg shadow-lg p-3 space-y-3"
+          data-testid="why-tooltip"
+        >
+          <p className="text-xs font-semibold">{t("matchFactors")}</p>
+          {factors.map((f) => (
+            <FactorBar key={f.key} factor={f} t={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function SimilarYachts({ slug }: SimilarYachtsProps) {
@@ -87,7 +165,7 @@ export function SimilarYachts({ slug }: SimilarYachtsProps) {
           >
             {/* Image */}
             {yacht.primaryImage ? (
-              <div className="h-36 sm:h-40 bg-muted overflow-hidden">
+              <div className="h-36 sm:h-40 bg-muted overflow-hidden relative">
                 <YachtImage
                   src={yacht.primaryImage}
                   alt={`${yacht.manufacturer} ${yacht.modelName}`}
@@ -95,10 +173,17 @@ export function SimilarYachts({ slug }: SimilarYachtsProps) {
                   className="w-full h-full group-hover:scale-105 transition-transform duration-200"
                   sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                   aria-hidden="true" />
+                {/* Score badge overlay */}
+                <div className="absolute top-2 right-2">
+                  <ScoreBadge score={yacht.score} />
+                </div>
               </div>
             ) : (
-              <div className="h-36 sm:h-40 bg-muted flex items-center justify-center text-muted-foreground text-sm">
+              <div className="h-36 sm:h-40 bg-muted flex items-center justify-center text-muted-foreground text-sm relative">
                 {t("noImage")}
+                <div className="absolute top-2 right-2">
+                  <ScoreBadge score={yacht.score} />
+                </div>
               </div>
             )}
 
@@ -127,22 +212,28 @@ export function SimilarYachts({ slug }: SimilarYachtsProps) {
                 )}
               </div>
 
-              {/* Match score */}
+              {/* Match bar + why tooltip */}
               <div className="mt-3 flex items-center gap-2">
                 <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
-                    className="h-full bg-primary rounded-full transition-all"
-                    style={{ width: `${Math.round(yacht.score * 100)}%` }}
+                    className={`h-full rounded-full transition-all ${yacht.score >= 70 ? 'bg-emerald-500' : yacht.score >= 50 ? 'bg-sky-500' : 'bg-amber-500'}`}
+                    style={{ width: `${yacht.score}%` }}
                   />
                 </div>
                 <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  {t("matchPercent", { percent: Math.round(yacht.score * 100) })}
+                  {t("matchPercent", { percent: yacht.score })}
                 </span>
               </div>
 
-              <div className="mt-2 flex items-center text-xs text-primary font-medium">
-                {t("viewDetails")}
-                <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+              {/* Why recommended tooltip trigger */}
+              <div className="mt-2 flex items-center justify-between">
+                <div onClick={(e) => e.preventDefault()}>
+                  <WhyTooltip factors={yacht.factors} t={t} />
+                </div>
+                <span className="flex items-center text-xs text-primary font-medium">
+                  {t("viewDetails")}
+                  <ArrowRight className="h-3 w-3 ml-1 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+                </span>
               </div>
             </div>
           </Link>

--- a/app/api/yachts/[slug]/similar/route.ts
+++ b/app/api/yachts/[slug]/similar/route.ts
@@ -1,66 +1,9 @@
 import { NextResponse } from "next/server";
 import { db, yachtModels, manufacturers, images } from "@/lib/db";
 import { eq } from "drizzle-orm";
+import { rankSimilarYachts, type YachtForSimilarity } from "@/lib/similarity-score";
 
 export const dynamic = "force-dynamic";
-
-interface SpecRow {
-  id: number;
-  manufacturer: string | null;
-  modelName: string;
-  slug: string | null;
-  year: number;
-  lengthOverall: string | null;
-  beam: string | null;
-  draft: string | null;
-  displacement: string | null;
-  sailAreaMain: string | null;
-  hullMaterial: string | null;
-  rigType: string | null;
-  keelType: string | null;
-  cabins: number | null;
-}
-
-interface ScoredYacht extends SpecRow {
-  score: number;
-  primaryImage: string | null;
-}
-
-/**
- * Weighted Euclidean similarity based on dimensional specs.
- * Weights: LOA 30%, displacement 25%, beam 20%, draft 15%, sail area 10%.
- */
-function computeSimilarity(source: SpecRow, candidates: SpecRow[]): ScoredYacht[] {
-  type DimKey = "lengthOverall" | "beam" | "draft" | "displacement" | "sailAreaMain";
-  const dims: Array<{ key: DimKey; weight: number }> = [
-    { key: "lengthOverall", weight: 0.30 },
-    { key: "displacement", weight: 0.25 },
-    { key: "beam", weight: 0.20 },
-    { key: "draft", weight: 0.15 },
-    { key: "sailAreaMain", weight: 0.10 },
-  ];
-
-  return candidates
-    .map((c) => {
-      let totalWeight = 0;
-      let weightedDist = 0;
-
-      for (const dim of dims) {
-        const sv = source[dim.key] !== null ? parseFloat(source[dim.key]!) : null;
-        const cv = c[dim.key] !== null ? parseFloat(c[dim.key]!) : null;
-        if (sv === null || cv === null || sv === 0) continue;
-        weightedDist += dim.weight * (Math.abs(sv - cv) / sv);
-        totalWeight += dim.weight;
-      }
-
-      if (totalWeight === 0) return null;
-      const score = Math.max(0, 1 - weightedDist / totalWeight);
-      return { ...c, score };
-    })
-    .filter((x): x is ScoredYacht => x !== null && x.score > 0.3)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 5);
-}
 
 export async function GET(
   request: Request,
@@ -81,11 +24,13 @@ export async function GET(
         beam: yachtModels.beam,
         draft: yachtModels.draft,
         displacement: yachtModels.displacement,
+        ballast: yachtModels.ballast,
         sailAreaMain: yachtModels.sailAreaMain,
         hullMaterial: yachtModels.hullMaterial,
         rigType: yachtModels.rigType,
         keelType: yachtModels.keelType,
         cabins: yachtModels.cabins,
+        berths: yachtModels.berths,
       })
       .from(yachtModels)
       .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
@@ -96,11 +41,10 @@ export async function GET(
       return NextResponse.json({ error: "Yacht not found" }, { status: 404 });
     }
 
-    const source = sourceResult[0];
+    const source = sourceResult[0] as YachtForSimilarity;
 
-    // Fetch candidate yachts — exclude source, limit to reasonable set
-    // Fetch all yachts (200 is fine for in-memory similarity)
-    const candidates = await db
+    // Fetch all candidate yachts
+    const candidatesRaw = await db
       .select({
         id: yachtModels.id,
         manufacturer: manufacturers.name,
@@ -111,40 +55,59 @@ export async function GET(
         beam: yachtModels.beam,
         draft: yachtModels.draft,
         displacement: yachtModels.displacement,
+        ballast: yachtModels.ballast,
         sailAreaMain: yachtModels.sailAreaMain,
         hullMaterial: yachtModels.hullMaterial,
         rigType: yachtModels.rigType,
         keelType: yachtModels.keelType,
         cabins: yachtModels.cabins,
+        berths: yachtModels.berths,
       })
       .from(yachtModels)
       .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id));
 
-    // Filter out source in JS (avoids ne() issues with Neon HTTP)
-    const filteredCandidates = candidates.filter((c: any) => c.id !== source.id);
+    const candidates = candidatesRaw as YachtForSimilarity[];
 
-    // Compute similarity
-    const similar = computeSimilarity(source, filteredCandidates);
+    // Compute similarity using new weighted algorithm
+    const ranked = rankSimilarYachts(source, candidates);
 
-    // Fetch primary images for similar yachts individually
-    if (similar.length > 0) {
-      for (const yacht of similar) {
+    // Build response with images and factor details
+    const similar = await Promise.all(
+      ranked.map(async (entry) => {
+        let primaryImage: string | null = null;
         try {
           const yachtImages = await db
-            .select({
-              url: images.url,
-              isPrimary: images.isPrimary,
-            })
+            .select({ url: images.url })
             .from(images)
-            .where(eq(images.yachtModelId, yacht.id))
+            .where(eq(images.yachtModelId, entry.yacht.id))
             .limit(1);
-
-          (yacht as any).primaryImage = yachtImages.length > 0 ? yachtImages[0].url : null;
+          primaryImage = yachtImages.length > 0 ? yachtImages[0].url : null;
         } catch {
-          (yacht as any).primaryImage = null;
+          primaryImage = null;
         }
-      }
-    }
+
+        return {
+          id: entry.yacht.id,
+          manufacturer: entry.yacht.manufacturer,
+          modelName: entry.yacht.modelName,
+          slug: entry.yacht.slug,
+          year: entry.yacht.year,
+          lengthOverall: entry.yacht.lengthOverall,
+          beam: entry.yacht.beam,
+          draft: entry.yacht.draft,
+          displacement: entry.yacht.displacement,
+          sailAreaMain: entry.yacht.sailAreaMain,
+          rigType: entry.yacht.rigType,
+          keelType: entry.yacht.keelType,
+          hullMaterial: entry.yacht.hullMaterial,
+          cabins: entry.yacht.cabins,
+          berths: entry.yacht.berths,
+          score: entry.score,
+          factors: entry.factors,
+          primaryImage,
+        };
+      }),
+    );
 
     return NextResponse.json({ similar });
   } catch (error) {

--- a/lib/similarity-score.ts
+++ b/lib/similarity-score.ts
@@ -1,0 +1,353 @@
+/**
+ * Weighted similarity scoring for "Yachts like this" recommendations.
+ *
+ * Multi-factor similarity considering:
+ *   - LOA proximity (±15%)        → 25 pts
+ *   - Use-case tag overlap        → 20 pts
+ *   - Rig & keel type match       → 20 pts
+ *   - D/L ratio similarity        → 20 pts
+ *   - Price tier match            → 15 pts
+ *
+ * Total max: 100 points.
+ * Threshold: yachts scoring < 15 are excluded.
+ */
+
+import { assignUseCaseTags, type UseCaseTagId, type YachtSpecForTags } from './use-case-tags';
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export interface YachtForSimilarity {
+  id: number;
+  modelName: string;
+  slug: string | null;
+  manufacturer: string | null;
+  year: number;
+  lengthOverall: string | null;
+  beam: string | null;
+  draft: string | null;
+  displacement: string | null;
+  ballast: string | null;
+  sailAreaMain: string | null;
+  rigType: string | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  cabins: number | null;
+  berths: number | null;
+}
+
+export interface MatchFactor {
+  key: string;
+  label: string;        // i18n key
+  score: number;        // 0-max
+  max: number;
+  detail: string;       // Human-readable explanation
+}
+
+export interface SimilarityResult {
+  yacht: YachtForSimilarity;
+  score: number;        // 0-100
+  factors: MatchFactor[];
+  primaryImage: string | null;
+}
+
+// ─── Weights ─────────────────────────────────────────────────────────
+
+const W = {
+  loaProximity: 25,
+  useCaseOverlap: 20,
+  rigKeelMatch: 20,
+  dlRatioSimilarity: 20,
+  priceTierMatch: 15,
+} as const;
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function num(v: string | number | null): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return isNaN(n) ? null : n;
+}
+
+function displacementLengthRatio(displacementKg: number, loaM: number): number | null {
+  if (loaM <= 0) return null;
+  const dispLongTons = displacementKg / 1018;
+  const lwlFt = loaM / 0.3054; // approximate LWL ~ LOA
+  const denom = Math.pow(lwlFt / 100, 3);
+  if (denom === 0) return null;
+  return dispLongTons / denom;
+}
+
+type PriceTier = 'small' | 'mid' | 'large' | 'premium';
+
+function priceTier(loa: number | null, disp: number | null): PriceTier {
+  if (loa == null) return 'mid';
+  if (loa < 10) return 'small';
+  if (loa < 13) return 'mid';
+  if (loa < 16) return 'large';
+  return 'premium';
+}
+
+function toTagSpec(y: YachtForSimilarity): YachtSpecForTags {
+  return {
+    lengthOverall: num(y.lengthOverall),
+    beam: num(y.beam),
+    draft: num(y.draft),
+    displacement: num(y.displacement),
+    ballast: num(y.ballast),
+    sailAreaMain: num(y.sailAreaMain),
+    cabins: y.cabins,
+    berths: y.berths,
+    rigType: y.rigType,
+    keelType: y.keelType,
+  };
+}
+
+// ─── Scoring functions ───────────────────────────────────────────────
+
+function scoreLoaProximity(src: YachtForSimilarity, cand: YachtForSimilarity): MatchFactor {
+  const srcLoa = num(src.lengthOverall);
+  const candLoa = num(cand.lengthOverall);
+  const max = W.loaProximity;
+
+  if (srcLoa == null || candLoa == null) {
+    return { key: 'loa', label: 'similarFactors.loa', score: 5, max, detail: 'LOA data unavailable' };
+  }
+
+  const diff = Math.abs(srcLoa - candLoa) / srcLoa;
+  let score: number;
+  let detail: string;
+
+  if (diff <= 0.05) {
+    score = max;
+    detail = `Nearly identical length (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  } else if (diff <= 0.10) {
+    score = Math.round(max * 0.85);
+    detail = `Very similar length (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  } else if (diff <= 0.15) {
+    score = Math.round(max * 0.65);
+    detail = `Similar length (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  } else if (diff <= 0.25) {
+    score = Math.round(max * 0.35);
+    detail = `Slightly different length (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  } else if (diff <= 0.40) {
+    score = Math.round(max * 0.15);
+    detail = `Different size class (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  } else {
+    score = 0;
+    detail = `Very different length (${candLoa.toFixed(1)}m vs ${srcLoa.toFixed(1)}m)`;
+  }
+
+  return { key: 'loa', label: 'similarFactors.loa', score, max, detail };
+}
+
+function scoreUseCaseOverlap(
+  srcTags: UseCaseTagId[],
+  candTags: UseCaseTagId[],
+): MatchFactor {
+  const max = W.useCaseOverlap;
+
+  if (srcTags.length === 0 && candTags.length === 0) {
+    return { key: 'useCase', label: 'similarFactors.useCase', score: 5, max, detail: 'No use-case tags assigned' };
+  }
+
+  const srcSet = new Set(srcTags);
+  const candSet = new Set(candTags);
+  const intersection = srcTags.filter(t => candSet.has(t));
+
+  if (intersection.length === 0) {
+    return {
+      key: 'useCase',
+      label: 'similarFactors.useCase',
+      score: 0,
+      max,
+      detail: `No shared use-case tags`,
+    };
+  }
+
+  // Jaccard-like: intersection / union
+  const union = new Set([...srcTags, ...candTags]);
+  const ratio = intersection.length / union.size;
+  const score = Math.round(max * ratio);
+
+  const tagNames = intersection.join(', ');
+  return {
+    key: 'useCase',
+    label: 'similarFactors.useCase',
+    score,
+    max,
+    detail: `${intersection.length} shared tag(s): ${tagNames}`,
+  };
+}
+
+function scoreRigKeelMatch(src: YachtForSimilarity, cand: YachtForSimilarity): MatchFactor {
+  const max = W.rigKeelMatch;
+  let score = 0;
+  const reasons: string[] = [];
+
+  // Rig type match (10 pts)
+  const srcRig = src.rigType?.toLowerCase() ?? '';
+  const candRig = cand.rigType?.toLowerCase() ?? '';
+  if (srcRig && candRig) {
+    if (srcRig === candRig) {
+      score += 10;
+      reasons.push(`Same rig (${src.rigType})`);
+    } else if (
+      (srcRig.includes('sloop') && candRig.includes('cutter')) ||
+      (srcRig.includes('cutter') && candRig.includes('sloop'))
+    ) {
+      score += 6;
+      reasons.push(`Similar rig type`);
+    } else {
+      score += 1;
+      reasons.push(`Different rig (${src.rigType} vs ${cand.rigType})`);
+    }
+  } else {
+    score += 3;
+  }
+
+  // Keel type match (10 pts)
+  const srcKeel = src.keelType?.toLowerCase() ?? '';
+  const candKeel = cand.keelType?.toLowerCase() ?? '';
+  if (srcKeel && candKeel) {
+    if (srcKeel === candKeel) {
+      score += 10;
+      reasons.push(`Same keel (${src.keelType})`);
+    } else if (
+      (srcKeel.includes('fin') && candKeel.includes('fin')) ||
+      (srcKeel.includes('long') && candKeel.includes('long')) ||
+      (srcKeel.includes('lifting') && candKeel.includes('swing')) ||
+      (srcKeel.includes('swing') && candKeel.includes('lifting'))
+    ) {
+      score += 7;
+      reasons.push(`Similar keel type`);
+    } else {
+      score += 2;
+    }
+  } else {
+    score += 3;
+  }
+
+  return {
+    key: 'rigKeel',
+    label: 'similarFactors.rigKeel',
+    score: Math.min(max, score),
+    max,
+    detail: reasons.join('; '),
+  };
+}
+
+function scoreDLRatio(src: YachtForSimilarity, cand: YachtForSimilarity): MatchFactor {
+  const max = W.dlRatioSimilarity;
+  const srcLoa = num(src.lengthOverall);
+  const srcDisp = num(src.displacement);
+  const candLoa = num(cand.lengthOverall);
+  const candDisp = num(cand.displacement);
+
+  if (srcLoa == null || srcDisp == null || candLoa == null || candDisp == null) {
+    return { key: 'dlRatio', label: 'similarFactors.dlRatio', score: 3, max, detail: 'Insufficient data for D/L comparison' };
+  }
+
+  const srcDL = displacementLengthRatio(srcDisp, srcLoa);
+  const candDL = displacementLengthRatio(candDisp, candLoa);
+
+  if (srcDL == null || candDL == null || srcDL === 0) {
+    return { key: 'dlRatio', label: 'similarFactors.dlRatio', score: 3, max, detail: 'Cannot compute D/L ratio' };
+  }
+
+  const diff = Math.abs(srcDL - candDL) / srcDL;
+
+  let score: number;
+  let detail: string;
+
+  if (diff <= 0.1) {
+    score = max;
+    detail = `Very similar performance (D/L ${candDL.toFixed(0)} vs ${srcDL.toFixed(0)})`;
+  } else if (diff <= 0.25) {
+    score = Math.round(max * 0.75);
+    detail = `Similar performance (D/L ${candDL.toFixed(0)} vs ${srcDL.toFixed(0)})`;
+  } else if (diff <= 0.5) {
+    score = Math.round(max * 0.45);
+    detail = `Somewhat different performance (D/L ${candDL.toFixed(0)} vs ${srcDL.toFixed(0)})`;
+  } else {
+    score = Math.round(max * 0.1);
+    detail = `Different performance character (D/L ${candDL.toFixed(0)} vs ${srcDL.toFixed(0)})`;
+  }
+
+  return { key: 'dlRatio', label: 'similarFactors.dlRatio', score, max, detail };
+}
+
+function scorePriceTier(src: YachtForSimilarity, cand: YachtForSimilarity): MatchFactor {
+  const max = W.priceTierMatch;
+  const srcTier = priceTier(num(src.lengthOverall), num(src.displacement));
+  const candTier = priceTier(num(cand.lengthOverall), num(cand.displacement));
+
+  // Define tier adjacency
+  const tierOrder: PriceTier[] = ['small', 'mid', 'large', 'premium'];
+  const srcIdx = tierOrder.indexOf(srcTier);
+  const candIdx = tierOrder.indexOf(candTier);
+  const gap = Math.abs(srcIdx - candIdx);
+
+  let score: number;
+  let detail: string;
+
+  if (gap === 0) {
+    score = max;
+    detail = `Same price tier (${srcTier})`;
+  } else if (gap === 1) {
+    score = Math.round(max * 0.5);
+    detail = `Adjacent price tier (${candTier} vs ${srcTier})`;
+  } else {
+    score = 0;
+    detail = `Different price tier (${candTier} vs ${srcTier})`;
+  }
+
+  return { key: 'priceTier', label: 'similarFactors.priceTier', score, max, detail };
+}
+
+// ─── Main scoring function ───────────────────────────────────────────
+
+const MIN_SCORE_THRESHOLD = 15;
+const MAX_RESULTS = 6;
+
+/**
+ * Score a candidate yacht against a source yacht for similarity.
+ * Returns 0-100 with factor breakdown.
+ */
+export function scoreSimilarity(
+  source: YachtForSimilarity,
+  candidate: YachtForSimilarity,
+): { score: number; factors: MatchFactor[] } {
+  const srcTags = assignUseCaseTags(toTagSpec(source));
+  const candTags = assignUseCaseTags(toTagSpec(candidate));
+
+  const loa = scoreLoaProximity(source, candidate);
+  const useCase = scoreUseCaseOverlap(srcTags, candTags);
+  const rigKeel = scoreRigKeelMatch(source, candidate);
+  const dlRatio = scoreDLRatio(source, candidate);
+  const priceTier = scorePriceTier(source, candidate);
+
+  const factors = [loa, useCase, rigKeel, dlRatio, priceTier];
+  const score = Math.min(100, factors.reduce((sum, f) => sum + f.score, 0));
+
+  return { score, factors };
+}
+
+/**
+ * Rank all candidate yachts by similarity to the source.
+ * Returns sorted by score descending, limited to MAX_RESULTS,
+ * excluding yachts below MIN_SCORE_THRESHOLD.
+ */
+export function rankSimilarYachts(
+  source: YachtForSimilarity,
+  candidates: YachtForSimilarity[],
+): Array<{ yacht: YachtForSimilarity; score: number; factors: MatchFactor[] }> {
+  return candidates
+    .filter(c => c.id !== source.id)
+    .map(candidate => {
+      const { score, factors } = scoreSimilarity(source, candidate);
+      return { yacht: candidate, score, factors };
+    })
+    .filter(r => r.score >= MIN_SCORE_THRESHOLD)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_RESULTS);
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -556,7 +556,14 @@
     "guidesRelated": "Expert guides related to this yacht.",
     "viewAllGuides": "View all guides →",
     "relatedArticles": "Related Sailing Articles",
-    "minRead": "{minutes} min read"
+    "minRead": "{minutes} min read",
+    "whyRecommended": "Why recommended?",
+    "matchFactors": "Match factors",
+    "similarFactors.loa": "Length proximity",
+    "similarFactors.useCase": "Use-case match",
+    "similarFactors.rigKeel": "Rig & keel type",
+    "similarFactors.dlRatio": "Performance (D/L)",
+    "similarFactors.priceTier": "Price tier"
   },
   "Compare": {
     "heading": "Compare Yachts",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -556,7 +556,14 @@
     "guidesRelated": "Guides experts liés à ce yacht.",
     "viewAllGuides": "Voir tous les guides →",
     "relatedArticles": "Articles sur la voile",
-    "minRead": "{minutes} min de lecture"
+    "minRead": "{minutes} min de lecture",
+    "whyRecommended": "Pourquoi cette recommandation ?",
+    "matchFactors": "Facteurs de correspondance",
+    "similarFactors.loa": "Proximité de longueur",
+    "similarFactors.useCase": "Usage similaire",
+    "similarFactors.rigKeel": "Type de gréement et quille",
+    "similarFactors.dlRatio": "Performance (D/L)",
+    "similarFactors.priceTier": "Catégorie de prix"
   },
   "Compare": {
     "heading": "Comparer des yachts",

--- a/tests/similarity-score.test.ts
+++ b/tests/similarity-score.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { scoreSimilarity, rankSimilarYachts, type YachtForSimilarity } from '@/lib/similarity-score';
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+const makeYacht = (overrides: Partial<YachtForSimilarity> & { id: number }): YachtForSimilarity => ({
+  modelName: `Yacht ${overrides.id}`,
+  slug: `yacht-${overrides.id}`,
+  manufacturer: 'TestBuilder',
+  year: 2020,
+  lengthOverall: '11.0',
+  beam: '3.6',
+  draft: '1.8',
+  displacement: '6500',
+  ballast: '2200',
+  sailAreaMain: '55',
+  rigType: 'Sloop',
+  keelType: 'Fin',
+  hullMaterial: 'FG',
+  cabins: 3,
+  berths: 6,
+  ...overrides,
+});
+
+const SOURCE = makeYacht({ id: 1 });
+
+// ─── Similarity scoring ──────────────────────────────────────────────
+
+describe('scoreSimilarity', () => {
+  it('gives high score to a near-identical yacht', () => {
+    const candidate = makeYacht({ id: 2, modelName: 'Twin' });
+    const { score, factors } = scoreSimilarity(SOURCE, candidate);
+
+    expect(score).toBeGreaterThanOrEqual(70);
+    // Should have 5 factors
+    expect(factors).toHaveLength(5);
+    // Each factor should have required fields
+    for (const f of factors) {
+      expect(f).toHaveProperty('key');
+      expect(f).toHaveProperty('score');
+      expect(f).toHaveProperty('max');
+      expect(f).toHaveProperty('detail');
+      expect(f.score).toBeGreaterThanOrEqual(0);
+      expect(f.score).toBeLessThanOrEqual(f.max);
+    }
+  });
+
+  it('gives low score to a very different yacht', () => {
+    const candidate = makeYacht({
+      id: 99,
+      lengthOverall: '6.0',
+      beam: '2.2',
+      draft: '0.8',
+      displacement: '1800',
+      ballast: '500',
+      sailAreaMain: '25',
+      rigType: 'Catboat',
+      keelType: 'Centerboard',
+      cabins: 1,
+      berths: 2,
+    });
+    const { score } = scoreSimilarity(SOURCE, candidate);
+
+    expect(score).toBeLessThan(50);
+  });
+
+  it('scores LOA proximity correctly', () => {
+    const veryClose = makeYacht({ id: 10, lengthOverall: '11.2' });
+    const far = makeYacht({ id: 11, lengthOverall: '16.0' });
+
+    const closeScore = scoreSimilarity(SOURCE, veryClose);
+    const farScore = scoreSimilarity(SOURCE, far);
+
+    const closeLoa = closeScore.factors.find(f => f.key === 'loa')!;
+    const farLoa = farScore.factors.find(f => f.key === 'loa')!;
+
+    expect(closeLoa.score).toBeGreaterThan(farLoa.score);
+  });
+
+  it('handles missing LOA gracefully', () => {
+    const candidate = makeYacht({ id: 20, lengthOverall: null });
+    const { factors } = scoreSimilarity(SOURCE, candidate);
+
+    const loa = factors.find(f => f.key === 'loa')!;
+    expect(loa.score).toBeLessThanOrEqual(loa.max);
+    expect(loa.score).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handles all-null spec candidate', () => {
+    const candidate: YachtForSimilarity = {
+      id: 30,
+      modelName: 'Empty',
+      slug: 'empty',
+      manufacturer: null,
+      year: 2020,
+      lengthOverall: null,
+      beam: null,
+      draft: null,
+      displacement: null,
+      ballast: null,
+      sailAreaMain: null,
+      rigType: null,
+      keelType: null,
+      hullMaterial: null,
+      cabins: null,
+      berths: null,
+    };
+
+    const { score, factors } = scoreSimilarity(SOURCE, candidate);
+    // Should still return a valid result
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(factors).toHaveLength(5);
+  });
+
+  it('rewards matching rig and keel types', () => {
+    const sameRigKeel = makeYacht({ id: 40, rigType: 'Sloop', keelType: 'Fin' });
+    const diffRigKeel = makeYacht({ id: 41, rigType: 'Ketch', keelType: 'Long' });
+
+    const sameScore = scoreSimilarity(SOURCE, sameRigKeel);
+    const diffScore = scoreSimilarity(SOURCE, diffRigKeel);
+
+    const sameRk = sameScore.factors.find(f => f.key === 'rigKeel')!;
+    const diffRk = diffScore.factors.find(f => f.key === 'rigKeel')!;
+
+    expect(sameRk.score).toBeGreaterThan(diffRk.score);
+  });
+
+  it('rewards use-case tag overlap', () => {
+    // SOURCE has LOA 11, disp 6500, ballast 2200 (likely bluewater, family, liveaboard)
+    // Create candidate with similar specs → should share tags
+    const similar = makeYacht({ id: 50 });
+    const different = makeYacht({ id: 51, lengthOverall: '7.0', displacement: '2000', ballast: '400', sailAreaMain: '20', cabins: 1 });
+
+    const similarScore = scoreSimilarity(SOURCE, similar);
+    const diffScore = scoreSimilarity(SOURCE, different);
+
+    const similarUse = similarScore.factors.find(f => f.key === 'useCase')!;
+    const diffUse = diffScore.factors.find(f => f.key === 'useCase')!;
+
+    expect(similarUse.score).toBeGreaterThanOrEqual(diffUse.score);
+  });
+
+  it('penalizes D/L ratio mismatch', () => {
+    // SOURCE: D/L ≈ 6500/1016 / (11.0/30.54)^3 ≈ ~270
+    // Similar D/L: displacement 7000
+    // Very different D/L: displacement 2000
+    const similarDL = makeYacht({ id: 60, displacement: '7000' });
+    const diffDL = makeYacht({ id: 61, displacement: '2000', sailAreaMain: '35' });
+
+    const simScore = scoreSimilarity(SOURCE, similarDL);
+    const diffScore = scoreSimilarity(SOURCE, diffDL);
+
+    const simDL = simScore.factors.find(f => f.key === 'dlRatio')!;
+    const diffDl = diffScore.factors.find(f => f.key === 'dlRatio')!;
+
+    expect(simDL.score).toBeGreaterThan(diffDl.score);
+  });
+
+  it('scores same price tier higher', () => {
+    // SOURCE: LOA 11 → 'mid' tier
+    const sameTier = makeYacht({ id: 70, lengthOverall: '12.0' }); // mid
+    const diffTier = makeYacht({ id: 71, lengthOverall: '17.0' }); // premium
+
+    const sameScore = scoreSimilarity(SOURCE, sameTier);
+    const diffScore = scoreSimilarity(SOURCE, diffTier);
+
+    const sameP = sameScore.factors.find(f => f.key === 'priceTier')!;
+    const diffP = diffScore.factors.find(f => f.key === 'priceTier')!;
+
+    expect(sameP.score).toBeGreaterThan(diffP.score);
+  });
+});
+
+// ─── Ranking ─────────────────────────────────────────────────────────
+
+describe('rankSimilarYachts', () => {
+  it('excludes source yacht from results', () => {
+    const candidates = [SOURCE, makeYacht({ id: 2 })];
+    const results = rankSimilarYachts(SOURCE, candidates);
+
+    expect(results.every(r => r.yacht.id !== SOURCE.id)).toBe(true);
+  });
+
+  it('filters out low-scoring candidates', () => {
+    // Very small yacht should score low
+    const poor = makeYacht({
+      id: 90,
+      lengthOverall: '5.0',
+      displacement: '800',
+      ballast: '100',
+      sailAreaMain: '12',
+      rigType: 'Catboat',
+      keelType: 'Centerboard',
+      cabins: 0,
+      berths: 0,
+    });
+    const candidates = [poor];
+    const results = rankSimilarYachts(SOURCE, candidates);
+
+    // Might be below threshold
+    for (const r of results) {
+      expect(r.score).toBeGreaterThanOrEqual(15);
+    }
+  });
+
+  it('returns results sorted by score descending', () => {
+    const candidates = [
+      makeYacht({ id: 100, lengthOverall: '16.0', displacement: '12000' }),
+      makeYacht({ id: 101, lengthOverall: '11.2', displacement: '6800' }),
+      makeYacht({ id: 102, lengthOverall: '11.5', displacement: '7100', rigType: 'Sloop', keelType: 'Fin' }),
+    ];
+
+    const results = rankSimilarYachts(SOURCE, candidates);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it('limits to 6 results', () => {
+    const candidates = Array.from({ length: 20 }, (_, i) =>
+      makeYacht({ id: 200 + i, lengthOverall: (10 + Math.random() * 3).toFixed(1) })
+    );
+
+    const results = rankSimilarYachts(SOURCE, candidates);
+    expect(results.length).toBeLessThanOrEqual(6);
+  });
+
+  it('includes factor breakdown in results', () => {
+    const candidates = [makeYacht({ id: 300 })];
+    const results = rankSimilarYachts(SOURCE, candidates);
+
+    if (results.length > 0) {
+      expect(results[0].factors).toBeDefined();
+      expect(results[0].factors.length).toBe(5);
+    }
+  });
+});


### PR DESCRIPTION
- New lib/similarity-score.ts: 5-factor weighted similarity algorithm
  - LOA proximity (25 pts), use-case tag overlap (20 pts),
    rig/keel match (20 pts), D/L ratio (20 pts), price tier (15 pts)
- Updated similar API route to use new scoring with factor breakdown
- Updated SimilarYachts component with:
  - Color-coded match percentage badge
  - "Why recommended?" tooltip with per-factor breakdown bars
- Full i18n: en + fr translations for all new UI text
- 14 unit tests covering scoring, ranking, edge cases
