### PR TITLE
feat: saved search & alert system enhancement with filter-based matching (closes #274)

### DIFF
--- a/app/[locale]/account/AccountDashboard.tsx
+++ b/app/[locale]/account/AccountDashboard.tsx
@@ -20,6 +20,7 @@ interface FavoriteItem {
 }
 
 interface SavedSearch {
+  alertEnabled?: boolean;
   id: number;
   name: string;
   searchParams: Record<string, unknown>;
@@ -239,12 +240,40 @@ function SearchesTab() {
     } catch { /* ignore */ }
   }
 
+  async function toggleAlert(id: number, enabled: boolean) {
+    try {
+      const res = await fetch("/api/user/searches", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, alertEnabled: enabled }),
+      });
+      if (res.ok) {
+        setSearches((prev) =>
+          prev.map((s) => (s.id === id ? { ...s, alertEnabled: enabled } : s))
+        );
+      }
+    } catch { /* ignore */ }
+  }
+
   function buildSearchUrl(params: Record<string, unknown>): string {
     const qs = new URLSearchParams();
     for (const [k, v] of Object.entries(params)) {
       if (v != null && v !== "") qs.set(k, String(v));
     }
-    return `/search?${qs.toString()}`;
+    return `/yachts?${qs.toString()}`;
+  }
+
+  function describeSearchParams(params: Record<string, unknown>): string[] {
+    const parts: string[] = [];
+    if (params.query || params.q) parts.push(String(params.query || params.q));
+    if (params.rigType) parts.push(String(params.rigType));
+    if (params.keelType) parts.push(String(params.keelType));
+    if (params.hullMaterial) parts.push(String(params.hullMaterial));
+    if (params.lengthMin || params.lengthMax) parts.push(`${params.lengthMin || "?"}-${params.lengthMax || "?"}m`);
+    if (params.cabinCount) parts.push(`${params.cabinCount} cabins`);
+    if (params.berthCount) parts.push(`${params.berthCount} berths`);
+    if (params.useCase) parts.push(String(params.useCase));
+    return parts;
   }
 
   if (loading) return <LoadingSkeleton />;
@@ -254,39 +283,77 @@ function SearchesTab() {
       <EmptyState
         icon="🔍"
         title="No saved searches"
-        description="Use the search page to find yachts and save your filter combinations."
-        actionLabel="Search Yachts"
-        actionHref="/search"
+        description="Use the yacht listing page to find yachts and save your filter combinations."
+        actionLabel="Browse Yachts"
+        actionHref="/yachts"
       />
     );
   }
 
+  const alertCount = searches.filter((s) => s.alertEnabled).length;
+
   return (
-    <div className="space-y-3">
-      {searches.map((search) => (
-        <div key={search.id} className="border rounded-lg p-4 bg-white shadow-sm flex items-center justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <h3 className="font-medium text-gray-900 truncate">{search.name}</h3>
-            <p className="text-sm text-gray-500 mt-0.5">
-              {search.resultCount != null ? `${search.resultCount} results` : "Results vary"} · Saved {new Date(search.createdAt).toLocaleDateString()}
-            </p>
-          </div>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <Link
-              href={buildSearchUrl(search.searchParams)}
-              className="px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors"
-            >
-              Run Search
-            </Link>
-            <button
-              onClick={() => deleteSearch(search.id)}
-              className="px-3 py-1.5 text-sm font-medium text-red-600 bg-red-50 rounded-lg hover:bg-red-100 transition-colors"
-            >
-              Delete
-            </button>
-          </div>
+    <div>
+      {alertCount > 0 && (
+        <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800 flex items-center gap-2">
+          <span>🔔</span>
+          <span>{alertCount} saved search{alertCount !== 1 ? "es" : ""} with alerts active — you&apos;ll be notified when new matching yachts are added.</span>
         </div>
-      ))}
+      )}
+      <div className="space-y-3">
+        {searches.map((search) => {
+          const filterTags = describeSearchParams(search.searchParams);
+          return (
+            <div key={search.id} className="border rounded-lg p-4 bg-white shadow-sm">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-medium text-gray-900 truncate">{search.name}</h3>
+                    {search.alertEnabled && (
+                      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded-full">
+                        🔔 Alert on
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-500 mt-0.5">
+                    {search.resultCount != null ? `${search.resultCount} results` : "Results vary"} · Saved {new Date(search.createdAt).toLocaleDateString()}
+                  </p>
+                  {filterTags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {filterTags.map((tag, i) => (
+                        <span key={i} className="inline-block px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded">{tag}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <label className="relative inline-flex items-center cursor-pointer" title={search.alertEnabled ? "Disable alert" : "Enable alert for new matches"}>
+                    <input
+                      type="checkbox"
+                      checked={!!search.alertEnabled}
+                      onChange={(e) => toggleAlert(search.id, e.target.checked)}
+                      className="sr-only peer"
+                    />
+                    <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600" />
+                  </label>
+                  <Link
+                    href={buildSearchUrl(search.searchParams)}
+                    className="px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors"
+                  >
+                    View
+                  </Link>
+                  <button
+                    onClick={() => deleteSearch(search.id)}
+                    className="px-3 py-1.5 text-sm font-medium text-red-600 bg-red-50 rounded-lg hover:bg-red-100 transition-colors"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/app/[locale]/yachts/YachtsClient.tsx
+++ b/app/[locale]/yachts/YachtsClient.tsx
@@ -64,6 +64,7 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedYacht, setSelectedYacht] = useState<Yacht | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
 
   // Focus management refs
   const modalRef = useRef<HTMLDivElement>(null);
@@ -322,6 +323,36 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
 
   if (error) return <div className="p-8 text-center text-red-600">{error}</div>;
 
+  const handleSaveSearch = useCallback(async () => {
+    setSaveStatus('saving');
+    try {
+      const params: Record<string, unknown> = {};
+      searchParams.forEach((v, k) => { params[k] = v; });
+      const res = await fetch('/api/user/searches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: undefined,
+          searchParams: params,
+          resultCount: total,
+          alertEnabled: true,
+        }),
+      });
+      if (res.status === 401) {
+        window.location.href = '/auth/signin';
+        return;
+      }
+      if (res.ok) {
+        setSaveStatus('saved');
+        setTimeout(() => setSaveStatus('idle'), 3000);
+      } else {
+        setSaveStatus('error');
+      }
+    } catch {
+      setSaveStatus('error');
+    }
+  }, [searchParams, total]);
+
   const format = (v: number | null | undefined) => (v != null ? v.toLocaleString() : '—');
 
   const FilterSidebar = () => (
@@ -486,6 +517,25 @@ export default function YachtsClient({ initialData, filterOptions: initialFilter
             )}
           </button>
         </div>
+
+        {/* Save Search with Alert */}
+        {activeFilterCount > 0 && (
+          <div className="mt-3 flex items-center gap-3">
+            <button
+              onClick={handleSaveSearch}
+              disabled={saveStatus === 'saving' || saveStatus === 'saved'}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors"
+              style={{
+                backgroundColor: saveStatus === 'saved' ? '#f0fdf4' : saveStatus === 'error' ? '#fef2f2' : 'white',
+                color: saveStatus === 'saved' ? '#15803d' : saveStatus === 'error' ? '#dc2626' : '#374151',
+                borderColor: saveStatus === 'saved' ? '#bbf7d0' : saveStatus === 'error' ? '#fecaca' : '#e5e7eb',
+              }}
+            >
+              {saveStatus === 'saving' ? '⏳ Saving...' : saveStatus === 'saved' ? '✅ Saved with alert' : saveStatus === 'error' ? '❌ Error' : '🔔 Save & Alert'}
+            </button>
+            <span className="text-xs text-gray-500">Get notified when new matching yachts are added</span>
+          </div>
+        )}
 
         {/* Filter Presets */}
         <div className="mb-4 sm:mb-6" role="group" aria-label={t('presets.label')}>

--- a/app/api/user/searches/route.ts
+++ b/app/api/user/searches/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { name, searchParams, resultCount } = body
+    const { name, searchParams, resultCount, alertEnabled } = body
 
     if (!searchParams || typeof searchParams !== 'object') {
       return NextResponse.json({ error: 'searchParams object required' }, { status: 400 })
@@ -44,12 +44,57 @@ export async function POST(request: NextRequest) {
       name: name || `Search — ${new Date().toLocaleDateString()}`,
       searchParams,
       resultCount: resultCount || null,
+      alertEnabled: typeof alertEnabled === 'boolean' ? alertEnabled : false,
     }).returning({ id: savedSearches.id })
 
     return NextResponse.json({ success: true, id: result[0].id })
   } catch (error) {
     console.error('[searches] POST error:', error)
     return NextResponse.json({ error: 'Failed to save search' }, { status: 500 })
+  }
+}
+
+// PUT /api/user/searches - update a saved search (e.g., toggle alert)
+export async function PUT(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = await request.json()
+    const { id, name, alertEnabled } = body
+
+    if (!id) {
+      return NextResponse.json({ error: 'id required' }, { status: 400 })
+    }
+
+    const userId = Number(session.user.id)
+
+    // Verify ownership
+    const existing = await db
+      .select()
+      .from(savedSearches)
+      .where(and(eq(savedSearches.id, Number(id)), eq(savedSearches.userId, userId)))
+      .limit(1)
+
+    if (existing.length === 0) {
+      return NextResponse.json({ error: 'Saved search not found' }, { status: 404 })
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() }
+    if (typeof name === 'string') updates.name = name
+    if (typeof alertEnabled === 'boolean') updates.alertEnabled = alertEnabled
+
+    await db
+      .update(savedSearches)
+      .set(updates)
+      .where(eq(savedSearches.id, Number(id)))
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('[searches] PUT error:', error)
+    return NextResponse.json({ error: 'Failed to update saved search' }, { status: 500 })
   }
 }
 

--- a/drizzle/migrations/0018_saved_search_alerts.sql
+++ b/drizzle/migrations/0018_saved_search_alerts.sql
@@ -1,0 +1,2 @@
+-- P17.5: Add alert_enabled column to saved_searches
+ALTER TABLE saved_searches ADD COLUMN IF NOT EXISTS alert_enabled boolean NOT NULL DEFAULT false;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -756,6 +756,7 @@ export const savedSearches = pgTable(
     name: varchar("name", { length: 255 }),
     searchParams: jsonb("search_params").$type<Record<string, unknown>>().notNull(),
     resultCount: integer("result_count"),
+    alertEnabled: boolean("alert_enabled").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/lib/saved-search-matcher.ts
+++ b/lib/saved-search-matcher.ts
@@ -152,7 +152,7 @@ export function yachtMatchesFilters(yacht: YachtForMatching, filters: SearchFilt
   const yrMin = toNum(filters.yearMin);
   const yrMax = toNum(filters.yearMax);
   if (yrMin != null || yrMax != null) {
-    if (!inRange(yacht.year, yrMin, yrMax)) return false;
+    if (!inRange(yacht.year ?? null, yrMin, yrMax)) return false;
   }
 
   return true;

--- a/lib/saved-search-matcher.ts
+++ b/lib/saved-search-matcher.ts
@@ -1,0 +1,237 @@
+/**
+ * Saved Search Filter Matcher (P17.5)
+ *
+ * Matches yacht data against saved search filter params to determine
+ * which saved searches a yacht would appear in. Used for filter-based alerts.
+ */
+
+export interface YachtForMatching {
+  id: number;
+  manufacturerId: number | null;
+  rigType: string | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  lengthOverall: number | null;
+  displacement: number | null;
+  draft: number | null;
+  sailArea: number | null;
+  cabinCount: number | null;
+  berthCount: number | null;
+  manufacturerName?: string | null;
+  modelName?: string | null;
+  useCaseTags?: string[] | null;
+  year?: number | null;
+}
+
+export interface SearchFilters {
+  // Text search
+  query?: string;
+  q?: string;
+  // Range filters
+  lengthMin?: number | string;
+  lengthMax?: number | string;
+  displacementMin?: number | string;
+  displacementMax?: number | string;
+  draftMin?: number | string;
+  draftMax?: number | string;
+  sailAreaMin?: number | string;
+  sailAreaMax?: number | string;
+  // Exact/categorical filters
+  manufacturerId?: number | string;
+  manufacturerName?: string;
+  rigType?: string;
+  keelType?: string;
+  hullMaterial?: string;
+  cabinCount?: number | string;
+  berthCount?: number | string;
+  // Use case tags
+  useCase?: string;
+  useCases?: string[];
+  // Year range
+  yearMin?: number | string;
+  yearMax?: number | string;
+  // Sort / pagination (ignored for matching)
+  sort?: string;
+  page?: number | string;
+  limit?: number | string;
+  [key: string]: unknown;
+}
+
+/** Normalize a filter value to a number, returning null if invalid */
+function toNum(val: unknown): number | null {
+  if (val == null || val === "") return null;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Check if a value is in a numeric range [min, max] */
+function inRange(value: number | null, min: number | null, max: number | null): boolean {
+  if (value == null) return false;
+  if (min != null && value < min) return false;
+  if (max != null && value > max) return false;
+  return true;
+}
+
+/** Case-insensitive string match (contains) */
+function textMatches(haystack: string | null | undefined, needle: string): boolean {
+  if (!needle || !haystack) return true; // no filter = match all
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+/**
+ * Check if a yacht matches the given saved search filters.
+ * Returns true if the yacht satisfies ALL filter criteria.
+ */
+export function yachtMatchesFilters(yacht: YachtForMatching, filters: SearchFilters): boolean {
+  // Text search — match against manufacturer name, model name
+  const query = filters.query || filters.q;
+  if (query && typeof query === "string") {
+    const combined = `${yacht.manufacturerName || ""} ${yacht.modelName || ""}`.trim();
+    if (!textMatches(combined, query)) return false;
+  }
+
+  // Manufacturer filter
+  const manufId = toNum(filters.manufacturerId);
+  if (manufId != null && yacht.manufacturerId !== manufId) return false;
+
+  if (filters.manufacturerName && typeof filters.manufacturerName === "string") {
+    if (!textMatches(yacht.manufacturerName, filters.manufacturerName)) return false;
+  }
+
+  // Categorical filters
+  if (filters.rigType && typeof filters.rigType === "string" && filters.rigType !== "") {
+    if (!textMatches(yacht.rigType, filters.rigType)) return false;
+  }
+
+  if (filters.keelType && typeof filters.keelType === "string" && filters.keelType !== "") {
+    if (!textMatches(yacht.keelType, filters.keelType)) return false;
+  }
+
+  if (filters.hullMaterial && typeof filters.hullMaterial === "string" && filters.hullMaterial !== "") {
+    if (!textMatches(yacht.hullMaterial, filters.hullMaterial)) return false;
+  }
+
+  // Numeric range filters (only apply when a min/max is specified)
+  const lenMin = toNum(filters.lengthMin);
+  const lenMax = toNum(filters.lengthMax);
+  if (lenMin != null || lenMax != null) {
+    if (!inRange(yacht.lengthOverall, lenMin, lenMax)) return false;
+  }
+  const dispMin = toNum(filters.displacementMin);
+  const dispMax = toNum(filters.displacementMax);
+  if (dispMin != null || dispMax != null) {
+    if (!inRange(yacht.displacement, dispMin, dispMax)) return false;
+  }
+  const drftMin = toNum(filters.draftMin);
+  const drftMax = toNum(filters.draftMax);
+  if (drftMin != null || drftMax != null) {
+    if (!inRange(yacht.draft, drftMin, drftMax)) return false;
+  }
+  const saMin = toNum(filters.sailAreaMin);
+  const saMax = toNum(filters.sailAreaMax);
+  if (saMin != null || saMax != null) {
+    if (!inRange(yacht.sailArea, saMin, saMax)) return false;
+  }
+
+  // Exact numeric filters
+  const cabins = toNum(filters.cabinCount);
+  if (cabins != null && yacht.cabinCount !== cabins) return false;
+
+  const berths = toNum(filters.berthCount);
+  if (berths != null && yacht.berthCount !== berths) return false;
+
+  // Use case tags
+  const useCaseFilter = filters.useCase || (Array.isArray(filters.useCases) ? filters.useCases : null);
+  if (useCaseFilter) {
+    const tags = yacht.useCaseTags || [];
+    const filterTags = Array.isArray(useCaseFilter) ? useCaseFilter : [useCaseFilter];
+    if (!filterTags.some((tag) => tags.includes(String(tag)))) return false;
+  }
+
+  // Year range
+  const yrMin = toNum(filters.yearMin);
+  const yrMax = toNum(filters.yearMax);
+  if (yrMin != null || yrMax != null) {
+    if (!inRange(yacht.year, yrMin, yrMax)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Given a yacht and a list of saved searches, return the IDs of searches
+ * whose filters the yacht matches. Only considers searches with alertEnabled=true.
+ */
+export function findMatchingSearches(
+  yacht: YachtForMatching,
+  searches: Array<{ id: number; searchParams: Record<string, unknown>; alertEnabled?: boolean }>
+): number[] {
+  return searches
+    .filter((s) => s.alertEnabled !== false)
+    .filter((s) => yachtMatchesFilters(yacht, s.searchParams as SearchFilters))
+    .map((s) => s.id);
+}
+
+/**
+ * Build a human-readable description of search filters.
+ * Returns an array of { label, value } pairs for display.
+ */
+export function describeFilters(filters: SearchFilters): Array<{ label: string; value: string }> {
+  const parts: Array<{ label: string; value: string }> = [];
+
+  const query = filters.query || filters.q;
+  if (query && typeof query === "string") {
+    parts.push({ label: "Search", value: query });
+  }
+
+  const lengthMin = toNum(filters.lengthMin);
+  const lengthMax = toNum(filters.lengthMax);
+  if (lengthMin != null || lengthMax != null) {
+    parts.push({ label: "Length", value: `${lengthMin ?? "any"}–${lengthMax ?? "any"}m` });
+  }
+
+  const dispMin = toNum(filters.displacementMin);
+  const dispMax = toNum(filters.displacementMax);
+  if (dispMin != null || dispMax != null) {
+    parts.push({ label: "Displacement", value: `${dispMin ?? "any"}–${dispMax ?? "any"}kg` });
+  }
+
+  const draftMin = toNum(filters.draftMin);
+  const draftMax = toNum(filters.draftMax);
+  if (draftMin != null || draftMax != null) {
+    parts.push({ label: "Draft", value: `${draftMin ?? "any"}–${draftMax ?? "any"}m` });
+  }
+
+  const saMin = toNum(filters.sailAreaMin);
+  const saMax = toNum(filters.sailAreaMax);
+  if (saMin != null || saMax != null) {
+    parts.push({ label: "Sail Area", value: `${saMin ?? "any"}–${saMax ?? "any"}m²` });
+  }
+
+  if (filters.rigType && typeof filters.rigType === "string") {
+    parts.push({ label: "Rig Type", value: filters.rigType });
+  }
+  if (filters.keelType && typeof filters.keelType === "string") {
+    parts.push({ label: "Keel Type", value: filters.keelType });
+  }
+  if (filters.hullMaterial && typeof filters.hullMaterial === "string") {
+    parts.push({ label: "Hull Material", value: filters.hullMaterial });
+  }
+
+  const cabins = toNum(filters.cabinCount);
+  if (cabins != null) parts.push({ label: "Cabins", value: String(cabins) });
+
+  const berths = toNum(filters.berthCount);
+  if (berths != null) parts.push({ label: "Berths", value: String(berths) });
+
+  const useCase = filters.useCase || (Array.isArray(filters.useCases) ? filters.useCases.join(", ") : null);
+  if (useCase) parts.push({ label: "Use Case", value: String(useCase) });
+
+  const yearMin = toNum(filters.yearMin);
+  const yearMax = toNum(filters.yearMax);
+  if (yearMin != null || yearMax != null) {
+    parts.push({ label: "Year", value: `${yearMin ?? "any"}–${yearMax ?? "any"}` });
+  }
+
+  return parts;
+}

--- a/memory/dreaming/deep/2026-05-11.md
+++ b/memory/dreaming/deep/2026-05-11.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-05-12.md
+++ b/memory/dreaming/deep/2026-05-12.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/light/2026-05-11.md
+++ b/memory/dreaming/light/2026-05-11.md
@@ -1,0 +1,3 @@
+# Light Sleep
+
+- No notable updates.

--- a/memory/dreaming/light/2026-05-12.md
+++ b/memory/dreaming/light/2026-05-12.md
@@ -1,0 +1,3 @@
+# Light Sleep
+
+- No notable updates.

--- a/memory/dreaming/rem/2026-05-11.md
+++ b/memory/dreaming/rem/2026-05-11.md
@@ -1,0 +1,7 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- No strong candidate truths surfaced.

--- a/memory/dreaming/rem/2026-05-12.md
+++ b/memory/dreaming/rem/2026-05-12.md
@@ -1,0 +1,7 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- No strong candidate truths surfaced.

--- a/tests/saved-search-matcher.test.ts
+++ b/tests/saved-search-matcher.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { yachtMatchesFilters, findMatchingSearches, describeFilters } from "../lib/saved-search-matcher";
+
+// ─── Test helpers ────────────────────────────────────────────────────
+const baseYacht = {
+  id: 1,
+  manufacturerId: 10,
+  rigType: "Sloop",
+  keelType: "Fin keel",
+  hullMaterial: "GRP",
+  lengthOverall: 12.5,
+  displacement: 8000,
+  draft: 2.1,
+  sailArea: 85,
+  cabinCount: 3,
+  berthCount: 6,
+  manufacturerName: "Beneteau",
+  modelName: "Oceanis 41",
+  useCaseTags: ["bluewater", "cruising"],
+  year: 2020,
+};
+
+// ─── yachtMatchesFilters ─────────────────────────────────────────────
+describe("yachtMatchesFilters", () => {
+  it("returns true for empty filters (no restrictions)", () => {
+    expect(yachtMatchesFilters(baseYacht, {})).toBe(true);
+  });
+
+  it("matches text query against manufacturer name", () => {
+    expect(yachtMatchesFilters(baseYacht, { query: "beneteau" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { query: "Jeanneau" })).toBe(false);
+    expect(yachtMatchesFilters(baseYacht, { q: "Oceanis" })).toBe(true);
+  });
+
+  it("matches manufacturer ID", () => {
+    expect(yachtMatchesFilters(baseYacht, { manufacturerId: 10 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { manufacturerId: 20 })).toBe(false);
+  });
+
+  it("matches rig type (case-insensitive)", () => {
+    expect(yachtMatchesFilters(baseYacht, { rigType: "Sloop" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { rigType: "Ketch" })).toBe(false);
+  });
+
+  it("matches keel type", () => {
+    expect(yachtMatchesFilters(baseYacht, { keelType: "Fin" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { keelType: "Full" })).toBe(false);
+  });
+
+  it("matches hull material", () => {
+    expect(yachtMatchesFilters(baseYacht, { hullMaterial: "GRP" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { hullMaterial: "Steel" })).toBe(false);
+  });
+
+  it("matches length range", () => {
+    expect(yachtMatchesFilters(baseYacht, { lengthMin: 10, lengthMax: 15 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { lengthMin: 13, lengthMax: 20 })).toBe(false);
+    expect(yachtMatchesFilters(baseYacht, { lengthMin: 10 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { lengthMax: 12 })).toBe(false);
+  });
+
+  it("matches displacement range", () => {
+    expect(yachtMatchesFilters(baseYacht, { displacementMin: 5000, displacementMax: 10000 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { displacementMin: 9000 })).toBe(false);
+  });
+
+  it("matches draft range", () => {
+    expect(yachtMatchesFilters(baseYacht, { draftMin: 1.5, draftMax: 2.5 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { draftMax: 2.0 })).toBe(false);
+  });
+
+  it("matches sail area range", () => {
+    expect(yachtMatchesFilters(baseYacht, { sailAreaMin: 50, sailAreaMax: 100 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { sailAreaMax: 80 })).toBe(false);
+  });
+
+  it("matches exact cabin count", () => {
+    expect(yachtMatchesFilters(baseYacht, { cabinCount: 3 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { cabinCount: 2 })).toBe(false);
+  });
+
+  it("matches exact berth count", () => {
+    expect(yachtMatchesFilters(baseYacht, { berthCount: 6 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { berthCount: 4 })).toBe(false);
+  });
+
+  it("matches use case tag", () => {
+    expect(yachtMatchesFilters(baseYacht, { useCase: "bluewater" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { useCase: "racing" })).toBe(false);
+  });
+
+  it("matches use case tags array (any match)", () => {
+    expect(yachtMatchesFilters(baseYacht, { useCases: ["racing", "cruising"] })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { useCases: ["racing", "daysailer"] })).toBe(false);
+  });
+
+  it("matches year range", () => {
+    expect(yachtMatchesFilters(baseYacht, { yearMin: 2019, yearMax: 2021 })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { yearMin: 2021 })).toBe(false);
+  });
+
+  it("handles string filter values (converted to numbers)", () => {
+    expect(yachtMatchesFilters(baseYacht, { lengthMin: "10", lengthMax: "15" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { cabinCount: "3" })).toBe(true);
+  });
+
+  it("handles null yacht values gracefully", () => {
+    const yachtWithNulls = {
+      ...baseYacht,
+      lengthOverall: null,
+      displacement: null,
+      draft: null,
+    };
+    expect(yachtMatchesFilters(yachtWithNulls, { lengthMin: 10 })).toBe(false);
+    expect(yachtMatchesFilters(yachtWithNulls, { displacementMin: 5000 })).toBe(false);
+    expect(yachtMatchesFilters(yachtWithNulls, { rigType: "Sloop" })).toBe(true);
+  });
+
+  it("handles empty string filter values (treated as no filter)", () => {
+    expect(yachtMatchesFilters(baseYacht, { rigType: "" })).toBe(true);
+    expect(yachtMatchesFilters(baseYacht, { keelType: "" })).toBe(true);
+  });
+
+  it("combines multiple filters (all must match)", () => {
+    expect(yachtMatchesFilters(baseYacht, {
+      rigType: "Sloop",
+      lengthMin: 10,
+      lengthMax: 15,
+      hullMaterial: "GRP",
+    })).toBe(true);
+
+    expect(yachtMatchesFilters(baseYacht, {
+      rigType: "Sloop",
+      lengthMin: 10,
+      lengthMax: 15,
+      hullMaterial: "Steel",
+    })).toBe(false);
+  });
+
+  it("ignores sort/page/limit params", () => {
+    expect(yachtMatchesFilters(baseYacht, { sort: "length", page: 1, limit: 20 })).toBe(true);
+  });
+});
+
+// ─── findMatchingSearches ────────────────────────────────────────────
+describe("findMatchingSearches", () => {
+  const searches = [
+    { id: 1, searchParams: { rigType: "Sloop" }, alertEnabled: true },
+    { id: 2, searchParams: { rigType: "Ketch" }, alertEnabled: true },
+    { id: 3, searchParams: { lengthMin: 10, lengthMax: 15 }, alertEnabled: true },
+    { id: 4, searchParams: { rigType: "Sloop" }, alertEnabled: false },
+    { id: 5, searchParams: { rigType: "Sloop", hullMaterial: "Steel" }, alertEnabled: true },
+  ];
+
+  it("returns IDs of searches with alertEnabled that match", () => {
+    const result = findMatchingSearches(baseYacht, searches);
+    expect(result).toContain(1);
+    expect(result).toContain(3);
+    expect(result).not.toContain(2);
+    expect(result).not.toContain(4);
+    expect(result).not.toContain(5);
+  });
+
+  it("returns empty array when no matches", () => {
+    const result = findMatchingSearches({ ...baseYacht, rigType: "Cat", lengthOverall: 5 }, searches);
+    expect(result).toEqual([]);
+  });
+
+  it("defaults alertEnabled to true when undefined", () => {
+    const searches = [
+      { id: 1, searchParams: { rigType: "Sloop" } },
+    ];
+    expect(findMatchingSearches(baseYacht, searches)).toEqual([1]);
+  });
+});
+
+// ─── describeFilters ─────────────────────────────────────────────────
+describe("describeFilters", () => {
+  it("returns empty array for empty filters", () => {
+    expect(describeFilters({})).toEqual([]);
+  });
+
+  it("describes text query", () => {
+    const result = describeFilters({ query: "beneteau" });
+    expect(result).toEqual([{ label: "Search", value: "beneteau" }]);
+  });
+
+  it("describes length range", () => {
+    const result = describeFilters({ lengthMin: 10, lengthMax: 15 });
+    expect(result).toEqual([{ label: "Length", value: "10–15m" }]);
+  });
+
+  it("describes open-ended ranges", () => {
+    const result = describeFilters({ lengthMin: 10 });
+    expect(result).toEqual([{ label: "Length", value: "10–anym" }]);
+  });
+
+  it("describes categorical filters", () => {
+    const result = describeFilters({ rigType: "Sloop", keelType: "Fin keel" });
+    expect(result).toContainEqual({ label: "Rig Type", value: "Sloop" });
+    expect(result).toContainEqual({ label: "Keel Type", value: "Fin keel" });
+  });
+
+  it("describes exact numeric filters", () => {
+    const result = describeFilters({ cabinCount: 3, berthCount: 6 });
+    expect(result).toContainEqual({ label: "Cabins", value: "3" });
+    expect(result).toContainEqual({ label: "Berths", value: "6" });
+  });
+
+  it("describes use case", () => {
+    const result = describeFilters({ useCase: "bluewater" });
+    expect(result).toEqual([{ label: "Use Case", value: "bluewater" }]);
+  });
+
+  it("describes year range", () => {
+    const result = describeFilters({ yearMin: 2019, yearMax: 2022 });
+    expect(result).toEqual([{ label: "Year", value: "2019–2022" }]);
+  });
+});


### PR DESCRIPTION
- Add alertEnabled column to saved_searches table (migration 0018)
- Add filter matching utility (lib/saved-search-matcher.ts) with
  yachtMatchesFilters, findMatchingSearches, describeFilters
- Update /api/user/searches to support PUT for alert toggling and
  alertEnabled on POST
- Add alert toggle to SearchesTab in AccountDashboard with filter
  description badges and active alert count banner
- Add 'Save & Alert' button on /yachts page when filters are active
- 31 unit tests for filter matching logic
