### PR TITLE
feat: add error boundaries with retry for all route segments (closes #278)

### DIFF
--- a/app/[locale]/ErrorBoundary.tsx
+++ b/app/[locale]/ErrorBoundary.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { captureError } from "@/lib/sentry";
+
+interface ErrorBoundaryProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  /** Translation key for the error title */
+  titleKey?: string;
+  /** Translation key for the error description */
+  descriptionKey?: string;
+  /** Label for the back link */
+  backLabel?: string;
+  /** URL for the back link */
+  backHref?: string;
+}
+
+/**
+ * Shared error boundary component used by all route-specific error.tsx files.
+ * Logs errors to Sentry and shows a user-friendly recovery UI.
+ */
+export default function ErrorBoundary({
+  error,
+  reset,
+  titleKey = "genericTitle",
+  descriptionKey = "genericDescription",
+  backLabel,
+  backHref,
+}: ErrorBoundaryProps) {
+  const t = useTranslations("Errors");
+
+  useEffect(() => {
+    captureError(error, {
+      errorDigest: error.digest || "unknown",
+      errorBoundary: "route",
+    });
+  }, [error]);
+
+  return (
+    <div
+      role="alert"
+      className="min-h-[50vh] flex items-center justify-center px-4 py-12"
+    >
+      <div className="max-w-md w-full text-center space-y-6">
+        {/* Error icon */}
+        <div className="flex justify-center">
+          <div className="h-20 w-20 rounded-full bg-red-50 flex items-center justify-center">
+            <svg
+              className="h-10 w-10 text-red-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+        </div>
+
+        {/* Error message */}
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">
+            {t(titleKey)}
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {t(descriptionKey)}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <svg
+              className="h-4 w-4 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+              />
+            </svg>
+            {t("tryAgain")}
+          </button>
+
+          {backHref && backLabel && (
+            <a
+              href={backHref}
+              className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {backLabel}
+            </a>
+          )}
+
+          <a
+            href="/"
+            className="inline-flex items-center justify-center text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {t("goHome")}
+          </a>
+        </div>
+
+        {/* Error digest for debugging */}
+        {error.digest && (
+          <p className="text-xs text-muted-foreground/60">
+            Error ID: {error.digest}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/compare/[slugA]-vs-[slugB]/error.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function CompareDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="compareDetailTitle"
+      descriptionKey="compareDetailDescription"
+    />
+  );
+}

--- a/app/[locale]/compare/error.tsx
+++ b/app/[locale]/compare/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function CompareError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="compareTitle"
+      descriptionKey="compareDescription"
+    />
+  );
+}

--- a/app/[locale]/glossary/[slug]/error.tsx
+++ b/app/[locale]/glossary/[slug]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function GlossaryDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="glossaryDetailTitle"
+      descriptionKey="glossaryDetailDescription"
+    />
+  );
+}

--- a/app/[locale]/glossary/error.tsx
+++ b/app/[locale]/glossary/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function GlossaryError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="glossaryTitle"
+      descriptionKey="glossaryDescription"
+    />
+  );
+}

--- a/app/[locale]/guides/[slug]/error.tsx
+++ b/app/[locale]/guides/[slug]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function GuideDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="guideDetailTitle"
+      descriptionKey="guideDetailDescription"
+    />
+  );
+}

--- a/app/[locale]/guides/error.tsx
+++ b/app/[locale]/guides/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function GuidesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="guidesTitle"
+      descriptionKey="guidesDescription"
+    />
+  );
+}

--- a/app/[locale]/manufacturers/[slug]/error.tsx
+++ b/app/[locale]/manufacturers/[slug]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function ManufacturerDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="manufacturerDetailTitle"
+      descriptionKey="manufacturerDetailDescription"
+    />
+  );
+}

--- a/app/[locale]/manufacturers/error.tsx
+++ b/app/[locale]/manufacturers/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function ManufacturersError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="manufacturersTitle"
+      descriptionKey="manufacturersDescription"
+    />
+  );
+}

--- a/app/[locale]/search/error.tsx
+++ b/app/[locale]/search/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function SearchError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="searchTitle"
+      descriptionKey="searchDescription"
+    />
+  );
+}

--- a/app/[locale]/yachts/[slug]/error.tsx
+++ b/app/[locale]/yachts/[slug]/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function YachtDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="yachtDetailTitle"
+      descriptionKey="yachtDetailDescription"
+      backHref="/yachts"
+      backLabel="← Browse yachts"
+    />
+  );
+}

--- a/app/[locale]/yachts/error.tsx
+++ b/app/[locale]/yachts/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function YachtsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="yachtsTitle"
+      descriptionKey="yachtsDescription"
+      backHref="/"
+      backLabel="← Home"
+    />
+  );
+}

--- a/app/[locale]/yachts/finder/error.tsx
+++ b/app/[locale]/yachts/finder/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "../../ErrorBoundary";
+
+export default function FinderError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="finderTitle"
+      descriptionKey="finderDescription"
+    />
+  );
+}

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,34 +1,43 @@
 # Sailing Yachts Builder Session Summary
 
-**Date:** 2026-05-12
-**Issues worked on:** #272 (P17.4 — "Yachts like this" smart recommendations)
+**Date:** 2026-05-13
+**Issues worked on:** #276 (P18.1 — Loading skeletons for all route segments)
 
 ## What was implemented
 
-### P17.4 — Smart Recommendations (Issue #272, PR #273)
-- **Similarity scoring library** (`lib/similarity-score.ts`):
-  - 5-factor weighted scoring (0-100): LOA proximity (25), use-case tag overlap (20), rig & keel match (20), D/L ratio similarity (20), price tier (15)
-  - `scoreSimilarity()` computes per-factor scores with human-readable details
-  - `rankSimilarYachts()` filters (≥15 threshold) and sorts descending, max 6 results
-- **Enhanced similar API** (`app/api/yachts/[slug]/similar/route.ts`):
-  - Uses new scoring algorithm instead of old Euclidean distance
-  - Returns score (0-100) + full factor breakdown per yacht
-  - Fetches images in parallel
-- **Updated SimilarYachts component**:
-  - Color-coded match percentage badge (emerald/sky/amber/orange by score range)
-  - Match progress bar with color coding
-  - "Why recommended?" tooltip with per-factor breakdown bars and detail text
-  - Tooltip opens on click, closes on blur
-- **i18n**: Full en + fr translations for 7 new translation keys
-- **Tests**: 14 unit tests covering scoring, ranking, edge cases, null handling
+### P18.1 — Loading Skeletons (Issue #276, PR #277)
+- **Skeleton component library** (`components/ui/skeleton.tsx`):
+  - 8 reusable variants: Skeleton, SkeletonLine, SkeletonCircle, SkeletonImage, SkeletonCard, SkeletonStat, SkeletonTableRow, SkeletonFilterSection
+  - All use Tailwind `animate-pulse` and `bg-muted`
+  - Uses `cn()` utility for class merging
+  - Configurable dimensions, aspect ratios, line counts
+- **14 `loading.tsx` files** for all major route segments:
+  - `/yachts` — filter sidebar + 3-column yacht card grid + pagination
+  - `/yachts/[slug]` — image + key specs + spec bars + full table + similar yachts
+  - `/yachts/finder` — progress steps + option cards
+  - `/compare` — dual search inputs + table + radar chart
+  - `/compare/[slugA]-vs-[slugB]` — two-column headers + comparison table + charts
+  - `/manufacturers` — 4-column card grid with logos
+  - `/manufacturers/[slug]` — header + fleet chart + yacht lineup
+  - `/guides` — category tabs + article card grid
+  - `/guides/[slug]` — hero image + content paragraphs + related guides
+  - `/search` — search bar + suggestions + results grid
+  - `/glossary` — alphabet nav + term list
+  - `/glossary/[slug]` — definition + related terms
+  - `/account` — stats + favorites + saved searches
+  - `/favorites` — card grid
+- **Phase 18 plan** added to FUTURE_ROADMAP.md (Performance & UX Polish)
+- **52 unit tests** for skeleton logic, file existence, and content validation
 
 ## Build/Test Results
 - **Typecheck**: ✅ Pass
 - **Build**: ✅ Pass
-- **Vitest**: ✅ 14/14 pass (similarity-score)
+- **Lint**: ✅ Pass
+- **Vitest**: ✅ 52/52 pass
 
 ## Deploy Status
-- **PR #273**: ✅ Merged (squash)
+- **PR #277**: ✅ Merged (squash)
+- **CI**: ✅ All checks green (Build, Lint, TypeScript, Performance Budgets)
 - **Vercel**: ✅ Production deployed
 
 ## Live Verification Results
@@ -36,16 +45,23 @@
 - **/yachts**: ✅ OK
 - **/search**: ✅ OK
 - **/compare**: ✅ OK
+- **/manufacturers**: ✅ OK
+- **/guides**: ✅ OK
+- **/glossary**: ✅ OK
 - **/yachts/beneteau-oceanis-40-1**: ✅ OK
+- **/compare/beneteau-oceanis-40-1-vs-jeanneau-sun-odyssey-410**: ✅ OK
+- **/yachts/finder**: ✅ OK
 - **API /api/yachts**: ✅ OK (201 yachts)
-- **API /api/yachts/.../similar**: ✅ OK (scores 0-100, factor breakdowns present)
-- **Browser console**: ✅ No errors
-- **Similar Yachts section**: ✅ Renders with score badges + "Why recommended?" tooltips
+- **Browser console**: ✅ No new errors (pre-existing /fr/auth/signin 404 only)
+- **Page rendering**: ✅ Correct (verified with browser snapshot)
 
-### Example API results (Beneteau Oceanis 40.1):
-1. Jeanneau Sun Odyssey 410 — 100% (4 shared tags, same rig/keel, same D/L, same tier)
-2. X-Yachts X4³ — 97%
-3. Wauquiez PS 42 — 97%
+## Previous phases status
+- Phase 14 (i18n): ✅ COMPLETE
+- Phase 15 (Visualizations): ✅ COMPLETE
+- Phase 16 (Manufacturer Data): ✅ COMPLETE
+- Phase 17 (Discovery & Recommendations): ✅ COMPLETE
+- Phase 18 (Performance & UX Polish): 🔄 In Progress
 
 ## Next Recommended Task
-- **P17.5** — Saved search & alert system enhancement (filter-based alerts, saved search management page)
+- **P18.2** — Error boundaries with retry for all route segments (error.tsx files)
+- **P18.3** — Custom 404/not-found page

--- a/messages/en.json
+++ b/messages/en.json
@@ -1123,5 +1123,35 @@
       "description": "This landing page is not defined in the system.",
       "homeLink": "Return to Home"
     }
+  },
+  "Errors": {
+    "genericTitle": "Something went wrong",
+    "genericDescription": "An unexpected error occurred. Please try again.",
+    "tryAgain": "Try again",
+    "goHome": "Go to homepage",
+    "yachtsTitle": "Failed to load yachts",
+    "yachtsDescription": "We could not load the yacht listings. Please try again.",
+    "yachtDetailTitle": "Yacht not available",
+    "yachtDetailDescription": "This yacht could not be loaded. It may have been removed or there was a temporary issue.",
+    "finderTitle": "Yacht Finder error",
+    "finderDescription": "The yacht finder encountered an error. Please try again.",
+    "compareTitle": "Comparison failed",
+    "compareDescription": "We could not load the comparison tool. Please try again.",
+    "compareDetailTitle": "Comparison not available",
+    "compareDetailDescription": "This comparison could not be loaded. One of the yachts may not exist.",
+    "manufacturersTitle": "Failed to load manufacturers",
+    "manufacturersDescription": "We could not load the manufacturer listings. Please try again.",
+    "manufacturerDetailTitle": "Manufacturer not available",
+    "manufacturerDetailDescription": "This manufacturer page could not be loaded. Please try again.",
+    "guidesTitle": "Failed to load guides",
+    "guidesDescription": "We could not load the sailing guides. Please try again.",
+    "guideDetailTitle": "Guide not available",
+    "guideDetailDescription": "This guide could not be loaded. It may have been moved or removed.",
+    "searchTitle": "Search error",
+    "searchDescription": "Something went wrong with search. Please try again.",
+    "glossaryTitle": "Failed to load glossary",
+    "glossaryDescription": "We could not load the nautical glossary. Please try again.",
+    "glossaryDetailTitle": "Term not available",
+    "glossaryDetailDescription": "This glossary term could not be loaded. Please try again."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1123,5 +1123,35 @@
       "description": "Cette page n'est pas définie dans le système.",
       "homeLink": "Retour à l'accueil"
     }
+  },
+  "Errors": {
+    "genericTitle": "Une erreur est survenue",
+    "genericDescription": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+    "tryAgain": "Réessayer",
+    "goHome": "Aller à l'accueil",
+    "yachtsTitle": "Impossible de charger les yachts",
+    "yachtsDescription": "Nous n'avons pas pu charger la liste des yachts. Veuillez réessayer.",
+    "yachtDetailTitle": "Yacht non disponible",
+    "yachtDetailDescription": "Ce yacht n'a pas pu être chargé. Il a peut-être été supprimé ou il y a un problème temporaire.",
+    "finderTitle": "Erreur du sélecteur de yachts",
+    "finderDescription": "Le sélecteur de yachts a rencontré une erreur. Veuillez réessayer.",
+    "compareTitle": "Comparaison échouée",
+    "compareDescription": "Nous n'avons pas pu charger l'outil de comparaison. Veuillez réessayer.",
+    "compareDetailTitle": "Comparaison non disponible",
+    "compareDetailDescription": "Cette comparaison n'a pas pu être chargée. L'un des yachts n'existe peut-être pas.",
+    "manufacturersTitle": "Impossible de charger les constructeurs",
+    "manufacturersDescription": "Nous n'avons pas pu charger la liste des constructeurs. Veuillez réessayer.",
+    "manufacturerDetailTitle": "Constructeur non disponible",
+    "manufacturerDetailDescription": "Cette page constructeur n'a pas pu être chargée. Veuillez réessayer.",
+    "guidesTitle": "Impossible de charger les guides",
+    "guidesDescription": "Nous n'avons pas pu charger les guides de navigation. Veuillez réessayer.",
+    "guideDetailTitle": "Guide non disponible",
+    "guideDetailDescription": "Ce guide n'a pas pu être chargé. Il a peut-être été déplacé ou supprimé.",
+    "searchTitle": "Erreur de recherche",
+    "searchDescription": "Un problème est survenu lors de la recherche. Veuillez réessayer.",
+    "glossaryTitle": "Impossible de charger le glossaire",
+    "glossaryDescription": "Nous n'avons pas pu charger le glossaire nautique. Veuillez réessayer.",
+    "glossaryDetailTitle": "Terme non disponible",
+    "glossaryDetailDescription": "Ce terme du glossaire n'a pas pu être chargé. Veuillez réessayer."
   }
 }

--- a/tests/error-boundaries.test.ts
+++ b/tests/error-boundaries.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+// ─── Error boundary file existence tests ────────────────────────
+
+describe("Error Boundary Files", () => {
+  const projectRoot = resolve(__dirname, "..");
+
+  const errorFiles = [
+    "app/[locale]/yachts/error.tsx",
+    "app/[locale]/yachts/[slug]/error.tsx",
+    "app/[locale]/yachts/finder/error.tsx",
+    "app/[locale]/compare/error.tsx",
+    "app/[locale]/compare/[slugA]-vs-[slugB]/error.tsx",
+    "app/[locale]/manufacturers/error.tsx",
+    "app/[locale]/manufacturers/[slug]/error.tsx",
+    "app/[locale]/guides/error.tsx",
+    "app/[locale]/guides/[slug]/error.tsx",
+    "app/[locale]/search/error.tsx",
+    "app/[locale]/glossary/error.tsx",
+    "app/[locale]/glossary/[slug]/error.tsx",
+  ];
+
+  it.each(errorFiles)("%s exists", (file) => {
+    const fullPath = resolve(projectRoot, file);
+    expect(existsSync(fullPath)).toBe(true);
+  });
+
+  it.each(errorFiles)("%s is a client component", (file) => {
+    const fullPath = resolve(projectRoot, file);
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it.each(errorFiles)("%s uses the shared ErrorBoundary component", (file) => {
+    const fullPath = resolve(projectRoot, file);
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("ErrorBoundary");
+  });
+
+  it("shared ErrorBoundary component exists and uses Sentry", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/ErrorBoundary.tsx");
+    expect(existsSync(fullPath)).toBe(true);
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain('"use client"');
+    expect(content).toContain("captureError");
+    expect(content).toContain("role=\"alert\"");
+    expect(content).toContain("useTranslations");
+  });
+
+  it("ErrorBoundary has retry button functionality", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/ErrorBoundary.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("onClick={reset}");
+  });
+
+  it("ErrorBoundary has error icon/svg for visual feedback", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/ErrorBoundary.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("<svg");
+  });
+});
+
+// ─── i18n error message tests ───────────────────────────────────
+
+describe("Error i18n Messages", () => {
+  const projectRoot = resolve(__dirname, "..");
+
+  const requiredKeys = [
+    "genericTitle",
+    "genericDescription",
+    "tryAgain",
+    "goHome",
+    "yachtsTitle",
+    "yachtsDescription",
+    "yachtDetailTitle",
+    "yachtDetailDescription",
+    "finderTitle",
+    "finderDescription",
+    "compareTitle",
+    "compareDescription",
+    "compareDetailTitle",
+    "compareDetailDescription",
+    "manufacturersTitle",
+    "manufacturersDescription",
+    "manufacturerDetailTitle",
+    "manufacturerDetailDescription",
+    "guidesTitle",
+    "guidesDescription",
+    "guideDetailTitle",
+    "guideDetailDescription",
+    "searchTitle",
+    "searchDescription",
+    "glossaryTitle",
+    "glossaryDescription",
+    "glossaryDetailTitle",
+    "glossaryDetailDescription",
+  ];
+
+  it("en.json has all error message keys", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    expect(en.Errors).toBeTruthy();
+    for (const key of requiredKeys) {
+      expect(en.Errors[key]).toBeTruthy();
+      expect(typeof en.Errors[key]).toBe("string");
+    }
+  });
+
+  it("fr.json has all error message keys", async () => {
+    const { default: fs } = await import("fs");
+    const fr = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    expect(fr.Errors).toBeTruthy();
+    for (const key of requiredKeys) {
+      expect(fr.Errors[key]).toBeTruthy();
+      expect(typeof fr.Errors[key]).toBe("string");
+    }
+  });
+
+  it("en.json and fr.json have same error keys", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const fr = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const enKeys = Object.keys(en.Errors).sort();
+    const frKeys = Object.keys(fr.Errors).sort();
+    expect(enKeys).toEqual(frKeys);
+  });
+
+  it("no error message is empty", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    for (const [key, value] of Object.entries(en.Errors)) {
+      expect((value as string).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
- Add shared ErrorBoundary component (app/[locale]/ErrorBoundary.tsx)
  with Sentry integration, retry button, back link, error icon
- Add error.tsx for 12 route segments:
  /yachts, /yachts/[slug], /yachts/finder, /compare, /compare/[slugA]-vs-[slugB],
  /manufacturers, /manufacturers/[slug], /guides, /guides/[slug],
  /search, /glossary, /glossary/[slug]
- Each error boundary has context-appropriate messages
- Add Errors i18n namespace with 28 keys in en.json and fr.json
- All error boundaries use role="alert" for accessibility
- 43 unit tests for file existence, content, and i18n validation
