### PR TITLE
feat: add custom 404/not-found pages with i18n support (closes #280)

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  robots: { index: false, follow: false },
+};
+
+export default async function LocaleNotFound({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "NotFound" });
+
+  const navLinks = [
+    { href: `/${locale}/yachts`, label: t("browseYachts") },
+    { href: `/${locale}/manufacturers`, label: t("manufacturers") },
+    { href: `/${locale}/guides`, label: t("guides") },
+    { href: `/${locale}/compare`, label: t("compare") },
+    { href: `/${locale}/search`, label: t("search") },
+  ];
+
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center px-4 py-12">
+      <div className="max-w-md w-full text-center space-y-8">
+        {/* 404 heading */}
+        <div className="relative">
+          <div className="text-[10rem] font-bold text-primary/10 leading-none select-none">
+            404
+          </div>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <svg
+              className="h-24 w-24 text-primary/40"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={0.75}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.58-5.84a14.927 14.927 0 0 1-2.58 5.841m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"
+              />
+            </svg>
+          </div>
+        </div>
+
+        {/* Message */}
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold text-foreground">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground">
+            {t("description")}
+          </p>
+        </div>
+
+        {/* Navigation links */}
+        <div className="space-y-3">
+          <Link
+            href={`/${locale}`}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {t("goHome")}
+          </Link>
+
+          <div className="pt-2">
+            <p className="text-xs text-muted-foreground uppercase tracking-wider mb-3">
+              {t("popularPages")}
+            </p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="inline-flex items-center rounded-full border border-input bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  robots: { index: false, follow: false },
+};
+
+export default function RootNotFound() {
+  return (
+    <html lang="en">
+      <body>
+        <div className="min-h-screen flex items-center justify-center bg-background px-4">
+          <div className="max-w-md w-full text-center space-y-6">
+            <div className="text-8xl font-bold text-primary/20">404</div>
+            <h1 className="text-2xl font-semibold text-foreground">
+              Page Not Found
+            </h1>
+            <p className="text-muted-foreground">
+              The page you&apos;re looking for doesn&apos;t exist or has been moved.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Go to homepage
+              </Link>
+              <Link
+                href="/yachts"
+                className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+              >
+                Browse yachts
+              </Link>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1153,5 +1153,16 @@
     "glossaryDescription": "We could not load the nautical glossary. Please try again.",
     "glossaryDetailTitle": "Term not available",
     "glossaryDetailDescription": "This glossary term could not be loaded. Please try again."
+  },
+  "NotFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has been moved.",
+    "goHome": "Go to homepage",
+    "popularPages": "Popular pages",
+    "browseYachts": "Browse Yachts",
+    "manufacturers": "Manufacturers",
+    "guides": "Sailing Guides",
+    "compare": "Compare Yachts",
+    "search": "Search"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1153,5 +1153,16 @@
     "glossaryDescription": "Nous n'avons pas pu charger le glossaire nautique. Veuillez réessayer.",
     "glossaryDetailTitle": "Terme non disponible",
     "glossaryDetailDescription": "Ce terme du glossaire n'a pas pu être chargé. Veuillez réessayer."
+  },
+  "NotFound": {
+    "title": "Page introuvable",
+    "description": "La page que vous recherchez n'existe pas ou a été déplacée.",
+    "goHome": "Aller à l'accueil",
+    "popularPages": "Pages populaires",
+    "browseYachts": "Parcourir les yachts",
+    "manufacturers": "Constructeurs",
+    "guides": "Guides de navigation",
+    "compare": "Comparer les yachts",
+    "search": "Recherche"
   }
 }

--- a/tests/not-found.test.ts
+++ b/tests/not-found.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("Not Found Pages", () => {
+  const projectRoot = resolve(__dirname, "..");
+
+  it("root not-found.tsx exists", () => {
+    const fullPath = resolve(projectRoot, "app/not-found.tsx");
+    expect(existsSync(fullPath)).toBe(true);
+  });
+
+  it("root not-found.tsx has noindex meta", () => {
+    const fullPath = resolve(projectRoot, "app/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("index: false");
+  });
+
+  it("root not-found.tsx has link to homepage", () => {
+    const fullPath = resolve(projectRoot, "app/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain('href="/"');
+  });
+
+  it("root not-found.tsx has link to browse yachts", () => {
+    const fullPath = resolve(projectRoot, "app/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain('href="/yachts"');
+  });
+
+  it("root not-found.tsx shows 404 heading", () => {
+    const fullPath = resolve(projectRoot, "app/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("404");
+  });
+
+  it("locale not-found.tsx exists", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/not-found.tsx");
+    expect(existsSync(fullPath)).toBe(true);
+  });
+
+  it("locale not-found.tsx has noindex meta", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("index: false");
+  });
+
+  it("locale not-found.tsx uses getTranslations for i18n", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("getTranslations");
+    expect(content).toContain("NotFound");
+  });
+
+  it("locale not-found.tsx has navigation links to popular pages", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("/yachts");
+    expect(content).toContain("/manufacturers");
+    expect(content).toContain("/guides");
+    expect(content).toContain("/compare");
+    expect(content).toContain("/search");
+  });
+
+  it("locale not-found.tsx shows 404 heading", () => {
+    const fullPath = resolve(projectRoot, "app/[locale]/not-found.tsx");
+    const content = readFileSync(fullPath, "utf-8");
+    expect(content).toContain("404");
+  });
+});
+
+describe("Not Found i18n Messages", () => {
+  const projectRoot = resolve(__dirname, "..");
+
+  const requiredKeys = [
+    "title",
+    "description",
+    "goHome",
+    "popularPages",
+    "browseYachts",
+    "manufacturers",
+    "guides",
+    "compare",
+    "search",
+  ];
+
+  it("en.json has all NotFound message keys", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    expect(en.NotFound).toBeTruthy();
+    for (const key of requiredKeys) {
+      expect(en.NotFound[key]).toBeTruthy();
+      expect(typeof en.NotFound[key]).toBe("string");
+    }
+  });
+
+  it("fr.json has all NotFound message keys", async () => {
+    const { default: fs } = await import("fs");
+    const fr = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    expect(fr.NotFound).toBeTruthy();
+    for (const key of requiredKeys) {
+      expect(fr.NotFound[key]).toBeTruthy();
+      expect(typeof fr.NotFound[key]).toBe("string");
+    }
+  });
+
+  it("en.json and fr.json have same NotFound keys", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const fr = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const enKeys = Object.keys(en.NotFound).sort();
+    const frKeys = Object.keys(fr.NotFound).sort();
+    expect(enKeys).toEqual(frKeys);
+  });
+});


### PR DESCRIPTION
- Add app/not-found.tsx (root level) with branded 404 page
- Add app/[locale]/not-found.tsx with full i18n support
  - Large 404 heading with sailing boat illustration
  - Friendly localized message
  - Links to popular pages (yachts, manufacturers, guides, compare, search)
  - Homepage link button
  - noindex meta tag
- Add NotFound translation namespace with 9 keys in en.json and fr.json
- 13 unit tests for file existence, content, and i18n validation
