### PR TITLE
feat: add scroll progress indicator & back-to-top button (closes #282)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 import { locales, type Locale } from "@/i18n";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { ClientNav } from "./ClientNav";
+import UXPolish from "@/components/UXPolish";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -111,6 +112,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
           </p>
         </div>
       </footer>
+      <UXPolish />
     </NextIntlClientProvider>
   );
 }

--- a/components/UXPolish.tsx
+++ b/components/UXPolish.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Dynamic imports to avoid adding to initial JS bundle
+const ScrollProgress = dynamic(() => import("@/components/ui/scroll-progress"), {
+  ssr: false,
+});
+
+const BackToTop = dynamic(() => import("@/components/ui/back-to-top"), {
+  ssr: false,
+});
+
+/**
+ * Client-side UX polish components that mount on every page.
+ * Uses dynamic imports to avoid SSR issues and reduce initial bundle.
+ */
+export default function UXPolish() {
+  return (
+    <>
+      <ScrollProgress />
+      <BackToTop />
+    </>
+  );
+}

--- a/components/ui/back-to-top.tsx
+++ b/components/ui/back-to-top.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
+
+interface BackToTopProps {
+  /** Scroll threshold in px before button appears (default: 300) */
+  threshold?: number;
+  /** Position from bottom in rem (default: 6) */
+  bottomRem?: number;
+  /** Position from right in rem (default: 6) */
+  rightRem?: number;
+}
+
+/**
+ * A floating "back to top" button that appears after scrolling down.
+ * Respects prefers-reduced-motion (instant scroll instead of smooth).
+ */
+export default function BackToTop({
+  threshold = 300,
+  bottomRem = 6,
+  rightRem = 6,
+}: BackToTopProps) {
+  const [visible, setVisible] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const t = useTranslations("UI");
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    setVisible(window.scrollY > threshold);
+  }, [threshold]);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const onScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          handleScroll();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    handleScroll(); // Initial check
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [handleScroll]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: reducedMotion ? "instant" : "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label={t("backToTop")}
+      className={`
+        fixed z-40 flex items-center justify-center
+        h-10 w-10 rounded-full
+        bg-primary text-primary-foreground
+        shadow-lg hover:bg-primary/90
+        transition-all duration-200
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+        ${visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-4 pointer-events-none"
+        }
+      `}
+      style={{ bottom: `${bottomRem}rem`, right: `${rightRem}rem` }}
+    >
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={2}
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4.5 15.75l7.5-7.5 7.5 7.5"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/components/ui/scroll-progress.tsx
+++ b/components/ui/scroll-progress.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface ScrollProgressProps {
+  /** Color class for the progress bar (default: bg-primary) */
+  colorClass?: string;
+  /** Height of the bar in pixels (default: 2) */
+  height?: number;
+  /** z-index for the fixed bar (default: 50) */
+  zIndex?: number;
+}
+
+/**
+ * A thin progress bar fixed to the top of the viewport that fills
+ * based on how far the user has scrolled down the page.
+ * Respects prefers-reduced-motion.
+ */
+export default function ScrollProgress({
+  colorClass = "bg-primary",
+  height = 2,
+  zIndex = 50,
+}: ScrollProgressProps) {
+  const [progress, setProgress] = useState(0);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  const updateProgress = useCallback(() => {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight <= 0) {
+      setProgress(0);
+      return;
+    }
+    setProgress(Math.min(scrollTop / docHeight, 1));
+  }, []);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const onScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          updateProgress();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    updateProgress(); // Initial calculation
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [updateProgress]);
+
+  // In reduced-motion mode, show a static full-width bar (indicates "scrollable content")
+  if (reducedMotion) {
+    return null;
+  }
+
+  const widthPercent = (progress * 100).toFixed(2);
+
+  return (
+    <div
+      className="fixed top-0 left-0 w-full pointer-events-none"
+      style={{ height: `${height}px`, zIndex }}
+      role="progressbar"
+      aria-valuenow={Math.round(progress * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Page scroll progress"
+    >
+      <div
+        className={`${colorClass} h-full transition-[width] duration-150 ease-out`}
+        style={{ width: `${widthPercent}%` }}
+      />
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1164,5 +1164,8 @@
     "guides": "Sailing Guides",
     "compare": "Compare Yachts",
     "search": "Search"
+  },
+  "UI": {
+    "backToTop": "Back to top"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1164,5 +1164,8 @@
     "guides": "Guides de navigation",
     "compare": "Comparer les yachts",
     "search": "Recherche"
+  },
+  "UI": {
+    "backToTop": "Retour en haut"
   }
 }

--- a/tests/scroll-ux.test.ts
+++ b/tests/scroll-ux.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const projectRoot = resolve(__dirname, "..");
+
+// ─── Component file tests ────────────────────────────────────────
+
+describe("Scroll Progress Component", () => {
+  const filePath = resolve(projectRoot, "components/ui/scroll-progress.tsx");
+
+  it("exists", () => {
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it("is a client component", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it("uses requestAnimationFrame for throttled scroll", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("requestAnimationFrame");
+  });
+
+  it("respects prefers-reduced-motion", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("prefers-reduced-motion");
+    expect(content).toContain("reduce");
+  });
+
+  it("has progressbar role for accessibility", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("role=\"progressbar\"");
+    expect(content).toContain("aria-valuenow");
+    expect(content).toContain("aria-valuemin");
+    expect(content).toContain("aria-valuemax");
+  });
+
+  it("uses passive scroll listener", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("passive: true");
+  });
+});
+
+describe("Back To Top Component", () => {
+  const filePath = resolve(projectRoot, "components/ui/back-to-top.tsx");
+
+  it("exists", () => {
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it("is a client component", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it("uses useTranslations for i18n aria-label", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("useTranslations");
+    expect(content).toContain("aria-label");
+    expect(content).toContain("backToTop");
+  });
+
+  it("has scroll threshold prop", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("threshold");
+  });
+
+  it("respects prefers-reduced-motion for scroll behavior", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("prefers-reduced-motion");
+    expect(content).toContain("instant");
+  });
+
+  it("has an up arrow SVG icon", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("<svg");
+    expect(content).toContain("M4.5 15.75l7.5-7.5 7.5 7.5");
+  });
+
+  it("uses requestAnimationFrame for throttled scroll", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("requestAnimationFrame");
+  });
+
+  it("has opacity/visibility transition", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("opacity-0");
+    expect(content).toContain("opacity-100");
+  });
+});
+
+describe("UXPolish Wrapper", () => {
+  const filePath = resolve(projectRoot, "components/UXPolish.tsx");
+
+  it("exists", () => {
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it("is a client component", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it("uses dynamic imports to reduce bundle", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("dynamic(");
+    expect(content).toContain("ssr: false");
+  });
+
+  it("imports both components", () => {
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("scroll-progress");
+    expect(content).toContain("back-to-top");
+  });
+});
+
+describe("Layout Integration", () => {
+  const layoutPath = resolve(projectRoot, "app/[locale]/layout.tsx");
+
+  it("layout imports UXPolish", () => {
+    const content = readFileSync(layoutPath, "utf-8");
+    expect(content).toContain("UXPolish");
+  });
+
+  it("UXPolish is rendered in layout", () => {
+    const content = readFileSync(layoutPath, "utf-8");
+    expect(content).toContain("<UXPolish />");
+  });
+});
+
+// ─── i18n tests ──────────────────────────────────────────────────
+
+describe("UI Translation Keys", () => {
+  it("en.json has backToTop key", async () => {
+    const { default: fs } = await import("fs");
+    const en = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    expect(en.UI).toBeTruthy();
+    expect(en.UI.backToTop).toBe("Back to top");
+  });
+
+  it("fr.json has backToTop key", async () => {
+    const { default: fs } = await import("fs");
+    const fr = JSON.parse(fs.readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    expect(fr.UI).toBeTruthy();
+    expect(fr.UI.backToTop).toBe("Retour en haut");
+  });
+});


### PR DESCRIPTION
- Add ScrollProgress component (components/ui/scroll-progress.tsx):
  - Thin fixed progress bar synced to scroll position
  - requestAnimationFrame-throttled scroll listener
  - Accessible: role=progressbar, aria-valuenow
  - Respects prefers-reduced-motion (hidden)
- Add BackToTop component (components/ui/back-to-top.tsx):
  - Floating button appears after 300px scroll
  - Smooth scroll to top (instant if prefers-reduced-motion)
  - i18n aria-label via UI.backToTop translation
  - Fade in/out animation
- Add UXPolish wrapper with dynamic imports (SSR: false)
- Integrate into locale layout for all pages
- Add UI.backToTop translation key in en.json and fr.json
- 22 unit tests for components, integration, and i18n
