### PR TITLE
feat: add error boundaries for account & favorites routes, expand i18n and tests (closes #284)

### DIFF
--- a/app/[locale]/account/error.tsx
+++ b/app/[locale]/account/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function AccountError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="accountTitle"
+      descriptionKey="accountDescription"
+      backHref="/"
+      backLabel="← Home"
+    />
+  );
+}

--- a/app/[locale]/favorites/error.tsx
+++ b/app/[locale]/favorites/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import ErrorBoundary from "../ErrorBoundary";
+
+export default function FavoritesError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      titleKey="favoritesTitle"
+      descriptionKey="favoritesDescription"
+      backHref="/"
+      backLabel="← Home"
+    />
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1152,7 +1152,11 @@
     "glossaryTitle": "Failed to load glossary",
     "glossaryDescription": "We could not load the nautical glossary. Please try again.",
     "glossaryDetailTitle": "Term not available",
-    "glossaryDetailDescription": "This glossary term could not be loaded. Please try again."
+    "glossaryDetailDescription": "This glossary term could not be loaded. Please try again.",
+    "accountTitle": "Account error",
+    "accountDescription": "We could not load your account. Please try again.",
+    "favoritesTitle": "Favorites error",
+    "favoritesDescription": "We could not load your favorites. Please try again."
   },
   "NotFound": {
     "title": "Page not found",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1152,7 +1152,11 @@
     "glossaryTitle": "Impossible de charger le glossaire",
     "glossaryDescription": "Nous n'avons pas pu charger le glossaire nautique. Veuillez réessayer.",
     "glossaryDetailTitle": "Terme non disponible",
-    "glossaryDetailDescription": "Ce terme du glossaire n'a pas pu être chargé. Veuillez réessayer."
+    "glossaryDetailDescription": "Ce terme du glossaire n'a pas pu être chargé. Veuillez réessayer.",
+    "accountTitle": "Erreur du compte",
+    "accountDescription": "Impossible de charger votre compte. Veuillez réessayer.",
+    "favoritesTitle": "Erreur des favoris",
+    "favoritesDescription": "Impossible de charger vos favoris. Veuillez réessayer."
   },
   "NotFound": {
     "title": "Page introuvable",

--- a/tests/error-boundaries.test.ts
+++ b/tests/error-boundaries.test.ts
@@ -20,6 +20,8 @@ describe("Error Boundary Files", () => {
     "app/[locale]/search/error.tsx",
     "app/[locale]/glossary/error.tsx",
     "app/[locale]/glossary/[slug]/error.tsx",
+    "app/[locale]/account/error.tsx",
+    "app/[locale]/favorites/error.tsx",
   ];
 
   it.each(errorFiles)("%s exists", (file) => {
@@ -96,6 +98,10 @@ describe("Error i18n Messages", () => {
     "glossaryDescription",
     "glossaryDetailTitle",
     "glossaryDetailDescription",
+    "accountTitle",
+    "accountDescription",
+    "favoritesTitle",
+    "favoritesDescription",
   ];
 
   it("en.json has all error message keys", async () => {


### PR DESCRIPTION
- Add error.tsx for /account and /favorites routes using shared ErrorBoundary
- Add account/favorites error messages in en.json and fr.json
- Expand error-boundaries test to cover 14 routes (was 12) and 4 new i18n keys
- All 49 tests pass
