### PR TITLE
feat: add unique og:image to manufacturer, compare, glossary & spotlight pages (closes #289)

### DIFF
--- a/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getYachtsBySlugs, generateComparisonIntro, generateComparisonMetadata, getPrimaryImage, type YachtComparisonData } from "@/lib/compare-canonical";
-import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd , buildLocaleAlternates } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 import { PriceTierBadge } from "@/app/components/PriceTierBadge";
 import { calculatePriceTier } from "@/lib/price-tier";
 import { CanonicalCompareClient } from "./CanonicalCompareClient";
@@ -37,11 +37,28 @@ export async function generateMetadata({
       url: getSiteUrl(`/compare/${slugA}-vs-${slugB}`),
       type: "website",
       siteName: "Sailing Yacht Info",
+      images: [{
+        url: buildOgImageUrl({
+          type: "compare",
+          title: `${yachtA.manufacturer} ${yachtA.modelName} vs ${yachtB.manufacturer} ${yachtB.modelName}`,
+          description: "Side-by-side comparison",
+          length: yachtA.lengthOverall ? `${yachtA.lengthOverall.toFixed(1)}m vs ${yachtB.lengthOverall ? yachtB.lengthOverall.toFixed(1) : "?"}m` : undefined,
+        }),
+        width: 1200,
+        height: 630,
+        alt: meta.title,
+      }],
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title: meta.title,
       description: meta.description,
+      images: [buildOgImageUrl({
+        type: "compare",
+        title: `${yachtA.manufacturer} ${yachtA.modelName} vs ${yachtB.manufacturer} ${yachtB.modelName}`,
+        description: "Side-by-side comparison",
+        length: yachtA.lengthOverall ? `${yachtA.lengthOverall.toFixed(1)}m vs ${yachtB.lengthOverall ? yachtB.lengthOverall.toFixed(1) : "?"}m` : undefined,
+      })],
     },
     alternates: buildLocaleAlternates(`/compare/${slugA}-vs-${slugB}`),
   };

--- a/app/[locale]/glossary/[slug]/page.tsx
+++ b/app/[locale]/glossary/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getTermBySlug, getRelatedTerms } from "@/lib/glossary";
-import { getSiteUrl, generateBreadcrumbJsonLd , buildLocaleAlternates } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 
 // ISR: Revalidate glossary term pages every 6 hours
 export const revalidate = 21600;
@@ -45,11 +45,13 @@ export async function generateMetadata({
       url: getSiteUrl(`/glossary/${slug}`),
       type: "website",
       siteName: "Sailing Yacht Info",
+      images: [{ url: buildOgImageUrl({ type: "glossary", title: term.term, description: term.category ?? undefined }), width: 1200, height: 630, alt: term.term }],
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title: `${term.term} – Sailing Glossary`,
       description,
+      images: [buildOgImageUrl({ type: "glossary", title: term.term, description: term.category ?? undefined })],
     },
     alternates: buildLocaleAlternates(`/glossary/${slug}`),
   };

--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   generateCollectionPageJsonLd,
   getSiteUrl,
   buildLocaleAlternates,
+  buildOgImageUrl,
 } from "@/lib/seo";
 import {
   getManufacturerBySlug,
@@ -97,13 +98,23 @@ export async function generateMetadata({
       url: getSiteUrl(`/manufacturers/${slug}`),
       type: "website",
       siteName: "Sailing Yacht Info",
-      images: [{ url: getSiteUrl("/api/og"), width: 1200, height: 630, alt: title }],
+      images: [{ url: buildOgImageUrl({
+        type: "manufacturer",
+        title: manufacturer.name,
+        description: manufacturer.country ?? undefined,
+        length: manufacturer.foundedYear ? `Est. ${manufacturer.foundedYear}` : undefined,
+      }), width: 1200, height: 630, alt: title }],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [getSiteUrl("/api/og")],
+      images: [buildOgImageUrl({
+        type: "manufacturer",
+        title: manufacturer.name,
+        description: manufacturer.country ?? undefined,
+        length: manufacturer.foundedYear ? `Est. ${manufacturer.foundedYear}` : undefined,
+      })],
     },
     alternates: buildLocaleAlternates(`/manufacturers/${slug}`),
   };

--- a/app/[locale]/manufacturers/[slug]/spotlight/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/spotlight/page.tsx
@@ -6,7 +6,7 @@ import { getTranslations } from "next-intl/server";
 import { marked } from "marked";
 
 import { getSpotlightBySlug } from "@/lib/manufacturer-spotlights";
-import { generateBreadcrumbJsonLd, getSiteUrl , buildLocaleAlternates } from "@/lib/seo";
+import { generateBreadcrumbJsonLd, getSiteUrl, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -90,13 +90,13 @@ export async function generateMetadata({
       url,
       type: "article",
       siteName: "Sailing Yacht Info",
-      images: [{ url: getSiteUrl("/api/og"), width: 1200, height: 630, alt: title }],
+      images: [{ url: buildOgImageUrl({ type: "manufacturer", title: spotlight.manufacturer.name, description: spotlight.manufacturer.country ?? undefined }), width: 1200, height: 630, alt: title }],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [getSiteUrl("/api/og")],
+      images: [buildOgImageUrl({ type: "manufacturer", title: spotlight.manufacturer.name, description: spotlight.manufacturer.country ?? undefined })],
     },
     alternates: buildLocaleAlternates(`/manufacturers/${slug}/spotlight`),
   };

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -16,9 +16,24 @@ function trimText(value: string | null, maxLength: number, fallback: string): st
     : normalized;
 }
 
+// Type-specific tag lines shown at the bottom of OG images
+const TYPE_TAGS: Record<string, string[]> = {
+  yacht: ["Specs", "Dimensions", "Comparisons"],
+  manufacturer: ["Models", "Specs", "Fleet Overview"],
+  compare: ["Side-by-Side", "Specs", "Ratios"],
+  guide: ["Buying Guide", "Expert Tips", "Resources"],
+  glossary: ["Terminology", "Definitions", "Reference"],
+  default: ["Specs", "Comparisons", "Reviews"],
+};
+
+function getTags(type: string | null): string[] {
+  return TYPE_TAGS[type ?? ""] ?? TYPE_TAGS.default;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
+  const type = searchParams.get("type") ?? "default";
   const title = trimText(searchParams.get("title"), 64, "Sailing Yacht Specs");
   const description = trimText(
     searchParams.get("description"),
@@ -26,6 +41,7 @@ export async function GET(request: Request) {
     "Manufacturer profile and dimensions",
   );
   const length = trimText(searchParams.get("length"), 24, "Detailed specs");
+  const tags = getTags(type);
 
   return new ImageResponse(
     (
@@ -168,11 +184,12 @@ export async function GET(request: Request) {
           }}
         >
           <div style={{ display: "flex", gap: "18px" }}>
-            <span>Specs</span>
-            <span>•</span>
-            <span>Comparisons</span>
-            <span>•</span>
-            <span>Reviews</span>
+            {tags.map((tag, i) => (
+              <span key={i}>
+                {i > 0 && <span style={{ marginRight: "18px" }}>•</span>}
+                {tag}
+              </span>
+            ))}
           </div>
           <div style={{ fontWeight: 600 }}>info.sailboats.fr</div>
         </div>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -32,12 +32,17 @@ export function buildLocaleAlternates(pathWithoutLocale: string): {
 }
 
 export function buildOgImageUrl(params: {
+  type?: "yacht" | "manufacturer" | "compare" | "guide" | "glossary" | "default";
   title: string;
   description?: string | null;
   length?: number | string | null;
 }): string {
   const searchParams = new URLSearchParams();
   searchParams.set("title", params.title);
+
+  if (params.type && params.type !== "default") {
+    searchParams.set("type", params.type);
+  }
 
   if (params.description) {
     searchParams.set("description", params.description);

--- a/tests/og-image.test.ts
+++ b/tests/og-image.test.ts
@@ -1,0 +1,120 @@
+/**
+ * OG Image Route Tests
+ * Verifies the dynamic OG image generation API and buildOgImageUrl utility
+ */
+
+import { describe, test, expect } from "vitest";
+import { buildOgImageUrl } from "@/lib/seo";
+
+describe("buildOgImageUrl", () => {
+  test("generates URL with title param", () => {
+    const url = buildOgImageUrl({ title: "Oceanis 40.1" });
+    expect(url).toContain("/api/og?");
+    expect(url).toContain("title=Oceanis+40.1");
+  });
+
+  test("includes description when provided", () => {
+    const url = buildOgImageUrl({ title: "Test", description: "Beneteau" });
+    expect(url).toContain("description=Beneteau");
+  });
+
+  test("includes length when number provided", () => {
+    const url = buildOgImageUrl({ title: "Test", length: 12.4 });
+    expect(url).toContain("length=12.4m+LOA");
+  });
+
+  test("includes length as string when provided", () => {
+    const url = buildOgImageUrl({ title: "Test", length: "Est. 1884" });
+    expect(url).toContain("length=Est.+1884");
+  });
+
+  test("omits description when null", () => {
+    const url = buildOgImageUrl({ title: "Test", description: null });
+    expect(url).not.toContain("description=");
+  });
+
+  test("omits length when undefined", () => {
+    const url = buildOgImageUrl({ title: "Test" });
+    expect(url).not.toContain("length=");
+  });
+
+  test("includes type when provided and not default", () => {
+    const url = buildOgImageUrl({ type: "manufacturer", title: "Beneteau" });
+    expect(url).toContain("type=manufacturer");
+  });
+
+  test("omits type when default", () => {
+    const url = buildOgImageUrl({ type: "default", title: "Test" });
+    expect(url).not.toContain("type=");
+  });
+
+  test("omits type when not provided", () => {
+    const url = buildOgImageUrl({ title: "Test" });
+    expect(url).not.toContain("type=");
+  });
+
+  test("generates manufacturer OG URL with all params", () => {
+    const url = buildOgImageUrl({
+      type: "manufacturer",
+      title: "Beneteau",
+      description: "France",
+      length: "Est. 1884",
+    });
+    expect(url).toContain("type=manufacturer");
+    expect(url).toContain("title=Beneteau");
+    expect(url).toContain("description=France");
+    expect(url).toContain("length=Est.+1884");
+  });
+
+  test("generates compare OG URL", () => {
+    const url = buildOgImageUrl({
+      type: "compare",
+      title: "Oceanis 40.1 vs Sun Odyssey 440",
+      description: "Side-by-side comparison",
+      length: "12.4m vs 13.2m",
+    });
+    expect(url).toContain("type=compare");
+    expect(url).toContain("title=Oceanis+40.1+vs+Sun+Odyssey+440");
+  });
+
+  test("generates glossary OG URL", () => {
+    const url = buildOgImageUrl({
+      type: "glossary",
+      title: "LOA",
+      description: "Hull & Forms",
+    });
+    expect(url).toContain("type=glossary");
+    expect(url).toContain("title=LOA");
+    expect(url).toContain("description=Hull+%26+Forms");
+  });
+});
+
+describe("OG image route (production)", () => {
+  const BASE = "https://info.sailboats.fr";
+
+  test("default OG image returns PNG", async () => {
+    const res = await fetch(`${BASE}/api/og?title=Test`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+    const buf = Buffer.from(await res.arrayBuffer());
+    // PNG magic bytes
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50); // P
+    expect(buf[2]).toBe(0x4e); // N
+    expect(buf[3]).toBe(0x47); // G
+  });
+
+  test("OG image with type param returns PNG", async () => {
+    const res = await fetch(`${BASE}/api/og?title=Beneteau&type=manufacturer&description=France`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+  });
+
+  test("OG image with compare type returns PNG", async () => {
+    const res = await fetch(
+      `${BASE}/api/og?title=Oceanis+40.1+vs+Sun+Odyssey+440&type=compare&description=Side-by-side&length=12.4m+vs+13.2m`
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+  });
+});


### PR DESCRIPTION
- Fix manufacturer detail pages to use dynamic OG images with name/country/year
- Fix manufacturer spotlight pages to use dynamic OG images
- Add OG images to compare pages (was missing entirely)
- Add OG images to glossary term pages
- Add type param to OG image route (yacht/manufacturer/compare/guide/glossary)
- Each type shows contextual tag line at bottom of image
- Update buildOgImageUrl to support type parameter
- Add 15 tests for buildOgImageUrl and OG image route
