### PR TITLE
fix: resolve 500 errors on glossary, best, and best-value pages

### DIFF
--- a/app/[locale]/best-value/[slug]/page.tsx
+++ b/app/[locale]/best-value/[slug]/page.tsx
@@ -82,9 +82,6 @@ export const BEST_VALUE_PAGES: BestValuePageDef[] = [
   },
 ];
 
-export async function generateStaticParams() {
-  return BEST_VALUE_PAGES.map((p) => ({ slug: p.slug }));
-}
 
 export async function generateMetadata({
   params,

--- a/app/[locale]/best/[slug]/page.tsx
+++ b/app/[locale]/best/[slug]/page.tsx
@@ -10,9 +10,6 @@ import { generateBreadcrumbJsonLd, getSiteUrl, generateCollectionPageJsonLd, gen
 export const revalidate = 21600;
 
 // Generate static params for all defined landing pages
-export async function generateStaticParams() {
-  return getAllLandingPageSlugs().map((slug) => ({ slug }));
-}
 
 // Generate metadata for each landing page
 export async function generateMetadata({

--- a/app/[locale]/glossary/[slug]/page.tsx
+++ b/app/[locale]/glossary/[slug]/page.tsx
@@ -57,15 +57,6 @@ export async function generateMetadata({
   };
 }
 
-export async function generateStaticParams() {
-  const terms = [
-    "loa", "beam", "draft", "displacement", "ballast", "ballast-ratio",
-    "fin-keel", "wing-keel", "cutter-rig", "sloop-rig", "ketch-rig",
-    "shoal-draft", "lwl", "hull-speed", "cabin", "berth", "head",
-    "bluewater", "coastal-cruiser", "liveaboard",
-  ];
-  return terms.map((slug) => ({ slug }));
-}
 
 export default async function GlossaryTermPage({ params }: GlossaryTermPageProps) {
   const { slug, locale } = await params;


### PR DESCRIPTION
Removes generateStaticParams from glossary/[slug], best/[slug], and best-value/[slug] pages that were causing 500 errors in production.

Root cause: generateStaticParams returning only {slug} without locale caused a runtime TypeError in the [locale] layout where params could not be resolved correctly for ISR pages.

Fix: Make these pages dynamic with ISR instead of statically generated.