### PR TITLE
feat: dynamic lastmod dates for all sitemaps (closes #293)

### DIFF
--- a/app/sitemap-compare.xml/route.ts
+++ b/app/sitemap-compare.xml/route.ts
@@ -12,7 +12,11 @@ async function getCompareEntries(): Promise<SitemapEntry[]> {
     async () => {
       // Fetch top 50 yachts by ID for comparison pairs
       const topYachts = await db
-        .select({ id: yachtModels.id, slug: yachtModels.slug })
+        .select({
+          id: yachtModels.id,
+          slug: yachtModels.slug,
+          updatedAt: yachtModels.updatedAt,
+        })
         .from(yachtModels)
         .where(isNotNull(yachtModels.slug))
         .limit(50)
@@ -26,10 +30,16 @@ async function getCompareEntries(): Promise<SitemapEntry[]> {
           const yachtB = topYachts[j];
 
           if (yachtA.slug && yachtB.slug) {
+            // Use the most recent updatedAt between the two yachts
+            const dateA = yachtA.updatedAt ? new Date(yachtA.updatedAt).getTime() : 0;
+            const dateB = yachtB.updatedAt ? new Date(yachtB.updatedAt).getTime() : 0;
+            const lastmod = new Date(Math.max(dateA, dateB)).toISOString();
+
             // Generate entries for both locales
             for (const locale of LOCALES) {
               entries.push({
                 loc: `${SITE_URL}/${locale}/compare/${yachtA.slug}-vs-${yachtB.slug}`,
+                lastmod,
                 changefreq: "monthly",
                 priority: "0.5",
               });

--- a/app/sitemap-manufacturers.xml/route.ts
+++ b/app/sitemap-manufacturers.xml/route.ts
@@ -1,8 +1,8 @@
 import { unstable_cache } from "next/cache";
-import { db, manufacturers, manufacturerSpotlights } from "@/lib/db";
+import { db, manufacturers, manufacturerSpotlights, yachtModels } from "@/lib/db";
 import { slugify } from "@/lib/utils/slugify";
 import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
-import { eq } from "drizzle-orm";
+import { eq, sql, max } from "drizzle-orm";
 
 export const revalidate = 3600;
 
@@ -11,17 +11,37 @@ const LOCALES = ["en", "fr"] as const;
 async function getManufacturerEntries(): Promise<SitemapEntry[]> {
   return unstable_cache(
     async () => {
+      // Get lastmod per manufacturer based on their most recently updated yacht
+      const lastModRows = await db
+        .select({
+          manufacturerId: manufacturers.id,
+          lastmod: sql<string>`COALESCE(MAX(${yachtModels.updatedAt}), ${manufacturers.createdAt})`,
+        })
+        .from(manufacturers)
+        .leftJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+        .groupBy(manufacturers.id);
+
+      const lastModMap = new Map<number, string>();
+      for (const row of lastModRows) {
+        lastModMap.set(
+          row.manufacturerId,
+          new Date(row.lastmod).toISOString()
+        );
+      }
+
       const mfrs = await db
         .select({
+          id: manufacturers.id,
           name: manufacturers.name,
         })
         .from(manufacturers);
 
       const manufacturerEntries: SitemapEntry[] = mfrs
         .filter((m: { name: string | null }) => m.name !== null)
-        .flatMap((m: { name: string | null }) =>
+        .flatMap((m: { id: number; name: string | null }) =>
           LOCALES.map((locale) => ({
             loc: `${SITE_URL}/${locale}/manufacturers/${slugify(m.name!)}`,
+            lastmod: lastModMap.get(m.id),
             changefreq: "weekly" as const,
             priority: "0.6",
           }))
@@ -49,7 +69,7 @@ async function getManufacturerEntries(): Promise<SitemapEntry[]> {
       return [...manufacturerEntries, ...spotlightEntries];
     },
     ["sitemap-manufacturers"],
-    { tags: ["manufacturers", "manufacturer-spotlights"], revalidate: 3600 }
+    { tags: ["manufacturers", "manufacturer-spotlights", "yachts"], revalidate: 3600 }
   )();
 }
 

--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -7,6 +7,9 @@ export const revalidate = 86400;
 const LOCALES = ["en", "fr"] as const;
 
 export async function GET() {
+  // Use current deploy time as lastmod for static pages
+  const deployDate = new Date().toISOString().split("T")[0];
+
   const pages = [
     { path: "/", changefreq: "daily", priority: "1.0" },
     { path: "/yachts", changefreq: "daily", priority: "0.9" },
@@ -28,6 +31,7 @@ export async function GET() {
   const entries: SitemapEntry[] = pages.flatMap((page) =>
     LOCALES.map((locale) => ({
       loc: `${SITE_URL}/${locale}${page.path === "/" ? "" : page.path}`,
+      lastmod: deployDate,
       changefreq: page.changefreq,
       priority: page.priority,
     }))


### PR DESCRIPTION
## Changes
- **Pages sitemap**: deploy-date lastmod for static pages (updates on every deploy)
- **Manufacturers sitemap**: lastmod from most recently updated yacht per manufacturer  
- **Compare sitemap**: lastmod from most recent yacht update in each comparison pair

Previously, pages/manufacturers/compare sitemaps had no lastmod at all, and the sitemap index showed the same timestamp for all sub-sitemaps.

## Before
- Pages: no lastmod
- Manufacturers: no lastmod
- Compare: no lastmod
- Index: all sub-sitemaps had same timestamp

## After
- Pages: deploy-date lastmod
- Manufacturers: per-manufacturer lastmod based on yacht data freshness
- Compare: per-pair lastmod based on the freshest yacht in the pair
- Index: unchanged (already used MAX(updatedAt) from yachts)

Closes #293