### PR TITLE
fix: breadcrumb structured data — add missing item URLs (closes #297)

### DIFF
--- a/app/[locale]/best-value/[slug]/page.tsx
+++ b/app/[locale]/best-value/[slug]/page.tsx
@@ -300,9 +300,11 @@ export default async function BestValuePage({
   const pageIntro = t(pageDef.introKey);
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: "Home", path: "/" },
     { name: "Yachts", path: "/yachts" },
+    
     { name: "Best Value", path: "/best-value" },
-    { name: pageTitle },
+    { name: pageTitle, path: `/best-value/${slug}` },
   ], locale);
 
   const collectionJsonLd = {

--- a/app/[locale]/best/[slug]/page.tsx
+++ b/app/[locale]/best/[slug]/page.tsx
@@ -89,9 +89,11 @@ export default async function LandingPage({
 
   // Generate JSON-LD structured data
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: "Home", path: "/" },
     { name: "Browse Yachts", path: "/yachts" },
+    
     { name: "Best Yachts", path: "/best" },
-    { name: pageDefinition.title },
+    { name: pageDefinition.title, path: `/best/${slug}` },
   ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({

--- a/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
@@ -105,8 +105,9 @@ export default async function CanonicalComparePage({
 
   // Generate JSON-LD structured data
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: "Home", path: "/" },
     { name: "Compare Yachts", path: "/compare" },
-    { name: `${fullNameA} vs ${fullNameB}` },
+    { name: `${fullNameA} vs ${fullNameB}`, path: `/compare/${slugA}-vs-${slugB}` },
   ], locale);
 
   // Generate individual yacht JSON-LD

--- a/app/[locale]/compare/page.tsx
+++ b/app/[locale]/compare/page.tsx
@@ -55,7 +55,7 @@ export default async function ComparePage({
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
-    { name: t("heading") },
+    { name: t("heading"), path: "/compare" },
   ], locale);
 
   return (

--- a/app/[locale]/glossary/[slug]/page.tsx
+++ b/app/[locale]/glossary/[slug]/page.tsx
@@ -70,9 +70,9 @@ export default async function GlossaryTermPage({ params }: GlossaryTermPageProps
   const relatedTerms = getRelatedTerms(term);
 
   const breadcrumbItems = [
-    { name: "Home", item: getSiteUrl("/") },
-    { name: "Glossary", item: getSiteUrl("/glossary") },
-    { name: term.term, item: getSiteUrl(`/glossary/${slug}`) },
+    { name: "Home", path: "/" },
+    { name: "Glossary", path: "/glossary" },
+    { name: term.term, path: `/glossary/${slug}` },
   ];
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd(breadcrumbItems);

--- a/app/[locale]/glossary/page.tsx
+++ b/app/[locale]/glossary/page.tsx
@@ -63,8 +63,8 @@ export default async function GlossaryPage({ params }: GlossaryPageProps) {
   ]);
 
   const breadcrumbItems = [
-    { name: "Home", item: getSiteUrl("/") },
-    { name: "Glossary", item: getSiteUrl("/glossary") },
+    { name: "Home", path: "/" },
+    { name: "Glossary", path: "/glossary" },
   ];
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd(breadcrumbItems);

--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -136,7 +136,7 @@ export default async function ManufacturerPage({
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
     { name: "Manufacturers", path: "/manufacturers" },
-    { name: manufacturer.name },
+    { name: manufacturer.name, path: `/manufacturers/${slug}` },
   ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({

--- a/app/[locale]/manufacturers/page.tsx
+++ b/app/[locale]/manufacturers/page.tsx
@@ -70,7 +70,7 @@ export default async function ManufacturersPage({ params }: ManufacturersListing
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
-    { name: "Manufacturers" },
+    { name: "Manufacturers", path: "/manufacturers" },
   ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({

--- a/app/[locale]/yachts/page.tsx
+++ b/app/[locale]/yachts/page.tsx
@@ -91,7 +91,7 @@ export default async function YachtsPage({ params, searchParams }: YachtsPagePar
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", path: "/" },
-    { name: t("heading") },
+    { name: t("heading"), path: "/yachts" },
   ], locale);
 
   const collectionJsonLd = generateCollectionPageJsonLd({


### PR DESCRIPTION
## Changes
Fixed all BreadcrumbList JSON-LD entries that were missing `item` URLs:

### Pages Fixed
- **yachts/page.tsx**: Added path to second breadcrumb item
- **compare/page.tsx**: Added path to second breadcrumb item
- **compare/[slugA]-vs-[slugB]**: Added Home entry + path to final item
- **manufacturers/page.tsx**: Added path to second breadcrumb item
- **manufacturers/[slug]**: Added path to final item
- **glossary/page.tsx**: Fixed wrong property (`item` → `path`)
- **glossary/[slug]**: Fixed wrong property (`item` → `path`)
- **best/[slug]**: Added Home entry + path to final item
- **best-value/[slug]**: Added Home entry + path to final item

### Before
Many breadcrumb levels had no `item` URL, causing Google Rich Results validation errors.

### After
All breadcrumb items at every level have valid URLs.

Closes #297