### PR TITLE
feat: configure explicit image remotePatterns and AVIF/WebP optimization (closes #296)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,13 +3,78 @@ const createNextIntlPlugin = require("next-intl/plugin");
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
+/**
+ * Image remote patterns — explicit allowlist of all external image sources.
+ * Replaces the previous hostname wildcard for better security and
+ * to let Next.js Image Optimization proxy these domains correctly.
+ */
+const imageRemotePatterns = [
+  // Stock / community photos
+  { protocol: "https", hostname: "images.unsplash.com" },
+  { protocol: "https", hostname: "images.boats.com" },
+  { protocol: "https", hostname: "images.boatsgroup.com" },
+
+  // Spec aggregator sites
+  { protocol: "https", hostname: "www.boat-specs.com" },
+  { protocol: "https", hostname: "sailboatdata.com" },
+  { protocol: "https", hostname: "itboat.ams3.digitaloceanspaces.com" },
+
+  // Yacht brokerage / listing platforms
+  { protocol: "https", hostname: "**.yachtworld.com" },
+  { protocol: "https", hostname: "frg-fps.azurewebsites.net" },
+
+  // Manufacturer sites — Beneteau Group
+  { protocol: "https", hostname: "www.beneteau.com" },
+  { protocol: "https", hostname: "app.jeanneau.com" },
+  { protocol: "https", hostname: "www.jeanneau.com" },
+  { protocol: "https", hostname: "admin.catamarans-lagoon.com" },
+
+  // Manufacturer sites — others
+  { protocol: "https", hostname: "www.bavariayachts.com" },
+  { protocol: "https", hostname: "www.dufour-yachts.com" },
+  { protocol: "https", hostname: "media.elan-yachts.com" },
+  { protocol: "https", hostname: "www.hallberg-rassy.com" },
+  { protocol: "https", hostname: "www.nautorswan.com" },
+  { protocol: "https", hostname: "www.x-yachts.com" },
+  { protocol: "https", hostname: "www.wauquiez.com" },
+  { protocol: "https", hostname: "www.grandsoleil.net" },
+  { protocol: "https", hostname: "www.solarisyachts.com" },
+  { protocol: "https", hostname: "www.rm-yachts.com" },
+  { protocol: "https", hostname: "www.sirius-yachts.com" },
+  { protocol: "https", hostname: "www.neel-trimarans.com" },
+  { protocol: "https", hostname: "www.delphiayachts.com" },
+  { protocol: "https", hostname: "www.catalinayachts.com" },
+
+  // Smaller / niche builders
+  { protocol: "https", hostname: "dragonfly.dk" },
+  { protocol: "http", hostname: "dragonfly.dk" },
+  { protocol: "https", hostname: "arconayachts.se" },
+  { protocol: "https", hostname: "mylius.it" },
+  { protocol: "https", hostname: "oysteryachts.com" },
+  { protocol: "https", hostname: "saffieryachts.com" },
+  { protocol: "https", hostname: "tartanyachts.com" },
+  { protocol: "https", hostname: "jboats.com" },
+  { protocol: "https", hostname: "amel.fr" },
+
+  // CMS / CDN
+  { protocol: "https", hostname: "a.storyblok.com" },
+  { protocol: "https", hostname: "cdn.prod.website-files.com" },
+  { protocol: "https", hostname: "vz-b5717c1c-a70.b-cdn.net" },
+  { protocol: "https", hostname: "www.yachtbroker-charters.com" },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   experimental: {
     instrumentationHook: true,
   },
-  images: { remotePatterns: [{ hostname: '**' }] },
+  images: {
+    remotePatterns: imageRemotePatterns,
+    formats: ["image/avif", "image/webp"],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256],
+  },
   async redirects() {
     return [
       // Common alternate names for the yacht listing page → redirect to /en locale

--- a/tests/image-optimization.test.ts
+++ b/tests/image-optimization.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+
+// Load the raw next.config.js (before wrappers)
+const fs = require('fs')
+const path = require('path')
+
+// We parse the config to extract the images section
+// Since next.config.js uses module.exports with wrappers, we extract the raw config inline
+function getRawImagesConfig() {
+  const content = fs.readFileSync(path.join(__dirname, '..', 'next.config.js'), 'utf-8')
+
+  // Extract the imageRemotePatterns array
+  const patternsMatch = content.match(/const imageRemotePatterns = \[([\s\S]*?)\];/)
+  if (!patternsMatch) throw new Error('Could not find imageRemotePatterns in next.config.js')
+
+  // Extract the images config object
+  const imagesMatch = content.match(/images:\s*\{([^}]+)\}/g)
+  if (!imagesMatch) throw new Error('Could not find images config in next.config.js')
+
+  // Parse formats
+  const formatsMatch = content.match(/formats:\s*\[([^\]]+)\]/)
+  const formats = formatsMatch
+    ? formatsMatch[1].split(',').map((s: string) => s.trim().replace(/["']/g, ''))
+    : []
+
+  // Parse deviceSizes
+  const deviceSizesMatch = content.match(/deviceSizes:\s*\[([^\]]+)\]/)
+  const deviceSizes = deviceSizesMatch
+    ? deviceSizesMatch[1].split(',').map((s: string) => parseInt(s.trim(), 10))
+    : []
+
+  // Parse imageSizes
+  const imageSizesMatch = content.match(/imageSizes:\s*\[([^\]]+)\]/)
+  const imageSizes = imageSizesMatch
+    ? imageSizesMatch[1].split(',').map((s: string) => parseInt(s.trim(), 10))
+    : []
+
+  // Count remote patterns by counting { protocol entries
+  const patternBlocks = patternsMatch[1].match(/\{[^}]+\}/g) || []
+
+  return { formats, deviceSizes, imageSizes, patternCount: patternBlocks.length, patternsRaw: patternsMatch[1] }
+}
+
+describe('Image optimization configuration', () => {
+  const config = getRawImagesConfig()
+
+  it('should have AVIF as the primary image format', () => {
+    expect(config.formats[0]).toBe('image/avif')
+  })
+
+  it('should have WebP as the fallback format', () => {
+    expect(config.formats[1]).toBe('image/webp')
+  })
+
+  it('should have at least 30 remote patterns for image sources', () => {
+    expect(config.patternCount).toBeGreaterThanOrEqual(30)
+  })
+
+  it('should include key image sources', () => {
+    const patterns = config.patternsRaw
+    expect(patterns).toContain('images.unsplash.com')
+    expect(patterns).toContain('images.boatsgroup.com')
+    expect(patterns).toContain('www.boat-specs.com')
+    expect(patterns).toContain('sailboatdata.com')
+    expect(patterns).toContain('www.beneteau.com')
+    expect(patterns).toContain('www.bavariayachts.com')
+    expect(patterns).toContain('www.x-yachts.com')
+  })
+
+  it('should have device sizes optimized for yacht images', () => {
+    expect(config.deviceSizes).toContain(640)
+    expect(config.deviceSizes).toContain(1200)
+    expect(config.deviceSizes).toContain(1920)
+  })
+
+  it('should have image sizes for thumbnails', () => {
+    expect(config.imageSizes).toContain(96)
+    expect(config.imageSizes).toContain(256)
+  })
+
+  it('should NOT use wildcard hostname pattern', () => {
+    const content = fs.readFileSync(path.join(__dirname, '..', 'next.config.js'), 'utf-8')
+    expect(content).not.toMatch(/hostname:\s*['"]\*\*['"]/)
+  })
+})


### PR DESCRIPTION
- Replace wildcard hostname '**' with explicit allowlist of 38 image source domains
- Enable AVIF (primary) and WebP (fallback) image format optimization
- Configure deviceSizes and imageSizes for responsive yacht images
- Add 7 tests validating image configuration
- All domains sourced from actual image URLs in the database
