### PR TITLE
feat: add glossary-to-yacht internal links for SEO topic clusters (closes #300)

### DIFF
--- a/app/[locale]/glossary/[slug]/page.tsx
+++ b/app/[locale]/glossary/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getTermBySlug, getRelatedTerms } from "@/lib/glossary";
+import { getYachtLinksForTerm } from "@/lib/glossary-yacht-links";
 import { getSiteUrl, generateBreadcrumbJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 
 // ISR: Revalidate glossary term pages every 6 hours
@@ -68,6 +69,7 @@ export default async function GlossaryTermPage({ params }: GlossaryTermPageProps
   }
 
   const relatedTerms = getRelatedTerms(term);
+  const yachtLinks = getYachtLinksForTerm(slug, locale);
 
   const breadcrumbItems = [
     { name: "Home", path: "/" },
@@ -123,6 +125,29 @@ export default async function GlossaryTermPage({ params }: GlossaryTermPageProps
             </p>
           </div>
         </section>
+
+        {/* Browse related yachts */}
+        {yachtLinks.length > 0 && (
+          <section className="max-w-5xl mx-auto px-4 py-8 border-t border-gray-200" data-testid="glossary-yacht-links">
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              {t("term.browseYachtsTitle")}
+            </h2>
+            <div className="flex flex-wrap gap-3">
+              {yachtLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="inline-flex items-center px-4 py-2.5 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition text-sm"
+                >
+                  {locale === "fr" ? link.labelFr : link.label}
+                  <svg className="ml-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Related Terms */}
         {relatedTerms.length > 0 && (

--- a/lib/glossary-yacht-links.ts
+++ b/lib/glossary-yacht-links.ts
@@ -1,0 +1,90 @@
+/**
+ * Maps glossary term slugs to relevant yacht browse links.
+ * Each entry provides 1-2 contextual links to filtered yacht listings
+ * or specific yacht pages, giving search engines crawlable internal links
+ * from glossary content to yacht discovery pages.
+ */
+
+export interface GlossaryYachtLink {
+  href: string
+  label: string   // en
+  labelFr: string  // fr
+}
+
+const LINK_MAP: Record<string, GlossaryYachtLink[]> = {
+  "loa": [
+    { href: "/yachts?filters[lengthMin]=12&filters[lengthMax]=15", label: "Browse yachts 12–15m", labelFr: "Yachts de 12 à 15 m" },
+    { href: "/yachts?filters[lengthMin]=15", label: "Browse yachts over 15m", labelFr: "Yachts de plus de 15 m" },
+  ],
+  "beam": [
+    { href: "/yachts?filters[lengthMin]=10&filters[lengthMax]=14", label: "Browse 10–14m cruising yachts", labelFr: "Yachts de croisière de 10 à 14 m" },
+  ],
+  "draft": [
+    { href: "/yachts?filters[lengthMin]=9&filters[lengthMax]=12", label: "Browse shallow-draft yachts", labelFr: "Yachts à faible tirant d'eau" },
+  ],
+  "displacement": [
+    { href: "/yachts?filters[lengthMin]=12", label: "Browse large displacement yachts", labelFr: "Yachts à déplacement lourds" },
+  ],
+  "ballast": [
+    { href: "/yachts?filters[lengthMin]=10&filters[lengthMax]=14", label: "Browse performance cruisers", labelFr: "Yachts de croisière performants" },
+  ],
+  "ballast-ratio": [
+    { href: "/yachts?filters[lengthMin]=10", label: "Compare yacht stability", labelFr: "Comparer la stabilité des yachts" },
+  ],
+  "fin-keel": [
+    { href: "/yachts?filters[keelType]=Fin+Keel", label: "Browse fin-keel yachts", labelFr: "Yachts à quille pendulaire" },
+  ],
+  "wing-keel": [
+    { href: "/yachts?filters[keelType]=Wing+Keel", label: "Browse wing-keel yachts", labelFr: "Yachts à quille ailettes" },
+  ],
+  "cutter-rig": [
+    { href: "/yachts?filters[rigType]=Cutter", label: "Browse cutter-rigged yachts", labelFr: "Yachts gréés en cotre" },
+  ],
+  "sloop-rig": [
+    { href: "/yachts?filters[rigType]=Sloop", label: "Browse sloop-rigged yachts", labelFr: "Yachts gréés en sloop" },
+  ],
+  "ketch-rig": [
+    { href: "/yachts?filters[rigType]=Ketch", label: "Browse ketch-rigged yachts", labelFr: "Yachts gréés en ketch" },
+  ],
+  "shoal-draft": [
+    { href: "/yachts?filters[keelType]=Shoal+Draft", label: "Browse shoal-draft yachts", labelFr: "Yachts à faible tirant d'eau" },
+  ],
+  "lwl": [
+    { href: "/yachts?filters[lengthMin]=9&filters[lengthMax]=12", label: "Browse medium-length yachts", labelFr: "Yachts de taille moyenne" },
+  ],
+  "hull-speed": [
+    { href: "/yachts?filters[lengthMin]=12", label: "Browse fast yachts", labelFr: "Yachts rapides" },
+  ],
+  "cabin": [
+    { href: "/yachts?filters[cabinsMin]=3", label: "Browse yachts with 3+ cabins", labelFr: "Yachts avec 3 cabines ou plus" },
+  ],
+  "berth": [
+    { href: "/yachts?filters[cabinsMin]=2", label: "Browse family-friendly yachts", labelFr: "Yachts familiaux" },
+  ],
+  "head": [
+    { href: "/yachts?filters[cabinsMin]=2", label: "Browse yachts with multiple heads", labelFr: "Yachts avec plusieurs salles d'eau" },
+  ],
+  "bluewater": [
+    { href: "/yachts?filters[lengthMin]=12", label: "Browse bluewater cruising yachts", labelFr: "Yachts pour la grande croisière" },
+    { href: "/compare", label: "Compare bluewater yachts", labelFr: "Comparer les yachts hauturiers" },
+  ],
+  "coastal-cruiser": [
+    { href: "/yachts?filters[lengthMin]=8&filters[lengthMax]=12", label: "Browse coastal cruising yachts", labelFr: "Yachts pour la croisière côtière" },
+  ],
+  "liveaboard": [
+    { href: "/yachts?filters[lengthMin]=12&filters[cabinsMin]=3", label: "Browse liveaboard yachts", labelFr: "Yachts pour vivre à bord" },
+  ],
+}
+
+/**
+ * Get yacht browse links for a glossary term slug.
+ * Returns an empty array if no relevant links are defined.
+ */
+export function getYachtLinksForTerm(slug: string, locale: string): GlossaryYachtLink[] {
+  const links = LINK_MAP[slug]
+  if (!links) return []
+  return links.map((link) => ({
+    ...link,
+    href: `/${locale}${link.href}`,
+  }))
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -952,7 +952,8 @@
       "relatedTerms": "Related Terms",
       "exploreMoreTitle": "Explore More Terms",
       "exploreMoreDescription": "Browse our complete sailing glossary to learn more about nautical terminology and yacht specifications.",
-      "viewAllTerms": "View All Glossary Terms"
+      "viewAllTerms": "View All Glossary Terms",
+      "browseYachtsTitle": "Browse Related Yachts"
     }
   },
   "BestValue": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -952,7 +952,8 @@
       "relatedTerms": "Termes associés",
       "exploreMoreTitle": "Explorer plus de termes",
       "exploreMoreDescription": "Parcourez notre glossaire nautique complet pour en savoir plus sur la terminologie nautique et les spécifications de yachts.",
-      "viewAllTerms": "Voir tous les termes du glossaire"
+      "viewAllTerms": "Voir tous les termes du glossaire",
+      "browseYachtsTitle": "Explorer les yachts correspondants"
     }
   },
   "BestValue": {

--- a/tests/glossary-yacht-links.test.ts
+++ b/tests/glossary-yacht-links.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { getYachtLinksForTerm } from '@/lib/glossary-yacht-links'
+
+describe('Glossary yacht links', () => {
+  it('should return links for keel-type terms', () => {
+    const links = getYachtLinksForTerm('fin-keel', 'en')
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0].href).toContain('/en/yachts')
+    expect(links[0].href).toContain('keelType')
+  })
+
+  it('should return links for rig-type terms', () => {
+    const sloop = getYachtLinksForTerm('sloop-rig', 'en')
+    expect(sloop.length).toBeGreaterThan(0)
+    expect(sloop[0].href).toContain('rigType')
+
+    const ketch = getYachtLinksForTerm('ketch-rig', 'en')
+    expect(ketch.length).toBeGreaterThan(0)
+  })
+
+  it('should return links for dimension terms', () => {
+    const loa = getYachtLinksForTerm('loa', 'en')
+    expect(loa.length).toBeGreaterThanOrEqual(2)
+    expect(loa[0].href).toContain('lengthMin')
+  })
+
+  it('should return links for use-case terms', () => {
+    const bw = getYachtLinksForTerm('bluewater', 'en')
+    expect(bw.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should use French locale in href when locale is fr', () => {
+    const links = getYachtLinksForTerm('fin-keel', 'fr')
+    expect(links[0].href).toContain('/fr/yachts')
+  })
+
+  it('should return empty array for unknown terms', () => {
+    expect(getYachtLinksForTerm('nonexistent-term', 'en')).toEqual([])
+  })
+
+  it('should cover all 20 glossary slugs with at least one link', () => {
+    const slugs = [
+      'loa', 'beam', 'draft', 'displacement', 'ballast', 'ballast-ratio',
+      'fin-keel', 'wing-keel', 'cutter-rig', 'sloop-rig', 'ketch-rig',
+      'shoal-draft', 'lwl', 'hull-speed', 'cabin', 'berth', 'head',
+      'bluewater', 'coastal-cruiser', 'liveaboard',
+    ]
+    let covered = 0
+    for (const slug of slugs) {
+      const links = getYachtLinksForTerm(slug, 'en')
+      if (links.length > 0) covered++
+    }
+    // At least 18 of 20 terms should have yacht links
+    expect(covered).toBeGreaterThanOrEqual(18)
+  })
+
+  it('should have French labels on all links', () => {
+    const links = getYachtLinksForTerm('loa', 'en')
+    for (const link of links) {
+      expect(link.labelFr).toBeTruthy()
+      expect(link.labelFr.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
- Add contextual yacht browse links to all 20 glossary term pages
- Links use relevant search filters (keelType, rigType, lengthMin/Max, cabinsMin)
- Bilingual labels (en + fr) for all link buttons
- 8 unit tests covering link generation, locale handling, and coverage
- Add browseYachtsTitle i18n key to en.json and fr.json
- All links are crawlable <a> tags with descriptive anchor text
