### PR TITLE
feat: add spec completeness audit admin page (closes #304)

### DIFF
--- a/app/admin/completeness/page.tsx
+++ b/app/admin/completeness/page.tsx
@@ -1,0 +1,247 @@
+import { requireAdmin } from '@/lib/admin-auth'
+import { headers } from 'next/headers'
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+interface YachtAuditEntry {
+  id: number
+  modelName: string
+  manufacturer: string
+  year: number | null
+  slug: string | null
+  score: number
+  level: { label: string; color: string; bgColor: string; textColor: string }
+  missingFields: string[]
+  missingCount: number
+  mediaCount: number
+}
+
+interface AuditStats {
+  totalYachts: number
+  averageScore: number
+  scoreDistribution: {
+    comprehensive: number
+    good: number
+    partial: number
+    basic: number
+    minimal: number
+  }
+  topMissingFields: { field: string; count: number; percentage: number }[]
+  categoryCompletion: Record<string, { label: string; completionRate: number; weight: number }>
+}
+
+export default async function AdminCompletenessPage() {
+  await requireAdmin()
+
+  let stats: AuditStats | null = null
+  let needsAttention: YachtAuditEntry[] = []
+  let fetchError: string | null = null
+
+  try {
+    const headersList = headers()
+    const host = headersList.get('x-forwarded-host') ?? headersList.get('host')
+    const proto = headersList.get('x-forwarded-proto') ?? 'http'
+    const baseUrl = host ? `${proto}://${host}` : 'http://localhost:3000'
+    const res = await fetch(`${baseUrl}/api/admin/completeness`, {
+      cache: 'no-store',
+      headers: { cookie: headersList.get('cookie') ?? '' },
+    })
+    if (!res.ok) throw new Error('Failed to fetch audit data')
+    const data = await res.json()
+    stats = data.stats
+    needsAttention = data.needsAttention ?? []
+  } catch (error) {
+    fetchError = error instanceof Error ? error.message : 'Unknown error'
+  }
+
+  if (!stats) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-8">
+        <div className="max-w-6xl mx-auto">
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+            Error loading audit: {fetchError}
+          </div>
+          <Link href="/admin" className="mt-4 inline-block text-blue-600 hover:underline">
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const dist = stats.scoreDistribution
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Spec Completeness Audit</h1>
+          <Link
+            href="/admin"
+            className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition duration-200"
+          >
+            Back to Dashboard
+          </Link>
+        </div>
+
+        {/* Summary Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <p className="text-sm font-medium text-gray-500">Total Yachts</p>
+            <p className="text-3xl font-bold text-gray-900">{stats.totalYachts}</p>
+          </div>
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <p className="text-sm font-medium text-gray-500">Average Score</p>
+            <p className="text-3xl font-bold text-blue-600">{stats.averageScore}%</p>
+          </div>
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <p className="text-sm font-medium text-gray-500">Low Quality (&lt;30%)</p>
+            <p className="text-3xl font-bold text-red-600">{dist.minimal + dist.basic}</p>
+          </div>
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <p className="text-sm font-medium text-gray-500">High Quality (≥80%)</p>
+            <p className="text-3xl font-bold text-green-600">{dist.comprehensive}</p>
+          </div>
+        </div>
+
+        {/* Score Distribution */}
+        <div className="bg-white rounded-lg shadow-sm border p-6 mb-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Score Distribution</h2>
+          <div className="space-y-3">
+            {[
+              { label: 'Comprehensive (80-100%)', count: dist.comprehensive, color: 'bg-green-500', textColor: 'text-green-700' },
+              { label: 'Good (60-79%)', count: dist.good, color: 'bg-blue-500', textColor: 'text-blue-700' },
+              { label: 'Partial (40-59%)', count: dist.partial, color: 'bg-yellow-500', textColor: 'text-yellow-700' },
+              { label: 'Basic (20-39%)', count: dist.basic, color: 'bg-orange-500', textColor: 'text-orange-700' },
+              { label: 'Minimal (0-19%)', count: dist.minimal, color: 'bg-red-500', textColor: 'text-red-700' },
+            ].map(({ label, count, color, textColor }) => (
+              <div key={label} className="flex items-center gap-3">
+                <span className="text-sm text-gray-600 w-48">{label}</span>
+                <div className="flex-1 bg-gray-200 rounded-full h-5 overflow-hidden">
+                  <div
+                    className={`h-full ${color} rounded-full transition-all`}
+                    style={{ width: `${stats.totalYachts > 0 ? (count / stats.totalYachts) * 100 : 0}%` }}
+                  />
+                </div>
+                <span className={`text-sm font-medium ${textColor} w-16 text-right`}>{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          {/* Category Completion */}
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Category Completion</h2>
+            <div className="space-y-3">
+              {Object.entries(stats.categoryCompletion).map(([key, cat]) => (
+                <div key={key}>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="text-gray-600">{cat.label}</span>
+                    <span className="font-medium text-gray-900">{cat.completionRate}%</span>
+                  </div>
+                  <div className="bg-gray-200 rounded-full h-3 overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        cat.completionRate >= 80 ? 'bg-green-500' :
+                        cat.completionRate >= 60 ? 'bg-blue-500' :
+                        cat.completionRate >= 40 ? 'bg-yellow-500' :
+                        'bg-red-500'
+                      }`}
+                      style={{ width: `${cat.completionRate}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Top Missing Fields */}
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Most Commonly Missing Fields</h2>
+            <div className="space-y-2">
+              {stats.topMissingFields.map(({ field, count, percentage }) => (
+                <div key={field} className="flex items-center justify-between py-1.5 border-b border-gray-100 last:border-0">
+                  <span className="text-sm text-gray-700 font-mono">{field}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-500">{count} yachts</span>
+                    <span className="text-sm font-medium text-red-600">{percentage}%</span>
+                  </div>
+                </div>
+              ))}
+              {stats.topMissingFields.length === 0 && (
+                <p className="text-gray-500 text-sm text-center py-4">All fields populated!</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Yachts Needing Attention */}
+        <div className="bg-white rounded-lg shadow-sm border p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">
+            Yachts Needing Attention (sorted by lowest score)
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Model</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Manufacturer</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Year</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Score</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Level</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Missing Fields</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Media</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {needsAttention.map((yacht) => (
+                  <tr key={yacht.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{yacht.modelName}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{yacht.manufacturer}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{yacht.year ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="w-16 bg-gray-200 rounded-full h-2">
+                          <div
+                            className={`h-full rounded-full ${yacht.level.color}`}
+                            style={{ width: `${yacht.score}%` }}
+                          />
+                        </div>
+                        <span className="text-sm font-medium">{yacht.score}%</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${yacht.level.bgColor} ${yacht.level.textColor}`}>
+                        {yacht.level.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 max-w-xs truncate" title={yacht.missingFields.join(', ')}>
+                      {yacht.missingCount} fields: {yacht.missingFields.slice(0, 3).join(', ')}{yacht.missingCount > 3 ? '...' : ''}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{yacht.mediaCount}</td>
+                    <td className="px-4 py-3 text-sm">
+                      <Link
+                        href={`/admin/yachts/${yacht.id}/edit`}
+                        prefetch={false}
+                        className="text-blue-600 hover:text-blue-800 px-2 py-1 rounded text-xs bg-blue-50"
+                      >
+                        Edit
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {needsAttention.length === 0 && (
+            <p className="text-gray-500 text-center py-8">No yachts found.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -101,6 +101,17 @@ export default async function AdminPage() {
               >
                 Manage Subscribers
               </a>
+
+            <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Completeness Audit</h2>
+              <p className="text-gray-600 mb-4">Analyze yacht spec completeness and identify data gaps.</p>
+              <a
+                href="/admin/completeness"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                View Audit Report
+              </a>
+            </div>
             </div>
           </div>
         </div>

--- a/app/api/admin/completeness/route.ts
+++ b/app/api/admin/completeness/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from 'next/server'
+import { ensureSchema, pool } from '@/lib/db'
+import {
+  calculateCompletenessScore,
+  getCompletenessLevel,
+  getMissingFields,
+  calculateAverageScore,
+  SPEC_CATEGORIES,
+} from '@/lib/completeness'
+
+export const dynamic = 'force-dynamic'
+
+interface YachtRow {
+  id: number
+  model_name: string
+  manufacturer_name: string | null
+  year: number | null
+  slug: string | null
+  length_overall: string | number | null
+  beam: string | number | null
+  draft: string | number | null
+  displacement: string | number | null
+  ballast: string | number | null
+  sail_area_main: string | number | null
+  rig_type: string | null
+  keel_type: string | null
+  hull_material: string | null
+  cabins: number | null
+  berths: number | null
+  heads: number | null
+  engine_hp: string | number | null
+  engine_type: string | null
+  fuel_capacity: string | number | null
+  water_capacity: string | number | null
+  description: string | null
+  design_notes: string | null
+  source_url: string | null
+  completeness_score: number | null
+  media_count: number | null
+}
+
+export async function GET() {
+  try {
+    await ensureSchema()
+
+    const result = await pool.query(`
+      SELECT
+        y.id,
+        y.model_name,
+        m.name AS manufacturer_name,
+        y.year,
+        y.slug,
+        y.length_overall,
+        y.beam,
+        y.draft,
+        y.displacement,
+        y.ballast,
+        y.sail_area_main,
+        y.rig_type,
+        y.keel_type,
+        y.hull_material,
+        y.cabins,
+        y.berths,
+        y.heads,
+        y.engine_hp,
+        y.engine_type,
+        y.fuel_capacity,
+        y.water_capacity,
+        y.description,
+        y.design_notes,
+        y.source_url,
+        y.completeness_score,
+        COALESCE(y.media_count, 0) AS media_count
+      FROM yacht_models y
+      LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+      ORDER BY y.id
+    `)
+
+    const yachts = result.rows.map((row: YachtRow) => {
+      const mapped = {
+        lengthOverall: row.length_overall,
+        beam: row.beam,
+        draft: row.draft,
+        displacement: row.displacement,
+        ballast: row.ballast,
+        sailAreaMain: row.sail_area_main,
+        rigType: row.rig_type,
+        keelType: row.keel_type,
+        hullMaterial: row.hull_material,
+        cabins: row.cabins,
+        berths: row.berths,
+        heads: row.heads,
+        engineHp: row.engine_hp,
+        engineType: row.engine_type,
+        fuelCapacity: row.fuel_capacity,
+        waterCapacity: row.water_capacity,
+        description: row.description,
+        designNotes: row.design_notes,
+      }
+
+      const score = calculateCompletenessScore(mapped)
+      const missingFields = getMissingFields(mapped)
+      const level = getCompletenessLevel(score)
+
+      return {
+        id: row.id,
+        modelName: row.model_name,
+        manufacturer: row.manufacturer_name ?? 'Unknown',
+        year: row.year,
+        slug: row.slug,
+        score,
+        level,
+        missingFields,
+        missingCount: missingFields.length,
+        mediaCount: Number(row.media_count) || 0,
+        storedScore: row.completeness_score,
+      }
+    })
+
+    // Compute stats
+    const totalYachts = yachts.length
+    const averageScore = calculateAverageScore(
+      yachts.map((y) => ({
+        lengthOverall: 1, beam: 1, draft: 1, displacement: 1, ballast: 1,
+        sailAreaMain: 1, rigType: 'x', keelType: 'x', hullMaterial: 'x',
+        cabins: 1, berths: 1, heads: 1, engineHp: 1, engineType: 'x',
+        fuelCapacity: 1, waterCapacity: 1, description: 'x', designNotes: 'x',
+        // Override with actual score
+        _score: y.score,
+      }))
+    )
+
+    const scoreDistribution = {
+      comprehensive: yachts.filter((y) => y.score >= 80).length,
+      good: yachts.filter((y) => y.score >= 60 && y.score < 80).length,
+      partial: yachts.filter((y) => y.score >= 40 && y.score < 60).length,
+      basic: yachts.filter((y) => y.score >= 20 && y.score < 40).length,
+      minimal: yachts.filter((y) => y.score < 20).length,
+    }
+
+    // Most commonly missing fields across all yachts
+    const missingFieldCounts: Record<string, number> = {}
+    for (const yacht of yachts) {
+      for (const field of yacht.missingFields) {
+        missingFieldCounts[field] = (missingFieldCounts[field] || 0) + 1
+      }
+    }
+    const topMissingFields = Object.entries(missingFieldCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([field, count]) => ({ field, count, percentage: Math.round((count / totalYachts) * 100) }))
+
+    // Yachts needing the most attention (lowest scores)
+    const needsAttention = [...yachts]
+      .sort((a, b) => a.score - b.score)
+      .slice(0, 50)
+
+    // Recalculate average properly
+    const avgScore = totalYachts > 0
+      ? Math.round(yachts.reduce((sum, y) => sum + y.score, 0) / totalYachts)
+      : 0
+
+    // Category completion rates
+    const categoryCompletion: Record<string, { label: string; completionRate: number; weight: number }> = {}
+    for (const [key, category] of Object.entries(SPEC_CATEGORIES)) {
+      const label = key.charAt(0).toUpperCase() + key.slice(1)
+      let populated = 0
+      let total = yachts.length * category.fields.length
+      for (const yacht of yachts) {
+        for (const field of category.fields) {
+          if (!yacht.missingFields.includes(field)) {
+            populated++
+          }
+        }
+      }
+      categoryCompletion[key] = {
+        label,
+        completionRate: total > 0 ? Math.round((populated / total) * 100) : 0,
+        weight: category.weight,
+      }
+    }
+
+    return NextResponse.json({
+      stats: {
+        totalYachts,
+        averageScore: avgScore,
+        scoreDistribution,
+        topMissingFields,
+        categoryCompletion,
+      },
+      needsAttention,
+    })
+  } catch (error) {
+    console.error('Failed to compute completeness audit:', error)
+    return NextResponse.json(
+      { error: 'Failed to compute completeness audit' },
+      { status: 500 }
+    )
+  }
+}

--- a/tests/completeness.test.ts
+++ b/tests/completeness.test.ts
@@ -4,6 +4,8 @@ import {
   getCompletenessLevel,
   shouldNoindex,
   getMissingFields,
+  calculateAverageScore,
+  SPEC_CATEGORIES,
 } from "../lib/completeness";
 
 describe("calculateCompletenessScore", () => {
@@ -52,32 +54,79 @@ describe("calculateCompletenessScore", () => {
     };
     expect(calculateCompletenessScore(withEmpty)).toBe(0);
   });
+
+  it("returns partial score for half-filled record", () => {
+    const half = {
+      lengthOverall: 10.5,
+      beam: 3.5,
+      draft: 2.0,
+      rigType: "Sloop",
+      keelType: "Fin keel",
+      hullMaterial: "Fiberglass",
+      cabins: 3,
+      engineHp: 30,
+      fuelCapacity: 120,
+      description: "A nice yacht",
+    };
+    const score = calculateCompletenessScore(half);
+    expect(score).toBeGreaterThan(30);
+    expect(score).toBeLessThan(80);
+  });
+
+  it("returns consistent score regardless of field order", () => {
+    const a = { lengthOverall: 10, beam: 3, draft: 2 };
+    const b = { draft: 2, beam: 3, lengthOverall: 10 };
+    expect(calculateCompletenessScore(a)).toBe(calculateCompletenessScore(b));
+  });
+
+  it("handles zero numeric values as populated", () => {
+    const withZero = {
+      cabins: 0,
+      berths: 0,
+      heads: 0,
+    };
+    const score = calculateCompletenessScore(withZero);
+    expect(score).toBeGreaterThan(0);
+  });
 });
 
 describe("getCompletenessLevel", () => {
   it("returns Comprehensive for 80+", () => {
-    const level = getCompletenessLevel(85);
-    expect(level.label).toBe("Comprehensive");
+    expect(getCompletenessLevel(85).label).toBe("Comprehensive");
+    expect(getCompletenessLevel(100).label).toBe("Comprehensive");
+    expect(getCompletenessLevel(80).label).toBe("Comprehensive");
   });
 
   it("returns Good for 60-79", () => {
-    const level = getCompletenessLevel(65);
-    expect(level.label).toBe("Good");
+    expect(getCompletenessLevel(65).label).toBe("Good");
+    expect(getCompletenessLevel(60).label).toBe("Good");
+    expect(getCompletenessLevel(79).label).toBe("Good");
   });
 
   it("returns Partial for 40-59", () => {
-    const level = getCompletenessLevel(50);
-    expect(level.label).toBe("Partial");
+    expect(getCompletenessLevel(50).label).toBe("Partial");
+    expect(getCompletenessLevel(40).label).toBe("Partial");
+    expect(getCompletenessLevel(59).label).toBe("Partial");
   });
 
   it("returns Basic for 20-39", () => {
-    const level = getCompletenessLevel(25);
-    expect(level.label).toBe("Basic");
+    expect(getCompletenessLevel(25).label).toBe("Basic");
+    expect(getCompletenessLevel(20).label).toBe("Basic");
+    expect(getCompletenessLevel(39).label).toBe("Basic");
   });
 
   it("returns Minimal for < 20", () => {
-    const level = getCompletenessLevel(10);
-    expect(level.label).toBe("Minimal");
+    expect(getCompletenessLevel(10).label).toBe("Minimal");
+    expect(getCompletenessLevel(0).label).toBe("Minimal");
+    expect(getCompletenessLevel(19).label).toBe("Minimal");
+  });
+
+  it("always returns all required display properties", () => {
+    const level = getCompletenessLevel(50);
+    expect(level).toHaveProperty("label");
+    expect(level).toHaveProperty("color");
+    expect(level).toHaveProperty("bgColor");
+    expect(level).toHaveProperty("textColor");
   });
 });
 
@@ -85,6 +134,7 @@ describe("shouldNoindex", () => {
   it("returns true for scores below 30", () => {
     expect(shouldNoindex(20)).toBe(true);
     expect(shouldNoindex(0)).toBe(true);
+    expect(shouldNoindex(29)).toBe(true);
   });
 
   it("returns false for scores at or above 30", () => {
@@ -92,12 +142,21 @@ describe("shouldNoindex", () => {
     expect(shouldNoindex(50)).toBe(false);
     expect(shouldNoindex(100)).toBe(false);
   });
+
+  it("supports custom threshold", () => {
+    expect(shouldNoindex(40, 50)).toBe(true);
+    expect(shouldNoindex(50, 50)).toBe(false);
+  });
 });
 
 describe("getMissingFields", () => {
   it("returns all fields for empty record", () => {
     const missing = getMissingFields({});
-    expect(missing.length).toBeGreaterThan(10);
+    const totalFields = Object.values(SPEC_CATEGORIES).reduce(
+      (sum, cat) => sum + cat.fields.length,
+      0
+    );
+    expect(missing.length).toBe(totalFields);
   });
 
   it("returns empty array for fully populated record", () => {
@@ -121,12 +180,68 @@ describe("getMissingFields", () => {
       description: "A fine yacht",
       designNotes: "Some notes",
     };
-    // sourceUrl is checked separately in our migration score, but not in SPEC_CATEGORIES
     const missing = getMissingFields(full);
-    // designNotes might still be listed if it's in SPEC_CATEGORIES
-    // Check no core fields are missing
+    expect(missing).toEqual([]);
+  });
+
+  it("returns only missing fields for partial record", () => {
+    const partial = {
+      lengthOverall: 10.5,
+      beam: 3.5,
+    };
+    const missing = getMissingFields(partial);
+    expect(missing).toContain("draft");
+    expect(missing).toContain("displacement");
     expect(missing).not.toContain("lengthOverall");
     expect(missing).not.toContain("beam");
-    expect(missing).not.toContain("draft");
+  });
+
+  it("treats empty strings as missing", () => {
+    const withEmpty = {
+      rigType: "",
+      keelType: "  ",
+    };
+    const missing = getMissingFields(withEmpty);
+    expect(missing).toContain("rigType");
+    expect(missing).toContain("keelType");
+  });
+});
+
+describe("calculateAverageScore", () => {
+  it("returns 0 for empty array", () => {
+    expect(calculateAverageScore([])).toBe(0);
+  });
+
+  it("returns score of single yacht", () => {
+    const yachts = [{ lengthOverall: 10.5, beam: 3.5, draft: 2.0 }];
+    expect(calculateAverageScore(yachts)).toBe(30);
+  });
+
+  it("averages multiple yachts", () => {
+    const yachts = [
+      { lengthOverall: 10.5, beam: 3.5, draft: 2.0 }, // 30
+      { lengthOverall: 10.5, beam: 3.5, draft: 2.0, displacement: 6000 }, // 30 + 4 = 34
+    ];
+    const avg = calculateAverageScore(yachts);
+    expect(avg).toBe(32); // (30 + 34) / 2 = 32
+  });
+});
+
+describe("SPEC_CATEGORIES", () => {
+  it("has weights summing to 100", () => {
+    const totalWeight = Object.values(SPEC_CATEGORIES).reduce(
+      (sum, cat) => sum + cat.weight,
+      0
+    );
+    expect(totalWeight).toBe(100);
+  });
+
+  it("has unique field names across categories", () => {
+    const allFields: string[] = [];
+    for (const cat of Object.values(SPEC_CATEGORIES)) {
+      allFields.push(...cat.fields);
+    }
+    const uniqueFields = new Set(allFields);
+    expect(uniqueFields.size).toBe(allFields.length);
   });
 });


### PR DESCRIPTION
- Add /api/admin/completeness API endpoint with yacht scoring stats
- Add /admin/completeness page with score distribution, category breakdown,
  top missing fields, and yacht attention list
- Add link to audit page from admin dashboard
- Expand completeness tests (25 tests) covering scoring, levels, averages,
  and spec category invariants
