### PR TITLE
feat: Enhanced yacht detail layout with quick facts, social share, TOC sidebar

### DIFF
--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
@@ -28,6 +28,9 @@ import SourceProvenance from "@/components/SourceProvenance";
 import { ReviewSummary } from "@/components/ReviewSummary";
 import { ReviewSubmissionForm } from "@/components/ReviewSubmissionForm";
 import { CorrectionForm } from "@/components/CorrectionForm";
+import QuickFacts from "@/components/QuickFacts";
+import SocialShareButtons from "@/components/SocialShareButtons";
+import TableOfContents from "@/components/TableOfContents";
 import dynamic from "next/dynamic";
 
 const SpecBarsChart = dynamic(
@@ -135,10 +138,12 @@ export default function YachtDetailClient() {
   const params = useParams();
   const slug = params.slug as string;
   const t = useTranslations("YachtDetail");
+  const tocT = useTranslations("TableOfContents");
 
   const [yacht, setYacht] = useState<YachtData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<string>("");
 
   // Translation-aware GROUP_LABELS
   const GROUP_LABELS: Record<string, string> = {
@@ -150,6 +155,68 @@ export default function YachtDetailClient() {
     hull: t("groupLabels.hull"),
     other: t("groupLabels.other"),
   };
+
+  // Build TOC sections based on available content
+  const buildTocSections = useCallback(() => {
+    if (!yacht) return [];
+    const sections: { id: string; label: string }[] = [];
+    // Quick Facts always first
+    sections.push({ id: "quick-facts", label: t("toc.quickFacts") });
+    // Specs
+    if (Object.keys(yacht.specsByGroup).length > 0) {
+      sections.push({ id: "specifications", label: t("toc.specifications") });
+    }
+    // Performance ratios
+    if (yacht.lengthOverall && yacht.displacement) {
+      sections.push({ id: "performance", label: t("toc.performance") });
+    }
+    // Recommendation
+    if (yacht.lengthOverall) {
+      sections.push({ id: "recommendation", label: t("toc.recommendation") });
+    }
+    // Media
+    if (yacht.mediaAssets && yacht.mediaAssets.length > 0) {
+      sections.push({ id: "media-gallery", label: t("toc.media") });
+    }
+    // Reviews
+    if (yacht.reviews && yacht.reviews.length > 0) {
+      sections.push({ id: "reviews", label: t("toc.reviews") });
+    }
+    // Similar
+    sections.push({ id: "similar-yachts", label: t("toc.similar") });
+    // Guides
+    sections.push({ id: "related-guides", label: t("toc.relatedGuides") });
+    // Contact
+    sections.push({ id: "contact", label: t("toc.contact") });
+    return sections;
+  }, [yacht, t]);
+
+  // Intersection observer for active TOC tracking
+  useEffect(() => {
+    if (!yacht) return;
+    const sections = buildTocSections();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: "-100px 0px -60% 0px" }
+    );
+    // Small delay to let DOM render
+    const timer = setTimeout(() => {
+      for (const s of sections) {
+        const el = document.getElementById(s.id);
+        if (el) observer.observe(el);
+      }
+    }, 500);
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [yacht, buildTocSections]);
 
   useEffect(() => {
     if (!slug) return;
@@ -225,6 +292,14 @@ export default function YachtDetailClient() {
   const primaryImage =
     yacht.images.find((img) => img.isPrimary) || yacht.images[0];
 
+  // Page URL for sharing
+  const pageUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/yachts/${yacht.slug}`
+    : `https://info.sailboats.fr/yachts/${yacht.slug}`;
+  const pageTitle = `${yacht.manufacturer} ${yacht.modelName} (${yacht.year}) — Sailing Yacht`;
+
+  const tocSections = buildTocSections();
+
   return (
     <div className="yacht-detail-page max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
       {/* Print-only header */}
@@ -267,483 +342,493 @@ export default function YachtDetailClient() {
         </ol>
       </nav>
 
-      {/* Back link + Print button */}
-      <div className="mb-4 sm:mb-6 flex items-center justify-between">
+      {/* Back link + Print button + Share buttons */}
+      <div className="mb-4 sm:mb-6 flex items-center justify-between flex-wrap gap-2">
         <Button asChild variant="ghost" size="sm" className="no-print">
           <Link href="/yachts">
             <ChevronLeft className="h-4 w-4 mr-1" aria-hidden="true" />
             {t("backToBrowse")}
           </Link>
         </Button>
-        <button
-          onClick={handlePrint}
-          className="print-spec-sheet-btn no-print inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
-          data-testid="print-spec-sheet-btn"
-          type="button"
-        >
-          <Printer className="h-4 w-4" aria-hidden="true" />
-          {t("printSpecSheet")}
-        </button>
-      </div>
-
-      {/* Hero */}
-      <div className="yacht-hero grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8 mb-10 sm:mb-12">
-        <div>
-          {primaryImage ? (
-            <YachtImage
-              src={primaryImage.url}
-              alt={
-                primaryImage.altText ||
-                `${yacht.manufacturer} ${yacht.modelName}`
-              }
-              fill
-              className="w-full h-56 sm:h-72 md:h-80 rounded-lg"
-              priority
-              sizes="(max-width: 768px) 100vw, 50vw"
-              aria-hidden="true" />
-          ) : (
-            <div className="w-full h-56 sm:h-72 md:h-80 bg-muted rounded-lg flex items-center justify-center text-muted-foreground">
-              {t("noImage")}
-            </div>
-          )}
-        </div>
-        <div>
-          <div className="flex items-start gap-3">
-            <h1 className="text-2xl sm:text-3xl font-bold mb-2">
-              {yacht.manufacturer} {yacht.modelName} ({yacht.year})
-            </h1>
-            <div className="no-print">
-              <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel aria-hidden="true" />
-            </div>
-          </div>
-          <div className="flex items-center gap-2 mb-2">
-            <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel aria-hidden="true" />
-          </div>
-          <div className="flex items-center gap-3 mb-4">
-            <ManufacturerLogo name={yacht.manufacturer} logoUrl={yacht.manufacturerLogoUrl ?? null} size={32} />
-            <p className="text-base sm:text-lg text-muted-foreground">
-              {t("builtBy", { manufacturer: yacht.manufacturer })}
-            </p>
-          </div>
-          {yacht.description && (
-            <p className="text-muted-foreground mb-4 leading-relaxed text-sm sm:text-base">
-              {yacht.description}
-            </p>
-          )}
-
-          {/* Core specs quick view */}
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 my-4 sm:my-6">
-            {yacht.lengthOverall && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
-                <div className="text-xs sm:text-sm text-muted-foreground">
-                  {t("coreSpecs.lengthOverall")}
-                </div>
-                <div className="text-xl sm:text-2xl font-semibold">
-                  {formatNumber(yacht.lengthOverall)} m
-                </div>
-              </div>
-            )}
-            {yacht.beam && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
-                <div className="text-xs sm:text-sm text-muted-foreground">{t("coreSpecs.beam")}</div>
-                <div className="text-xl sm:text-2xl font-semibold">
-                  {formatNumber(yacht.beam)} m
-                </div>
-              </div>
-            )}
-            {yacht.draft && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
-                <div className="text-xs sm:text-sm text-muted-foreground">{t("coreSpecs.draft")}</div>
-                <div className="text-xl sm:text-2xl font-semibold">
-                  {formatNumber(yacht.draft)} m
-                </div>
-              </div>
-            )}
-            {yacht.displacement && (
-              <div className="bg-card border border-border rounded-lg p-3 sm:p-4 spec-item">
-                <div className="text-xs sm:text-sm text-muted-foreground">
-                  {t("coreSpecs.displacement")}
-                </div>
-                <div className="text-xl sm:text-2xl font-semibold">
-                  {(Number(yacht.displacement) / 1000).toFixed(1)} t
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Price Range Estimate */}
-          <PriceTierDetail info={priceTierInfo} aria-hidden="true" />
-
-          {/* Real price data from DB (P8.2) */}
-          <PriceInsightBlock yachtId={yacht.id} modelName={yacht.modelName} aria-hidden="true" />
-
-          {/* Admin links */}
-          {yacht.adminLinks && yacht.adminLinks.length > 0 && (
-            <div className="admin-links flex flex-wrap gap-2 sm:gap-3 mt-4 no-print">
-              {yacht.adminLinks.map((link, idx) => (
-                <Button key={idx} asChild variant="outline" size="sm">
-                  <a href={link.url} target="_blank" rel="noopener noreferrer">
-                    {link.label}
-                  </a>
-                </Button>
-              ))}
-            </div>
-          )}
-
-          {yacht.sourceUrl && (
-            <p className="text-xs text-muted-foreground mt-4">
-              {t("sourceLabel")}{" "}
-              <a
-                href={yacht.sourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
-                {yacht.sourceAttribution || yacht.sourceUrl}
-              </a>
-            </p>
-          )}
+        <div className="flex items-center gap-3 no-print">
+          <SocialShareButtons
+            url={pageUrl}
+            title={pageTitle}
+            description={yacht.description || undefined}
+          />
+          <button
+            onClick={handlePrint}
+            className="print-spec-sheet-btn inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
+            data-testid="print-spec-sheet-btn"
+            type="button"
+          >
+            <Printer className="h-4 w-4" aria-hidden="true" />
+            {t("printSpecSheet")}
+          </button>
         </div>
       </div>
 
-      {/* Media Gallery (P10.2) */}
-      {yacht.mediaAssets && yacht.mediaAssets.length > 0 && (
-        <MediaGallery mediaAssets={yacht.mediaAssets} aria-hidden="true" />
-      )}
-
-      {/* Specs by Group */}
-      <div className="space-y-6 sm:space-y-8">
-        {Object.entries(yacht.specsByGroup).map(([group, specs]) => {
-          const label = GROUP_LABELS[group] || group;
-          const icon = GROUP_ICONS[group];
-          return (
-            <section key={group} className="spec-group">
-              <div className="flex items-center gap-2 mb-3 sm:mb-4">
-                {icon}
-                <h2 className="text-lg sm:text-xl font-bold">{label}</h2>
+      {/* Two-column layout: Main + TOC sidebar */}
+      <div className="flex gap-8">
+        {/* Main content */}
+        <div className="flex-1 min-w-0">
+          {/* Hero */}
+          <div className="yacht-hero grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8 mb-8 sm:mb-10">
+            <div>
+              {primaryImage ? (
+                <YachtImage
+                  src={primaryImage.url}
+                  alt={
+                    primaryImage.altText ||
+                    `${yacht.manufacturer} ${yacht.modelName}`
+                  }
+                  fill
+                  className="w-full h-56 sm:h-72 md:h-80 rounded-lg"
+                  priority
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  aria-hidden="true" />
+              ) : (
+                <div className="w-full h-56 sm:h-72 md:h-80 bg-muted rounded-lg flex items-center justify-center text-muted-foreground">
+                  {t("noImage")}
+                </div>
+              )}
+            </div>
+            <div>
+              <div className="flex items-start gap-3">
+                <h1 className="text-2xl sm:text-3xl font-bold mb-2">
+                  {yacht.manufacturer} {yacht.modelName} ({yacht.year})
+                </h1>
+                <div className="no-print">
+                  <FavoriteButton slug={yacht.slug} modelName={`${yacht.manufacturer} ${yacht.modelName}`} size="lg" showLabel aria-hidden="true" />
+                </div>
               </div>
-              <div className="spec-grid grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
-                {specs.map((spec, idx) => (
-                  <div
-                    key={idx}
-                    className="spec-item bg-card border border-border rounded-lg p-3 sm:p-4"
+              <div className="flex items-center gap-2 mb-2">
+                <CompletenessBadge score={calculateCompletenessScore(yacht)} size="md" showLabel aria-hidden="true" />
+              </div>
+              <div className="flex items-center gap-3 mb-4">
+                <ManufacturerLogo name={yacht.manufacturer} logoUrl={yacht.manufacturerLogoUrl ?? null} size={32} />
+                <p className="text-base sm:text-lg text-muted-foreground">
+                  {t("builtBy", { manufacturer: yacht.manufacturer })}
+                </p>
+              </div>
+              {yacht.description && (
+                <p className="text-muted-foreground mb-4 leading-relaxed text-sm sm:text-base">
+                  {yacht.description}
+                </p>
+              )}
+
+              {/* Price Range Estimate */}
+              <PriceTierDetail info={priceTierInfo} aria-hidden="true" />
+
+              {/* Real price data from DB */}
+              <PriceInsightBlock yachtId={yacht.id} modelName={yacht.modelName} aria-hidden="true" />
+
+              {/* Admin links */}
+              {yacht.adminLinks && yacht.adminLinks.length > 0 && (
+                <div className="admin-links flex flex-wrap gap-2 sm:gap-3 mt-4 no-print">
+                  {yacht.adminLinks.map((link, idx) => (
+                    <Button key={idx} asChild variant="outline" size="sm">
+                      <a href={link.url} target="_blank" rel="noopener noreferrer">
+                        {link.label}
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+              )}
+
+              {yacht.sourceUrl && (
+                <p className="text-xs text-muted-foreground mt-4">
+                  {t("sourceLabel")}{" "}
+                  <a
+                    href={yacht.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
                   >
-                    <div className="text-xs sm:text-sm text-muted-foreground">
-                      {spec.category}
-                    </div>
-                    <div className="text-base sm:text-lg font-medium mt-1">
-                      {formatSpecValue(spec.value, spec.unit)}
-                    </div>
+                    {yacht.sourceAttribution || yacht.sourceUrl}
+                  </a>
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Quick Facts Summary */}
+          <div id="quick-facts">
+            <QuickFacts
+              lengthOverall={yacht.lengthOverall}
+              beam={yacht.beam}
+              draft={yacht.draft}
+              displacement={yacht.displacement}
+              ballast={yacht.ballast}
+              sailAreaMain={yacht.sailAreaMain}
+              cabins={yacht.cabins}
+              berths={yacht.berths}
+              heads={yacht.heads}
+              engineHp={yacht.engineHp}
+              fuelCapacity={yacht.fuelCapacity}
+              waterCapacity={yacht.waterCapacity}
+              rigType={yacht.rigType}
+              hullMaterial={yacht.hullMaterial}
+              keelType={yacht.keelType}
+            />
+          </div>
+
+          {/* Media Gallery */}
+          {yacht.mediaAssets && yacht.mediaAssets.length > 0 && (
+            <div id="media-gallery" className="mb-8 sm:mb-10">
+              <MediaGallery mediaAssets={yacht.mediaAssets} aria-hidden="true" />
+            </div>
+          )}
+
+          {/* Specs by Group - Enhanced with icons */}
+          <div id="specifications" className="space-y-6 sm:space-y-8 mb-8 sm:mb-10">
+            {Object.entries(yacht.specsByGroup).map(([group, specs]) => {
+              const label = GROUP_LABELS[group] || group;
+              const icon = GROUP_ICONS[group];
+              return (
+                <section key={group} className="spec-group">
+                  <div className="flex items-center gap-2 mb-3 sm:mb-4">
+                    {icon && <span className="text-primary">{icon}</span>}
+                    <h2 className="text-lg sm:text-xl font-bold">{label}</h2>
                   </div>
-                ))}
-              </div>
-            </section>
-          );
-        })}
-      </div>
+                  <div className="spec-grid grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 sm:gap-3">
+                    {specs.map((spec, idx) => (
+                      <div
+                        key={idx}
+                        className="spec-item bg-card border border-border rounded-lg p-3 hover:border-primary/30 transition-colors"
+                      >
+                        <div className="text-xs sm:text-sm text-muted-foreground truncate">
+                          {spec.category}
+                        </div>
+                        <div className="text-base sm:text-lg font-semibold mt-1 truncate">
+                          {formatSpecValue(spec.value, spec.unit)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
 
+          {/* Spec Bars Visualization */}
+          <SpecBarsChart
+            yachtSpecs={{
+              lengthOverall: yacht.lengthOverall,
+              beam: yacht.beam,
+              draft: yacht.draft,
+              displacement: yacht.displacement,
+              ballast: yacht.ballast,
+              sailAreaMain: yacht.sailAreaMain,
+              engineHp: yacht.engineHp,
+            }}
+          />
 
+          {/* Source Provenance */}
+          <SourceProvenance
+            dataSource={yacht.dataSource}
+            sourceUrl={yacht.sourceUrl}
+            sourceAttribution={yacht.sourceAttribution}
+            sourceConfidence={yacht.sourceConfidence}
+            lastVerifiedAt={yacht.lastVerifiedAt}
+            completenessScore={yacht.completenessScore}
+            aria-hidden="true" />
 
-      {/* P15.2: Spec Bars Visualization */}
-      <SpecBarsChart
-        yachtSpecs={{
-          lengthOverall: yacht.lengthOverall,
-          beam: yacht.beam,
-          draft: yacht.draft,
-          displacement: yacht.displacement,
-          ballast: yacht.ballast,
-          sailAreaMain: yacht.sailAreaMain,
-          engineHp: yacht.engineHp,
-        }}
-      />
+          {/* User Correction */}
+          <CorrectionForm
+            yachtId={yacht.id}
+            yachtSlug={yacht.slug}
+            specFields={[
+              { name: "lengthOverall", label: t("correctionFields.lengthOverall"), currentValue: yacht.lengthOverall },
+              { name: "beam", label: t("correctionFields.beam"), currentValue: yacht.beam },
+              { name: "draft", label: t("correctionFields.draft"), currentValue: yacht.draft },
+              { name: "displacement", label: t("correctionFields.displacement"), currentValue: yacht.displacement },
+              { name: "ballast", label: t("correctionFields.ballast"), currentValue: yacht.ballast },
+              { name: "sailAreaMain", label: t("correctionFields.sailAreaMain"), currentValue: yacht.sailAreaMain },
+              { name: "rigType", label: t("correctionFields.rigType"), currentValue: yacht.rigType },
+              { name: "keelType", label: t("correctionFields.keelType"), currentValue: yacht.keelType },
+              { name: "hullMaterial", label: t("correctionFields.hullMaterial"), currentValue: yacht.hullMaterial },
+              { name: "cabins", label: t("correctionFields.cabins"), currentValue: yacht.cabins },
+              { name: "berths", label: t("correctionFields.berths"), currentValue: yacht.berths },
+              { name: "heads", label: t("correctionFields.heads"), currentValue: yacht.heads },
+              { name: "maxOccupancy", label: t("correctionFields.maxOccupancy"), currentValue: yacht.maxOccupancy },
+              { name: "engineHp", label: t("correctionFields.engineHp"), currentValue: yacht.engineHp },
+              { name: "engineType", label: t("correctionFields.engineType"), currentValue: yacht.engineType },
+              { name: "fuelCapacity", label: t("correctionFields.fuelCapacity"), currentValue: yacht.fuelCapacity },
+              { name: "waterCapacity", label: t("correctionFields.waterCapacity"), currentValue: yacht.waterCapacity },
+            ].filter(f => f.currentValue !== null && f.currentValue !== undefined)}
+          />
 
-      {/* Source Provenance (P10.3) */}
-      <SourceProvenance
-        dataSource={yacht.dataSource}
-        sourceUrl={yacht.sourceUrl}
-        sourceAttribution={yacht.sourceAttribution}
-        sourceConfidence={yacht.sourceConfidence}
-        lastVerifiedAt={yacht.lastVerifiedAt}
-        completenessScore={yacht.completenessScore}
-        aria-hidden="true" />
+          {/* Performance Ratios Section */}
+          <div id="performance">
+            {(() => {
+              const ratios = calculatePerformanceRatios(yacht, t);
+              if (ratios.length === 0) return null;
+              return (
+                <section className="mt-10 sm:mt-12">
+                  <h2 className="text-lg sm:text-xl font-bold mb-4">{t("performance.heading")}</h2>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                    {ratios.map((ratio) => (
+                      <div key={ratio.name} className="border border-border rounded-lg p-4 bg-card">
+                        <div className="text-sm text-muted-foreground">{ratio.name}</div>
+                        <div className="text-2xl font-bold mt-1">{ratio.value}</div>
+                        <div className="text-xs text-muted-foreground mt-2">{ratio.description}</div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })()}
+          </div>
 
-      {/* User Correction (P10.7) */}
-      <CorrectionForm
-        yachtId={yacht.id}
-        yachtSlug={yacht.slug}
-        specFields={[
-          { name: "lengthOverall", label: t("correctionFields.lengthOverall"), currentValue: yacht.lengthOverall },
-          { name: "beam", label: t("correctionFields.beam"), currentValue: yacht.beam },
-          { name: "draft", label: t("correctionFields.draft"), currentValue: yacht.draft },
-          { name: "displacement", label: t("correctionFields.displacement"), currentValue: yacht.displacement },
-          { name: "ballast", label: t("correctionFields.ballast"), currentValue: yacht.ballast },
-          { name: "sailAreaMain", label: t("correctionFields.sailAreaMain"), currentValue: yacht.sailAreaMain },
-          { name: "rigType", label: t("correctionFields.rigType"), currentValue: yacht.rigType },
-          { name: "keelType", label: t("correctionFields.keelType"), currentValue: yacht.keelType },
-          { name: "hullMaterial", label: t("correctionFields.hullMaterial"), currentValue: yacht.hullMaterial },
-          { name: "cabins", label: t("correctionFields.cabins"), currentValue: yacht.cabins },
-          { name: "berths", label: t("correctionFields.berths"), currentValue: yacht.berths },
-          { name: "heads", label: t("correctionFields.heads"), currentValue: yacht.heads },
-          { name: "maxOccupancy", label: t("correctionFields.maxOccupancy"), currentValue: yacht.maxOccupancy },
-          { name: "engineHp", label: t("correctionFields.engineHp"), currentValue: yacht.engineHp },
-          { name: "engineType", label: t("correctionFields.engineType"), currentValue: yacht.engineType },
-          { name: "fuelCapacity", label: t("correctionFields.fuelCapacity"), currentValue: yacht.fuelCapacity },
-          { name: "waterCapacity", label: t("correctionFields.waterCapacity"), currentValue: yacht.waterCapacity },
-        ].filter(f => f.currentValue !== null && f.currentValue !== undefined)}
-      />
+          {/* Who is this boat for? Section */}
+          <div id="recommendation">
+            {(() => {
+              const recommendation = getBoatRecommendation(yacht, t);
+              if (!recommendation) return null;
+              return (
+                <section className="mt-10 sm:mt-12 bg-gradient-to-r from-sky-50 to-cyan-50 border border-sky-200 rounded-xl p-6">
+                  <h2 className="text-lg sm:text-xl font-bold mb-3 text-sky-900">{t("recommendation.heading")}</h2>
+                  <p className="text-muted-foreground leading-relaxed">{recommendation}</p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {yacht.lengthOverall && yacht.lengthOverall < 10 && (
+                      <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.daySailer")}</span>
+                    )}
+                    {yacht.lengthOverall && yacht.lengthOverall >= 10 && yacht.lengthOverall < 13 && (
+                      <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.coastalCruiser")}</span>
+                    )}
+                    {yacht.lengthOverall && yacht.lengthOverall >= 13 && (
+                      <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.bluewater")}</span>
+                    )}
+                    {yacht.berths && yacht.berths >= 4 && (
+                      <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.familyFriendly")}</span>
+                    )}
+                    {yacht.rigType?.toLowerCase().includes("sloop") && (
+                      <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.easyHandling")}</span>
+                    )}
+                  </div>
+                </section>
+              );
+            })()}
+          </div>
 
-      {/* Performance Ratios Section */}
-      {(() => {
-        const ratios = calculatePerformanceRatios(yacht, t);
-        if (ratios.length === 0) return null;
-        return (
-          <section className="mt-10 sm:mt-12">
-            <h2 className="text-lg sm:text-xl font-bold mb-4">{t("performance.heading")}</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              {ratios.map((ratio) => (
-                <div key={ratio.name} className="border border-border rounded-lg p-4 bg-card">
-                  <div className="text-sm text-muted-foreground">{ratio.name}</div>
-                  <div className="text-2xl font-bold mt-1">{ratio.value}</div>
-                  <div className="text-xs text-muted-foreground mt-2">{ratio.description}</div>
+          {/* Review Summary */}
+          <div id="reviews">
+            {yacht.reviews && yacht.reviews.length > 0 && (() => {
+              const validRatings = yacht.reviews
+                .map(r => Number(r.rating))
+                .filter(n => !isNaN(n) && n > 0);
+              const overallRating = validRatings.length > 0
+                ? validRatings.reduce((a: number, b: number) => a + b, 0) / validRatings.length
+                : 0;
+              const breakdowns = yacht.reviews
+                .map(r => r.ratingBreakdown)
+                .filter(Boolean);
+              const avgBreakdown = {
+                build_quality: 0,
+                sailing_performance: 0,
+                comfort: 0,
+                value_for_money: 0,
+              };
+              if (breakdowns.length > 0) {
+                for (const b of breakdowns) {
+                  avgBreakdown.build_quality += Number(b!.build_quality) || 0;
+                  avgBreakdown.sailing_performance += Number(b!.sailing_performance) || 0;
+                  avgBreakdown.comfort += Number(b!.comfort) || 0;
+                  avgBreakdown.value_for_money += Number(b!.value_for_money) || 0;
+                }
+                const countB = (field: keyof typeof avgBreakdown) =>
+                  breakdowns.filter(b => b![field] !== null).length;
+                const safeAvg = (sum: number, field: keyof typeof avgBreakdown) => {
+                  const c = countB(field);
+                  return c > 0 ? sum / c : 0;
+                };
+                avgBreakdown.build_quality = safeAvg(avgBreakdown.build_quality, 'build_quality');
+                avgBreakdown.sailing_performance = safeAvg(avgBreakdown.sailing_performance, 'sailing_performance');
+                avgBreakdown.comfort = safeAvg(avgBreakdown.comfort, 'comfort');
+                avgBreakdown.value_for_money = safeAvg(avgBreakdown.value_for_money, 'value_for_money');
+              }
+              return (
+                <div className="mt-10 sm:mt-12">
+                  <ReviewSummary
+                    reviews={yacht.reviews}
+                    overallRating={overallRating}
+                    ratingBreakdown={avgBreakdown}
+                    aria-hidden="true" />
                 </div>
-              ))}
-            </div>
-          </section>
-        );
-      })()}
+              );
+            })()}
 
-      {/* Who is this boat for? Section */}
-      {(() => {
-        const recommendation = getBoatRecommendation(yacht, t);
-        if (!recommendation) return null;
-        return (
-          <section className="mt-10 sm:mt-12 bg-gradient-to-r from-sky-50 to-cyan-50 border border-sky-200 rounded-xl p-6">
-            <h2 className="text-lg sm:text-xl font-bold mb-3 text-sky-900">{t("recommendation.heading")}</h2>
-            <p className="text-muted-foreground leading-relaxed">{recommendation}</p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {yacht.lengthOverall && yacht.lengthOverall < 10 && (
-                <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.daySailer")}</span>
-              )}
-              {yacht.lengthOverall && yacht.lengthOverall >= 10 && yacht.lengthOverall < 13 && (
-                <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.coastalCruiser")}</span>
-              )}
-              {yacht.lengthOverall && yacht.lengthOverall >= 13 && (
-                <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.bluewater")}</span>
-              )}
-              {yacht.berths && yacht.berths >= 4 && (
-                <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.familyFriendly")}</span>
-              )}
-              {yacht.rigType?.toLowerCase().includes("sloop") && (
-                <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">{t("badges.easyHandling")}</span>
-              )}
-            </div>
-          </section>
-        );
-      })()}
-      {/* Review Summary (P10.4) */}
-      {yacht.reviews && yacht.reviews.length > 0 && (() => {
-        const validRatings = yacht.reviews
-          .map(r => Number(r.rating))
-          .filter(n => !isNaN(n) && n > 0);
-        const overallRating = validRatings.length > 0
-          ? validRatings.reduce((a: number, b: number) => a + b, 0) / validRatings.length
-          : 0;
-        const breakdowns = yacht.reviews
-          .map(r => r.ratingBreakdown)
-          .filter(Boolean);
-        const avgBreakdown = {
-          build_quality: 0,
-          sailing_performance: 0,
-          comfort: 0,
-          value_for_money: 0,
-        };
-        if (breakdowns.length > 0) {
-          for (const b of breakdowns) {
-            avgBreakdown.build_quality += Number(b!.build_quality) || 0;
-            avgBreakdown.sailing_performance += Number(b!.sailing_performance) || 0;
-            avgBreakdown.comfort += Number(b!.comfort) || 0;
-            avgBreakdown.value_for_money += Number(b!.value_for_money) || 0;
-          }
-          const countB = (field: keyof typeof avgBreakdown) =>
-            breakdowns.filter(b => b![field] !== null).length;
-          const safeAvg = (sum: number, field: keyof typeof avgBreakdown) => {
-            const c = countB(field);
-            return c > 0 ? sum / c : 0;
-          };
-          avgBreakdown.build_quality = safeAvg(avgBreakdown.build_quality, 'build_quality');
-          avgBreakdown.sailing_performance = safeAvg(avgBreakdown.sailing_performance, 'sailing_performance');
-          avgBreakdown.comfort = safeAvg(avgBreakdown.comfort, 'comfort');
-          avgBreakdown.value_for_money = safeAvg(avgBreakdown.value_for_money, 'value_for_money');
-        }
-        return (
-          <div className="mt-10 sm:mt-12">
-            <ReviewSummary
-              reviews={yacht.reviews}
-              overallRating={overallRating}
-              ratingBreakdown={avgBreakdown}
+            {/* Reviews Section */}
+            {yacht.reviews && yacht.reviews.length > 0 && (
+              <section className="mt-6 sm:mt-8">
+                <h2 className="text-lg sm:text-xl font-bold mb-4">{t("reviews.heading")}</h2>
+                <div className="space-y-4">
+                  {yacht.reviews.map((review, idx) => (
+                    <div key={idx} className="border border-border rounded-lg p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <span className="font-semibold">{review.authorName || review.source}</span>
+                          {review.reviewType && review.reviewType !== 'expert' && (
+                            <span className="ml-2 inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                              {review.reviewType.replace('_', ' ')}
+                            </span>
+                          )}
+                          {review.verified && (
+                            <span className="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                              {t("reviews.verified")}
+                            </span>
+                          )}
+                        </div>
+                        {review.rating && (
+                          <div className="flex items-center gap-1">
+                            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" aria-hidden="true" />
+                            <span>{parseFloat(String(review.rating)).toFixed(1)}</span>
+                          </div>
+                        )}
+                      </div>
+                      {review.summary && (
+                        <p className="mt-2 font-medium">{review.summary}</p>
+                      )}
+                      {review.fullText && (
+                        <p className="mt-1 text-muted-foreground text-sm">
+                          {review.fullText}
+                        </p>
+                      )}
+                      {(review.pros && review.pros.length > 0) && (
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {review.pros.map((pro, i) => (
+                            <span key={i} className="inline-flex items-center rounded-full bg-green-50 border border-green-200 px-2 py-0.5 text-xs text-green-700">+ {pro}</span>
+                          ))}
+                        </div>
+                      )}
+                      {(review.cons && review.cons.length > 0) && (
+                        <div className="mt-1.5 flex flex-wrap gap-1.5">
+                          {review.cons.map((con, i) => (
+                            <span key={i} className="inline-flex items-center rounded-full bg-red-50 border border-red-200 px-2 py-0.5 text-xs text-red-700">− {con}</span>
+                          ))}
+                        </div>
+                      )}
+                      {review.authorName && (
+                        <p className="text-xs text-muted-foreground mt-2">
+                          — {review.authorName}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {/* Review Submission Form */}
+          <div className="mt-8 sm:mt-10 no-print">
+            <ReviewSubmissionForm
+              yachtModelId={yacht.id}
+              yachtName={`${yacht.manufacturer} ${yacht.modelName}`}
               aria-hidden="true" />
           </div>
-        );
-      })()}
 
-      {/* Reviews Section */}
-      {yacht.reviews && yacht.reviews.length > 0 && (
-        <section className="mt-6 sm:mt-8">
-          <h2 className="text-lg sm:text-xl font-bold mb-4">{t("reviews.heading")}</h2>
-          <div className="space-y-4">
-            {yacht.reviews.map((review, idx) => (
-              <div key={idx} className="border border-border rounded-lg p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="font-semibold">{review.authorName || review.source}</span>
-                    {review.reviewType && review.reviewType !== 'expert' && (
-                      <span className="ml-2 inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
-                        {review.reviewType.replace('_', ' ')}
-                      </span>
-                    )}
-                    {review.verified && (
-                      <span className="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
-                        {t("reviews.verified")}
-                      </span>
-                    )}
-                  </div>
-                  {review.rating && (
-                    <div className="flex items-center gap-1">
-                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" aria-hidden="true" />
-                      <span>{parseFloat(String(review.rating)).toFixed(1)}</span>
-                    </div>
-                  )}
-                </div>
-                {review.summary && (
-                  <p className="mt-2 font-medium">{review.summary}</p>
-                )}
-                {review.fullText && (
-                  <p className="mt-1 text-muted-foreground text-sm">
-                    {review.fullText}
-                  </p>
-                )}
-                {(review.pros && review.pros.length > 0) && (
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {review.pros.map((pro, i) => (
-                      <span key={i} className="inline-flex items-center rounded-full bg-green-50 border border-green-200 px-2 py-0.5 text-xs text-green-700">+ {pro}</span>
-                    ))}
-                  </div>
-                )}
-                {(review.cons && review.cons.length > 0) && (
-                  <div className="mt-1.5 flex flex-wrap gap-1.5">
-                    {review.cons.map((con, i) => (
-                      <span key={i} className="inline-flex items-center rounded-full bg-red-50 border border-red-200 px-2 py-0.5 text-xs text-red-700">− {con}</span>
-                    ))}
-                  </div>
-                )}
-                {review.authorName && (
-                  <p className="text-xs text-muted-foreground mt-2">
-                    — {review.authorName}
-                  </p>
-                )}
+          {/* INTERNAL LINKING MODULES */}
+          <div id="similar-yachts">
+            <div className="similar-yachts-section no-print">
+              <SimilarYachts slug={slug} aria-hidden="true" />
+            </div>
+
+            {/* Same size alternatives */}
+            {yacht.lengthOverall && (
+              <div className="same-size-alternatives-section no-print">
+                <SameSizeAlternatives
+                  targetLength={yacht.lengthOverall}
+                  currentYachtId={yacht.id}
+                  aria-hidden="true" />
               </div>
-            ))}
+            )}
+
+            {/* More from this manufacturer */}
+            {yacht.manufacturerId && (
+              <div className="related-manufacturers-section no-print">
+                <RelatedManufacturers
+                  manufacturerId={yacht.manufacturerId}
+                  manufacturerSlug={slugify(yacht.manufacturer)}
+                  currentYachtId={yacht.id}
+                  aria-hidden="true" />
+              </div>
+            )}
           </div>
-        </section>
-      )}
 
-      {/* Review Submission Form (P10.4) */}
-      <div className="mt-8 sm:mt-10 no-print">
-        <ReviewSubmissionForm
-          yachtModelId={yacht.id}
-          yachtName={`${yacht.manufacturer} ${yacht.modelName}`}
-          aria-hidden="true" />
-      </div>
+          {/* Best value cross-link */}
+          {yacht.lengthOverall && (() => {
+            const loa = yacht.lengthOverall;
+            let bestValueSlug = "";
+            let bestValueLabel = "";
+            if (loa >= 11.5 && loa <= 12.8) { bestValueSlug = "40ft-cruisers"; bestValueLabel = "Best Value 40ft Cruisers"; }
+            else if (loa >= 10.0 && loa < 11.5) { bestValueSlug = "35ft-sailboats"; bestValueLabel = "Best Value 35ft Sailboats"; }
+            else if (loa >= 10.5 && loa <= 13.7) { bestValueSlug = "family-cruisers-under-45ft"; bestValueLabel = "Best Value Family Cruisers Under 45ft"; }
+            else if (loa >= 10.0 && loa <= 15.0) { bestValueSlug = "bluewater-value"; bestValueLabel = "Best Value Bluewater Sailboats"; }
+            return bestValueSlug ? (
+              <div className="best-value-cross-link no-print max-w-7xl mx-auto px-4 mb-8" data-testid="best-value-cross-link">
+                <a
+                  href={`/best-value/${bestValueSlug}`}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm font-medium hover:bg-emerald-100 transition"
+                >
+                  <span>🏆</span>
+                  {t("bestValue.seeRanked", { label: bestValueLabel })}
+                  <span>→</span>
+                </a>
+              </div>
+            ) : null;
+          })()}
 
-      {/* INTERNAL LINKING MODULES (P6.7) */}
+          {/* Related guides */}
+          <div id="related-guides">
+            <div className="related-guides-section no-print">
+              <RelatedGuides
+                manufacturer={yacht.manufacturer}
+                lengthOverall={yacht.lengthOverall}
+                rigType={yacht.rigType}
+                aria-hidden="true" />
+            </div>
 
-      {/* 1. Compare with similar boats - already implemented as SimilarYachts */}
-      <div className="similar-yachts-section no-print">
-        <SimilarYachts slug={slug} aria-hidden="true" />
-      </div>
-
-      {/* 2. Same size alternatives - NEW */}
-      {yacht.lengthOverall && (
-        <div className="same-size-alternatives-section no-print">
-          <SameSizeAlternatives
-            targetLength={yacht.lengthOverall}
-            currentYachtId={yacht.id}
-            aria-hidden="true" />
-        </div>
-      )}
-
-      {/* 3. More from this manufacturer - NEW */}
-      {yacht.manufacturerId && (
-        <div className="related-manufacturers-section no-print">
-          <RelatedManufacturers
-            manufacturerId={yacht.manufacturerId}
-            manufacturerSlug={slugify(yacht.manufacturer)}
-            currentYachtId={yacht.id}
-            aria-hidden="true" />
-        </div>
-      )}
-
-      {/* Best value cross-link */}
-      {yacht.lengthOverall && (() => {
-        const loa = yacht.lengthOverall;
-        let bestValueSlug = "";
-        let bestValueLabel = "";
-        if (loa >= 11.5 && loa <= 12.8) { bestValueSlug = "40ft-cruisers"; bestValueLabel = "Best Value 40ft Cruisers"; }
-        else if (loa >= 10.0 && loa < 11.5) { bestValueSlug = "35ft-sailboats"; bestValueLabel = "Best Value 35ft Sailboats"; }
-        else if (loa >= 10.5 && loa <= 13.7) { bestValueSlug = "family-cruisers-under-45ft"; bestValueLabel = "Best Value Family Cruisers Under 45ft"; }
-        else if (loa >= 10.0 && loa <= 15.0) { bestValueSlug = "bluewater-value"; bestValueLabel = "Best Value Bluewater Sailboats"; }
-        return bestValueSlug ? (
-          <div className="best-value-cross-link no-print max-w-7xl mx-auto px-4 mb-8" data-testid="best-value-cross-link">
-            <a
-              href={`/best-value/${bestValueSlug}`}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm font-medium hover:bg-emerald-100 transition"
-            >
-              <span>🏆</span>
-              {t("bestValue.seeRanked", { label: bestValueLabel })}
-              <span>→</span>
-            </a>
+            {/* Related Sailing Articles */}
+            <div className="related-articles-wrapper no-print">
+              <RelatedArticles
+                manufacturer={yacht.manufacturer}
+                lengthOverall={yacht.lengthOverall}
+                rigType={yacht.rigType}
+                keelType={yacht.keelType}
+                hullMaterial={yacht.hullMaterial}
+                cabins={yacht.cabins}
+                displacement={yacht.displacement}
+                aria-hidden="true" />
+            </div>
           </div>
-        ) : null;
-      })()}
 
-      {/* 4. Related guides - NEW (Phase 7 placeholder) */}
-      <div className="related-guides-section no-print">
-        <RelatedGuides
-          manufacturer={yacht.manufacturer}
-          lengthOverall={yacht.lengthOverall}
-          rigType={yacht.rigType}
-          aria-hidden="true" />
-      </div>
+          {/* Lead Forms */}
+          <div id="contact">
+            <div className="lead-forms-section mt-8 grid grid-cols-1 md:grid-cols-2 gap-4 no-print">
+              <LeadForm yachtIds={[yacht.id]} leadType="dealer_inquiry" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} aria-hidden="true" />
+              <LeadForm yachtIds={[yacht.id]} leadType="price_request" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} aria-hidden="true" />
+            </div>
+          </div>
 
-      {/* Related Sailing Articles from sailboats.fr */}
-      <div className="related-articles-wrapper no-print">
-        <RelatedArticles
-          manufacturer={yacht.manufacturer}
-          lengthOverall={yacht.lengthOverall}
-          rigType={yacht.rigType}
-          keelType={yacht.keelType}
-          hullMaterial={yacht.hullMaterial}
-          cabins={yacht.cabins}
-          displacement={yacht.displacement}
-          aria-hidden="true" />
-      </div>
+          {/* Affiliate Recommendations */}
+          <div className="affiliate-recommendations-section no-print">
+            <AffiliateRecommendations categories={affiliateRecommendations} aria-hidden="true" />
+          </div>
 
-      {/* Lead Forms */}
-      <div className="lead-forms-section mt-8 grid grid-cols-1 md:grid-cols-2 gap-4 no-print">
-        <LeadForm yachtIds={[yacht.id]} leadType="dealer_inquiry" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} aria-hidden="true" />
-        <LeadForm yachtIds={[yacht.id]} leadType="price_request" yachtName={`${yacht.manufacturer} ${yacht.modelName}`} aria-hidden="true" />
-      </div>
+          {/* Compare Button */}
+          <div className="compare-button-section mt-10 sm:mt-12 text-center no-print">
+            <Button asChild size="lg">
+              <Link href={`/compare?ids=${yacht.id}`}>{t("compare")}</Link>
+            </Button>
+          </div>
+        </div>
 
-      {/* Affiliate Recommendations */}
-      <div className="affiliate-recommendations-section no-print">
-        <AffiliateRecommendations categories={affiliateRecommendations} aria-hidden="true" />
-      </div>
-
-      {/* Compare Button */}
-      <div className="compare-button-section mt-10 sm:mt-12 text-center no-print">
-        <Button asChild size="lg">
-          <Link href={`/compare?ids=${yacht.id}`}>{t("compare")}</Link>
-        </Button>
+        {/* TOC Sidebar — desktop only */}
+        <div className="hidden lg:block w-56 flex-shrink-0 no-print">
+          <TableOfContents sections={tocSections} activeId={activeSection} />
+        </div>
       </div>
 
       {/* Print-only footer */}

--- a/components/QuickFacts.tsx
+++ b/components/QuickFacts.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Ruler,
+  Anchor,
+  Waves,
+  Weight,
+  Sailboat,
+  Bed,
+  DoorOpen,
+  Fuel,
+  Droplets,
+  Gauge,
+} from "lucide-react";
+
+interface QuickFact {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  highlight?: boolean;
+}
+
+interface QuickFactsProps {
+  lengthOverall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  ballast: number | null;
+  sailAreaMain: number | null;
+  cabins: number | null;
+  berths: number | null;
+  heads: number | null;
+  engineHp: number | null;
+  fuelCapacity: number | null;
+  waterCapacity: number | null;
+  rigType: string | null;
+  hullMaterial: string | null;
+  keelType: string | null;
+}
+
+function formatNum(n: number | null, decimals = 1): string {
+  if (n === null) return "—";
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export default function QuickFacts(props: QuickFactsProps) {
+  const t = useTranslations("QuickFacts");
+
+  const facts: QuickFact[] = [
+    {
+      icon: <Ruler className="h-4 w-4 text-blue-500" aria-hidden="true" />,
+      label: t("lengthOverall"),
+      value: props.lengthOverall ? `${formatNum(props.lengthOverall)} m` : "—",
+      highlight: true,
+    },
+    {
+      icon: <Anchor className="h-4 w-4 text-cyan-500" aria-hidden="true" />,
+      label: t("beam"),
+      value: props.beam ? `${formatNum(props.beam)} m` : "—",
+    },
+    {
+      icon: <Waves className="h-4 w-4 text-indigo-500" aria-hidden="true" />,
+      label: t("draft"),
+      value: props.draft ? `${formatNum(props.draft)} m` : "—",
+    },
+    {
+      icon: <Weight className="h-4 w-4 text-slate-500" aria-hidden="true" />,
+      label: t("displacement"),
+      value: props.displacement
+        ? `${(props.displacement / 1000).toFixed(1)} t`
+        : "—",
+    },
+    {
+      icon: <Sailboat className="h-4 w-4 text-sky-500" aria-hidden="true" />,
+      label: t("rigType"),
+      value: props.rigType || "—",
+    },
+    {
+      icon: <Bed className="h-4 w-4 text-purple-500" aria-hidden="true" />,
+      label: t("cabins"),
+      value: props.cabins !== null ? String(props.cabins) : "—",
+    },
+    {
+      icon: <DoorOpen className="h-4 w-4 text-pink-500" aria-hidden="true" />,
+      label: t("berths"),
+      value: props.berths !== null ? String(props.berths) : "—",
+    },
+    {
+      icon: <Gauge className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+      label: t("engineHp"),
+      value: props.engineHp ? `${formatNum(props.engineHp, 0)} hp` : "—",
+    },
+    {
+      icon: <Droplets className="h-4 w-4 text-teal-500" aria-hidden="true" />,
+      label: t("waterCapacity"),
+      value: props.waterCapacity
+        ? `${formatNum(props.waterCapacity, 0)} L`
+        : "—",
+    },
+    {
+      icon: <Fuel className="h-4 w-4 text-orange-500" aria-hidden="true" />,
+      label: t("fuelCapacity"),
+      value: props.fuelCapacity
+        ? `${formatNum(props.fuelCapacity, 0)} L`
+        : "—",
+    },
+  ].filter((f) => f.value !== "—");
+
+  if (facts.length === 0) return null;
+
+  return (
+    <section
+      className="quick-facts-section mb-8 sm:mb-10"
+      aria-label={t("sectionLabel")}
+      data-testid="quick-facts-section"
+    >
+      <h2 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4">
+        {t("heading")}
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+        {facts.map((fact, idx) => (
+          <div
+            key={idx}
+            className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${
+              fact.highlight
+                ? "border-blue-200 bg-blue-50/50"
+                : "border-border bg-card"
+            }`}
+          >
+            <div className="flex-shrink-0">{fact.icon}</div>
+            <div className="min-w-0">
+              <div className="text-xs text-muted-foreground truncate">
+                {fact.label}
+              </div>
+              <div className="text-sm font-semibold truncate">{fact.value}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/SocialShareButtons.tsx
+++ b/components/SocialShareButtons.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Share2, Twitter, Facebook, Linkedin, Link as LinkIcon, Check } from "lucide-react";
+
+interface SocialShareButtonsProps {
+  /** Full URL of the current page */
+  url: string;
+  /** Share title, e.g. "Beneteau Oceanis 40.1 (2024)" */
+  title: string;
+  /** Optional short description */
+  description?: string;
+  /** Extra CSS classes */
+  className?: string;
+}
+
+export default function SocialShareButtons({
+  url,
+  title,
+  description,
+  className = "",
+}: SocialShareButtonsProps) {
+  const t = useTranslations("SocialShare");
+  const [copied, setCopied] = useState(false);
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+  const encodedDesc = description ? encodeURIComponent(description) : "";
+
+  const shareLinks = [
+    {
+      name: "Twitter",
+      icon: <Twitter className="h-4 w-4" aria-hidden="true" />,
+      href: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
+      color: "hover:bg-sky-50 hover:text-sky-600 hover:border-sky-200",
+    },
+    {
+      name: "Facebook",
+      icon: <Facebook className="h-4 w-4" aria-hidden="true" />,
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+      color: "hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200",
+    },
+    {
+      name: "LinkedIn",
+      icon: <Linkedin className="h-4 w-4" aria-hidden="true" />,
+      href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      color: "hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-200",
+    },
+  ];
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement("textarea");
+      textarea.value = url;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div
+      className={`social-share-buttons flex items-center gap-2 ${className}`}
+      data-testid="social-share-buttons"
+    >
+      <Share2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      <span className="text-sm text-muted-foreground hidden sm:inline">
+        {t("share")}:
+      </span>
+      {shareLinks.map((link) => (
+        <a
+          key={link.name}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`inline-flex items-center justify-center w-8 h-8 rounded-md border border-border text-muted-foreground transition-colors ${link.color}`}
+          aria-label={t("shareOn", { platform: link.name })}
+          title={t("shareOn", { platform: link.name })}
+        >
+          {link.icon}
+        </a>
+      ))}
+      <button
+        type="button"
+        onClick={handleCopyLink}
+        className={`inline-flex items-center justify-center gap-1.5 h-8 px-2 rounded-md border border-border text-sm transition-colors ${
+          copied
+            ? "bg-green-50 text-green-600 border-green-200"
+            : "text-muted-foreground hover:bg-muted"
+        }`}
+        aria-label={t("copyLink")}
+        title={t("copyLink")}
+      >
+        {copied ? (
+          <>
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="hidden sm:inline text-xs">{t("copied")}</span>
+          </>
+        ) : (
+          <>
+            <LinkIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="hidden sm:inline text-xs">{t("copy")}</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface TableOfContentsProps {
+  sections: { id: string; label: string }[];
+  activeId?: string;
+}
+
+export default function TableOfContents({
+  sections,
+  activeId,
+}: TableOfContentsProps) {
+  const t = useTranslations("TableOfContents");
+
+  if (sections.length === 0) return null;
+
+  const handleClick = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  return (
+    <nav
+      className="hidden lg:block sticky top-24"
+      aria-label={t("label")}
+      data-testid="table-of-contents"
+    >
+      <div className="border border-border rounded-lg p-4 bg-card">
+        <h3 className="text-sm font-semibold mb-3">{t("heading")}</h3>
+        <ul className="space-y-2">
+          {sections.map((section) => (
+            <li key={section.id}>
+              <button
+                type="button"
+                onClick={() => handleClick(section.id)}
+                className={`text-left text-sm transition-colors w-full hover:text-primary ${
+                  activeId === section.id
+                    ? "text-primary font-medium"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {section.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -539,6 +539,17 @@
         "classMax": "Class Max",
         "percentile": "Percentile"
       }
+    },
+    "toc": {
+      "quickFacts": "Quick Facts",
+      "specifications": "Specifications",
+      "performance": "Performance",
+      "recommendation": "Who Is This Boat For?",
+      "reviews": "Reviews",
+      "media": "Media Gallery",
+      "similar": "Similar Yachts",
+      "relatedGuides": "Related Guides",
+      "contact": "Contact & Inquiries"
     }
   },
   "YachtDetailSub": {
@@ -1172,5 +1183,35 @@
   },
   "UI": {
     "backToTop": "Back to top"
+  },
+  "QuickFacts": {
+    "sectionLabel": "Quick Facts",
+    "heading": "At a Glance",
+    "lengthOverall": "Length",
+    "beam": "Beam",
+    "draft": "Draft",
+    "displacement": "Displacement",
+    "ballast": "Ballast",
+    "sailAreaMain": "Sail Area",
+    "rigType": "Rig Type",
+    "cabins": "Cabins",
+    "berths": "Berths",
+    "heads": "Heads",
+    "engineHp": "Engine",
+    "fuelCapacity": "Fuel",
+    "waterCapacity": "Water",
+    "hullMaterial": "Hull",
+    "keelType": "Keel"
+  },
+  "SocialShare": {
+    "share": "Share",
+    "shareOn": "Share on {platform}",
+    "copyLink": "Copy link",
+    "copy": "Copy",
+    "copied": "Copied!"
+  },
+  "TableOfContents": {
+    "label": "Page sections",
+    "heading": "On This Page"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -539,6 +539,17 @@
         "classMax": "Max catégorie",
         "percentile": "Percentile"
       }
+    },
+    "toc": {
+      "quickFacts": "En bref",
+      "specifications": "Spécifications",
+      "performance": "Performance",
+      "recommendation": "Pour qui ?",
+      "reviews": "Avis",
+      "media": "Galerie média",
+      "similar": "Yachts similaires",
+      "relatedGuides": "Guides associés",
+      "contact": "Contact & demandes"
     }
   },
   "YachtDetailSub": {
@@ -1172,5 +1183,35 @@
   },
   "UI": {
     "backToTop": "Retour en haut"
+  },
+  "QuickFacts": {
+    "sectionLabel": "En bref",
+    "heading": "En un coup d’œil",
+    "lengthOverall": "Longueur",
+    "beam": "Bau",
+    "draft": "Tirant d’eau",
+    "displacement": "Déplacement",
+    "ballast": "Lest",
+    "sailAreaMain": "Surface de voilure",
+    "rigType": "Gréement",
+    "cabins": "Cabines",
+    "berths": "Couchettes",
+    "heads": "Toilettes",
+    "engineHp": "Moteur",
+    "fuelCapacity": "Carburant",
+    "waterCapacity": "Eau",
+    "hullMaterial": "Coque",
+    "keelType": "Quille"
+  },
+  "SocialShare": {
+    "share": "Partager",
+    "shareOn": "Partager sur {platform}",
+    "copyLink": "Copier le lien",
+    "copy": "Copier",
+    "copied": "Copié !"
+  },
+  "TableOfContents": {
+    "label": "Sections de la page",
+    "heading": "Sur cette page"
   }
 }

--- a/tests/quick-facts.test.ts
+++ b/tests/quick-facts.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const projectRoot = resolve(__dirname, "..");
+
+describe("QuickFacts Component", () => {
+  const componentPath = resolve(projectRoot, "components/QuickFacts.tsx");
+  it("file exists", () => {
+    expect(existsSync(componentPath)).toBe(true);
+  });
+
+  it("exports default function", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("export default function QuickFacts");
+  });
+
+  it("has all required props interface", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("lengthOverall");
+    expect(content).toContain("beam");
+    expect(content).toContain("draft");
+    expect(content).toContain("displacement");
+    expect(content).toContain("cabins");
+    expect(content).toContain("berths");
+    expect(content).toContain("engineHp");
+  });
+
+  it("uses QuickFacts translation namespace", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('useTranslations("QuickFacts")');
+  });
+
+  it("has data-testid for integration testing", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('data-testid="quick-facts-section"');
+  });
+
+  it("formats displacement in tonnes", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    // Displacement should be divided by 1000 to show tonnes
+    expect(content).toContain("/ 1000");
+  });
+
+  it("returns null when all values are missing", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("facts.length === 0");
+    expect(content).toContain("return null");
+  });
+
+  it("highlights length overall with special styling", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("highlight");
+    expect(content).toContain("border-blue-200");
+  });
+});
+
+describe("QuickFacts i18n Messages", () => {
+  it("has all English translations", () => {
+    const en = JSON.parse(readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const qf = en.QuickFacts;
+    expect(qf).toBeDefined();
+    expect(qf.heading).toBeDefined();
+    expect(qf.lengthOverall).toBeDefined();
+    expect(qf.beam).toBeDefined();
+    expect(qf.draft).toBeDefined();
+    expect(qf.displacement).toBeDefined();
+    expect(qf.cabins).toBeDefined();
+    expect(qf.berths).toBeDefined();
+    expect(qf.engineHp).toBeDefined();
+    expect(qf.fuelCapacity).toBeDefined();
+    expect(qf.waterCapacity).toBeDefined();
+    expect(qf.rigType).toBeDefined();
+  });
+
+  it("has all French translations", () => {
+    const fr = JSON.parse(readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const qf = fr.QuickFacts;
+    expect(qf).toBeDefined();
+    expect(qf.heading).toBeDefined();
+    expect(qf.lengthOverall).toBeDefined();
+    expect(qf.beam).toBeDefined();
+    expect(qf.draft).toBeDefined();
+    expect(qf.displacement).toBeDefined();
+    expect(qf.cabins).toBeDefined();
+    expect(qf.berths).toBeDefined();
+  });
+});

--- a/tests/social-share.test.ts
+++ b/tests/social-share.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const projectRoot = resolve(__dirname, "..");
+
+describe("SocialShareButtons Component", () => {
+  const componentPath = resolve(projectRoot, "components/SocialShareButtons.tsx");
+
+  it("file exists", () => {
+    expect(existsSync(componentPath)).toBe(true);
+  });
+
+  it("exports default function", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("export default function SocialShareButtons");
+  });
+
+  it("has Twitter share link", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("twitter.com/intent/tweet");
+  });
+
+  it("has Facebook share link", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("facebook.com/sharer");
+  });
+
+  it("has LinkedIn share link", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("linkedin.com");
+  });
+
+  it("has copy link functionality using clipboard API", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("navigator.clipboard.writeText");
+  });
+
+  it("uses SocialShare translation namespace", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('useTranslations("SocialShare")');
+  });
+
+  it("has data-testid", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('data-testid="social-share-buttons"');
+  });
+
+  it("opens share links in new tab with rel=noopener", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('target="_blank"');
+    expect(content).toContain('rel="noopener noreferrer"');
+  });
+
+  it("shows copied state feedback", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("copied");
+    expect(content).toContain("Copied");
+  });
+});
+
+describe("SocialShare i18n Messages", () => {
+  it("has English translations", () => {
+    const en = JSON.parse(readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const ss = en.SocialShare;
+    expect(ss).toBeDefined();
+    expect(ss.share).toBeDefined();
+    expect(ss.shareOn).toBeDefined();
+    expect(ss.copyLink).toBeDefined();
+    expect(ss.copy).toBeDefined();
+    expect(ss.copied).toBeDefined();
+  });
+
+  it("has French translations", () => {
+    const fr = JSON.parse(readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const ss = fr.SocialShare;
+    expect(ss).toBeDefined();
+    expect(ss.share).toBe("Partager");
+    expect(ss.copy).toBe("Copier");
+    expect(ss.copied).toBeDefined();
+  });
+});

--- a/tests/table-of-contents.test.ts
+++ b/tests/table-of-contents.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const projectRoot = resolve(__dirname, "..");
+
+describe("TableOfContents Component", () => {
+  const componentPath = resolve(projectRoot, "components/TableOfContents.tsx");
+
+  it("file exists", () => {
+    expect(existsSync(componentPath)).toBe(true);
+  });
+
+  it("exports default function", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("export default function TableOfContents");
+  });
+
+  it("returns null when sections is empty", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("sections.length === 0");
+    expect(content).toContain("return null");
+  });
+
+  it("uses scrollIntoView for smooth scrolling", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("scrollIntoView");
+    expect(content).toContain("behavior: \"smooth\"");
+  });
+
+  it("has active section highlighting", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("activeId");
+    expect(content).toContain("text-primary");
+    expect(content).toContain("text-muted-foreground");
+  });
+
+  it("uses TableOfContents translation namespace", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('useTranslations("TableOfContents")');
+  });
+
+  it("is hidden on mobile and shown on desktop (lg:block)", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("hidden lg:block");
+  });
+
+  it("has sticky positioning for sidebar behavior", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("sticky");
+  });
+
+  it("has data-testid", () => {
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain('data-testid="table-of-contents"');
+  });
+});
+
+describe("TableOfContents i18n Messages", () => {
+  it("has English translations", () => {
+    const en = JSON.parse(readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const toc = en.TableOfContents;
+    expect(toc).toBeDefined();
+    expect(toc.heading).toBe("On This Page");
+    expect(toc.label).toBe("Page sections");
+  });
+
+  it("has French translations", () => {
+    const fr = JSON.parse(readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const toc = fr.TableOfContents;
+    expect(toc).toBeDefined();
+    expect(toc.heading).toBeDefined();
+    expect(toc.label).toBeDefined();
+  });
+});
+
+describe("YachtDetailClient — Enhanced Layout Integration", () => {
+  const clientPath = resolve(projectRoot, "app/[locale]/yachts/[slug]/YachtDetailClient.tsx");
+
+  it("imports QuickFacts component", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("import QuickFacts");
+  });
+
+  it("imports SocialShareButtons component", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("import SocialShareButtons");
+  });
+
+  it("imports TableOfContents component", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("import TableOfContents");
+  });
+
+  it("renders QuickFacts with id for TOC navigation", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain('id="quick-facts"');
+  });
+
+  it("renders specifications section with id", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain('id="specifications"');
+  });
+
+  it("renders performance section with id", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain('id="performance"');
+  });
+
+  it("renders reviews section with id", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain('id="reviews"');
+  });
+
+  it("renders contact section with id", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain('id="contact"');
+  });
+
+  it("uses two-column layout with TOC sidebar", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("TableOfContents sections={tocSections}");
+    expect(content).toContain("activeSection");
+  });
+
+  it("has IntersectionObserver for active TOC tracking", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("IntersectionObserver");
+  });
+
+  it("has enhanced spec grid with hover effects", () => {
+    const content = readFileSync(clientPath, "utf-8");
+    expect(content).toContain("hover:border-primary/30");
+  });
+
+  it("has YachtDetail TOC translations", () => {
+    const en = JSON.parse(readFileSync(resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const toc = en.YachtDetail.toc;
+    expect(toc).toBeDefined();
+    expect(toc.quickFacts).toBeDefined();
+    expect(toc.specifications).toBeDefined();
+    expect(toc.performance).toBeDefined();
+    expect(toc.recommendation).toBeDefined();
+    expect(toc.reviews).toBeDefined();
+    expect(toc.similar).toBeDefined();
+    expect(toc.relatedGuides).toBeDefined();
+    expect(toc.contact).toBeDefined();
+  });
+
+  it("has French TOC translations", () => {
+    const fr = JSON.parse(readFileSync(resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const toc = fr.YachtDetail.toc;
+    expect(toc).toBeDefined();
+    expect(toc.quickFacts).toBeDefined();
+    expect(toc.specifications).toBeDefined();
+    expect(toc.contact).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **P21.2 — Enhanced yacht detail layout** (closes #306)

### New Components
- **QuickFacts** — visual summary strip at the top of the page with icons for key specs (length, beam, draft, displacement, rig type, cabins, berths, engine, etc.)
- **SocialShareButtons** — share on Twitter, Facebook, LinkedIn + copy link to clipboard
- **TableOfContents** — sticky sidebar on desktop (lg+) with IntersectionObserver-based active section tracking

### Layout Changes
- Two-column layout on desktop: main content + TOC sidebar
- Section IDs added for all content areas (quick-facts, specifications, performance, recommendation, reviews, similar-yachts, related-guides, contact)
- Enhanced spec grid: 4-column responsive layout with hover effects
- Quick Facts section placed prominently after the hero section

### i18n
- New translation namespaces: QuickFacts, SocialShare, TableOfContents
- Full English and French translations
- YachtDetail.toc keys for section labels

### Tests
- 46 unit tests across 3 test files
- Component structure, translation coverage, and integration tests

## Checklist
- [x] Typecheck passes
- [x] Build passes
- [x] Tests pass (46/46)
- [x] i18n (en + fr)