### PR TITLE
fix: add ensureSchema() to also-viewed and generate-description API routes

### DIFF
--- a/app/api/admin/generate-description/route.ts
+++ b/app/api/admin/generate-description/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { pool } from "@/lib/db";
+import { ensureSchema, pool } from "@/lib/db";
 import {
   generateDescription,
   generateAllStyles,
@@ -7,6 +7,8 @@ import {
   scoreDescription,
   type DescriptionStyle,
 } from "@/lib/description-templates";
+
+export const dynamic = "force-dynamic";
 
 /**
  * GET /api/admin/generate-description?slug=<slug>&style=<style>
@@ -17,6 +19,8 @@ import {
 export async function GET(request: NextRequest) {
   const slug = request.nextUrl.searchParams.get("slug");
   const style = (request.nextUrl.searchParams.get("style") || "balanced") as DescriptionStyle;
+
+  await ensureSchema();
 
   if (slug) {
     // Generate description for a specific yacht

--- a/app/api/yachts/[slug]/also-viewed/route.ts
+++ b/app/api/yachts/[slug]/also-viewed/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { pool } from "@/lib/db";
+import { ensureSchema, pool } from "@/lib/db";
 import { buildFallbackAlsoViewed } from "@/lib/also-viewed";
+
+export const dynamic = "force-dynamic";
 
 export async function GET(
   request: NextRequest,
@@ -10,6 +12,8 @@ export async function GET(
 
   const client = await pool.connect();
   try {
+    await ensureSchema();
+
     // Get current yacht info
     const currentResult = await client.query(
       `SELECT ym.id, ym.length_overall, ym.manufacturer_id, m.name as manufacturer


### PR DESCRIPTION
Fixes 500 error on /api/yachts/[slug]/also-viewed by adding ensureSchema() call.