### PR TITLE
feat: Compare page structured data (P20.1)

### DIFF
--- a/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getYachtsBySlugs, generateComparisonIntro, generateComparisonMetadata, getPrimaryImage, type YachtComparisonData } from "@/lib/compare-canonical";
-import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
+import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd, generateComparePageJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 import { PriceTierBadge } from "@/app/components/PriceTierBadge";
 import { calculatePriceTier } from "@/lib/price-tier";
 import { localePath } from "@/lib/i18n-paths";
@@ -122,12 +122,27 @@ export default async function CanonicalComparePage({
     primaryImage: primaryImageUrlB ?? undefined,
   };
 
+  // Generate compare page structured data (ItemList with both products)
+  const comparePageJsonLd = generateComparePageJsonLd({
+    yachtA: yachtALdData,
+    yachtB: yachtBLdData,
+    slugA,
+    slugB,
+    locale,
+  });
+
   return (
     <>
       {/* Structured Data */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(comparePageJsonLd),
+        }}
       />
       <script
         type="application/ld+json"

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -792,3 +792,91 @@ export function generateDigitalDocumentJsonLd(params: {
     ...(params.encodingFormat ? { encodingFormat: params.encodingFormat } : {}),
   };
 }
+
+/* ------------------------------------------------------------------ */
+/*  Compare Page Structured Data (P20.1)                             */
+/* ------------------------------------------------------------------ */
+
+export interface JsonLdComparePage {
+  "@context": "https://schema.org";
+  "@type": "WebPage";
+  name: string;
+  description?: string;
+  url: string;
+  mainEntity: {
+    "@type": "ItemList";
+    name: string;
+    numberOfItems: number;
+    itemListElement: Array<{
+      "@type": "ListItem";
+      position: number;
+      name: string;
+      url: string;
+      item: JsonLdProduct;
+    }>;
+  };
+  about?: Array<{
+    "@type": "Product";
+    name: string;
+  }>;
+}
+
+/**
+ * Generate structured data for a yacht comparison page.
+ * Uses WebPage + ItemList schema to tell search engines this is a comparison
+ * of two products, with full Product schema for each yacht inline.
+ */
+export function generateComparePageJsonLd(params: {
+  yachtA: Parameters<typeof generateYachtJsonLd>[0];
+  yachtB: Parameters<typeof generateYachtJsonLd>[0];
+  slugA: string;
+  slugB: string;
+  locale?: string;
+}): JsonLdComparePage {
+  const locale = params.locale || "en";
+  const fullNameA = `${params.yachtA.manufacturer} ${params.yachtA.modelName}`;
+  const fullNameB = `${params.yachtB.manufacturer} ${params.yachtB.modelName}`;
+  const comparePath = `/compare/${params.slugA}-vs-${params.slugB}`;
+  const compareUrl = getSiteUrl(`/${locale}${comparePath}`);
+
+  const productA = generateYachtJsonLd(params.yachtA, locale);
+  const productB = generateYachtJsonLd(params.yachtB, locale);
+
+  const descriptions: Record<string, string> = {
+    en: `Side-by-side comparison of ${fullNameA} and ${fullNameB} sailing yachts with detailed specifications.`,
+    fr: `Comparaison côte à côte des voiliers ${fullNameA} et ${fullNameB} avec spécifications détaillées.`,
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `${fullNameA} vs ${fullNameB} — Sailing Yacht Comparison`,
+    description: descriptions[locale] || descriptions.en,
+    url: compareUrl,
+    mainEntity: {
+      "@type": "ItemList",
+      name: `${fullNameA} vs ${fullNameB}`,
+      numberOfItems: 2,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: fullNameA,
+          url: getSiteUrl(`/${locale}/yachts/${params.slugA}`),
+          item: productA,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: fullNameB,
+          url: getSiteUrl(`/${locale}/yachts/${params.slugB}`),
+          item: productB,
+        },
+      ],
+    },
+    about: [
+      { "@type": "Product", name: fullNameA },
+      { "@type": "Product", name: fullNameB },
+    ],
+  };
+}

--- a/tests/compare-structured-data.test.ts
+++ b/tests/compare-structured-data.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for P20.1 — Compare page structured data (Product comparison schema)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  generateComparePageJsonLd,
+  generateYachtJsonLd,
+} from "@/lib/seo";
+
+describe("generateComparePageJsonLd", () => {
+  const yachtA = {
+    manufacturer: "Beneteau",
+    modelName: "Oceanis 40.1",
+    year: 2020,
+    slug: "beneteau-oceanis-40-1",
+    lengthOverall: 12.43,
+    beam: 4.18,
+    draft: 2.45,
+    displacement: 8800,
+    hullMaterial: "GRP",
+    rigType: "Sloop",
+    cabins: 3,
+  };
+
+  const yachtB = {
+    manufacturer: "Jeanneau",
+    modelName: "Sun Odyssey 410",
+    year: 2019,
+    slug: "jeanneau-sun-odyssey-410",
+    lengthOverall: 12.35,
+    beam: 3.99,
+    draft: 2.24,
+    displacement: 8300,
+    hullMaterial: "GRP",
+    rigType: "Sloop",
+    cabins: 3,
+  };
+
+  it("generates a WebPage with ItemList mainEntity", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    expect(result["@context"]).toBe("https://schema.org");
+    expect(result["@type"]).toBe("WebPage");
+    expect(result.name).toContain("Beneteau Oceanis 40.1");
+    expect(result.name).toContain("Jeanneau Sun Odyssey 410");
+    expect(result.url).toContain("/compare/beneteau-oceanis-40-1-vs-jeanneau-sun-odyssey-410");
+    expect(result.mainEntity["@type"]).toBe("ItemList");
+    expect(result.mainEntity.numberOfItems).toBe(2);
+  });
+
+  it("includes both yachts as ListItem entries with full Product items", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    const items = result.mainEntity.itemListElement;
+    expect(items).toHaveLength(2);
+
+    // Item A
+    expect(items[0].position).toBe(1);
+    expect(items[0].name).toBe("Beneteau Oceanis 40.1");
+    expect(items[0].url).toContain("/yachts/beneteau-oceanis-40-1");
+    expect(items[0].item["@type"]).toBe("Product");
+    expect(items[0].item.name).toContain("Beneteau Oceanis 40.1");
+
+    // Item B
+    expect(items[1].position).toBe(2);
+    expect(items[1].name).toBe("Jeanneau Sun Odyssey 410");
+    expect(items[1].url).toContain("/yachts/jeanneau-sun-odyssey-410");
+    expect(items[1].item["@type"]).toBe("Product");
+    expect(items[1].item.name).toContain("Jeanneau Sun Odyssey 410");
+  });
+
+  it("includes Product specs as additionalProperty on each item", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    const productA = result.mainEntity.itemListElement[0].item;
+    expect(productA.additionalProperty).toBeDefined();
+    expect(productA.additionalProperty!.length).toBeGreaterThan(0);
+
+    // Check LOA is present
+    const loaProp = productA.additionalProperty!.find(
+      (p) => p.name === "Length Overall"
+    );
+    expect(loaProp).toBeDefined();
+    expect(loaProp!.value).toBe(12.43);
+    expect(loaProp!.unitCode).toBe("MTR");
+  });
+
+  it("includes about section referencing both products", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    expect(result.about).toHaveLength(2);
+    expect(result.about![0].name).toBe("Beneteau Oceanis 40.1");
+    expect(result.about![1].name).toBe("Jeanneau Sun Odyssey 410");
+  });
+
+  it("uses English description by default", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    expect(result.description).toContain("Side-by-side comparison");
+    expect(result.description).toContain("Beneteau Oceanis 40.1");
+    expect(result.description).toContain("Jeanneau Sun Odyssey 410");
+  });
+
+  it("uses French description when locale is fr", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+      locale: "fr",
+    });
+
+    expect(result.description).toContain("Comparaison côte à côte");
+    expect(result.url).toContain("/fr/compare/");
+  });
+
+  it("localizes Product additionalProperty names for French", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+      locale: "fr",
+    });
+
+    const productA = result.mainEntity.itemListElement[0].item;
+    const loaProp = productA.additionalProperty!.find(
+      (p) => p.name === "Longueur hors tout"
+    );
+    expect(loaProp).toBeDefined();
+  });
+
+  it("generates valid JSON that can be serialized", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).toBeTruthy();
+
+    // Verify it can be parsed back
+    const parsed = JSON.parse(serialized);
+    expect(parsed["@type"]).toBe("WebPage");
+    expect(parsed.mainEntity.itemListElement).toHaveLength(2);
+  });
+
+  it("handles yachts with minimal data", () => {
+    const minimalA = {
+      manufacturer: "Test",
+      modelName: "Boat A",
+      year: 2024,
+      slug: "test-boat-a",
+    };
+    const minimalB = {
+      manufacturer: "Test",
+      modelName: "Boat B",
+      year: 2024,
+      slug: "test-boat-b",
+    };
+
+    const result = generateComparePageJsonLd({
+      yachtA: minimalA,
+      yachtB: minimalB,
+      slugA: minimalA.slug,
+      slugB: minimalB.slug,
+    });
+
+    expect(result.mainEntity.numberOfItems).toBe(2);
+    expect(result.mainEntity.itemListElement[0].item.name).toContain("Test Boat A");
+  });
+
+  it("sets correct brand on each product", () => {
+    const result = generateComparePageJsonLd({
+      yachtA,
+      yachtB,
+      slugA: yachtA.slug,
+      slugB: yachtB.slug,
+    });
+
+    const productA = result.mainEntity.itemListElement[0].item;
+    expect(productA.brand).toBeDefined();
+    expect(productA.brand!.name).toBe("Beneteau");
+
+    const productB = result.mainEntity.itemListElement[1].item;
+    expect(productB.brand).toBeDefined();
+    expect(productB.brand!.name).toBe("Jeanneau");
+  });
+});


### PR DESCRIPTION
## Summary
Adds Product comparison schema (JSON-LD structured data) to the canonical compare detail pages.

### Changes
- **New function** `generateComparePageJsonLd()` in `lib/seo.ts`:
  - Uses `WebPage` type with `ItemList` as `mainEntity`
  - Each ListItem contains a full `Product` schema inline (brand, specs, additionalProperty)
  - `about` section references both products
  - Locale-aware descriptions (en/fr) and property name translations
- **Updated** compare detail page (`[slugA]-vs-[slugB]/page.tsx`) to render the compare page JSON-LD
- **10 unit tests** covering schema structure, localization, serialization, minimal data, and brand

### Structured Data Output
The compare page now emits 4 JSON-LD blocks:
1. BreadcrumbList (existing)
2. WebPage + ItemList compare schema (new)
3. Product schema for yacht A (existing)
4. Product schema for yacht B (existing)

### Testing
- Typecheck: ✅
- Build: ✅
- Vitest: ✅ 10/10

Relates to P20.1 — Compare page structured data (Product comparison schema)