### PR TITLE
fix: compare detail pages returning 404 (pg.Pool to neon-http)

### DIFF
--- a/lib/compare-canonical.ts
+++ b/lib/compare-canonical.ts
@@ -1,4 +1,4 @@
-import { pool } from "@/lib/db";
+import { neon } from "@neondatabase/serverless";
 import { unstable_cache } from "next/cache";
 
 export interface YachtComparisonData {
@@ -29,12 +29,22 @@ export interface YachtComparisonData {
   primaryImageUrl: string | null;
 }
 
+function getSql() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  return neon(connectionString);
+}
+
 async function getYachtsBySlugsUncached(
   slugA: string,
   slugB: string
 ): Promise<{ yachtA: YachtComparisonData | null; yachtB: YachtComparisonData | null }> {
-  const result = await pool.query(
-    `SELECT
+  const sql = getSql();
+
+  const rows = await sql`
+    SELECT
       ym.id, ym.model_name AS "modelName", ym.year, ym.slug,
       ym.length_overall AS "lengthOverall", ym.beam, ym.draft,
       ym.displacement, ym.ballast, ym.sail_area_main AS "sailAreaMain",
@@ -47,14 +57,27 @@ async function getYachtsBySlugsUncached(
       m.name AS manufacturer
     FROM yacht_models ym
     LEFT JOIN manufacturers m ON ym.manufacturer_id = m.id
-    WHERE ym.slug = $1 OR ym.slug = $2`,
-    [slugA, slugB]
-  );
+    WHERE ym.slug = ${slugA} OR ym.slug = ${slugB}
+  `;
 
-  console.log(`[canonical-compare] Query returned ${result.rows.length} yachts for slugs: ${slugA}, ${slugB}`);
+  console.log(`[canonical-compare] Query returned ${rows.length} yachts for slugs: ${slugA}, ${slugB}`);
 
-  const yachtA = result.rows.find((y: any) => y.slug === slugA) || null;
-  const yachtB = result.rows.find((y: any) => y.slug === slugB) || null;
+  // Normalize numeric fields from string (Neon HTTP returns decimal columns as strings)
+  const normalized = rows.map((row: any) => ({
+    ...row,
+    lengthOverall: row.lengthOverall != null ? Number(row.lengthOverall) : null,
+    beam: row.beam != null ? Number(row.beam) : null,
+    draft: row.draft != null ? Number(row.draft) : null,
+    displacement: row.displacement != null ? Number(row.displacement) : null,
+    ballast: row.ballast != null ? Number(row.ballast) : null,
+    sailAreaMain: row.sailAreaMain != null ? Number(row.sailAreaMain) : null,
+    engineHp: row.engineHp != null ? Number(row.engineHp) : null,
+    fuelCapacity: row.fuelCapacity != null ? Number(row.fuelCapacity) : null,
+    waterCapacity: row.waterCapacity != null ? Number(row.waterCapacity) : null,
+  }));
+
+  const yachtA = normalized.find((y: any) => y.slug === slugA) || null;
+  const yachtB = normalized.find((y: any) => y.slug === slugB) || null;
 
   console.log(`[canonical-compare] yachtA found: ${!!yachtA}, yachtB found: ${!!yachtB}`);
 
@@ -75,15 +98,14 @@ export async function getYachtsBySlugs(
 export async function getPrimaryImage(slug: string): Promise<string | null> {
   return unstable_cache(
     async () => {
-      const result = await pool.query(
-        `SELECT i.url FROM images i
-         JOIN yacht_models ym ON i.yacht_model_id = ym.id
-         WHERE ym.slug = $1 AND i.is_primary = true
-         LIMIT 1`,
-        [slug]
-      );
-
-      return result.rows[0]?.url || null;
+      const sql = getSql();
+      const rows = await sql`
+        SELECT i.url FROM images i
+        JOIN yacht_models ym ON i.yacht_model_id = ym.id
+        WHERE ym.slug = ${slug} AND i.is_primary = true
+        LIMIT 1
+      `;
+      return rows[0]?.url || null;
     },
     [`primary-image-${slug}`],
     { tags: ["images"], revalidate: 3600 }


### PR DESCRIPTION
## Problem
All canonical compare pages (e.g. `/compare/beneteau-oceanis-30-1-vs-jeanneau-sun-odyssey-349`) were returning 404 despite:
- The yacht slugs existing in the database
- The sitemap listing 2450 compare URLs
- HTTP 200 status code (soft 404)

## Root Cause
`compare-canonical.ts` used `pool.query()` (pg.Pool with TCP connections). These connections fail silently in Vercel's serverless Node.js runtime, causing the database query to return empty results and triggering `notFound()`.

## Fix
- Converted `compare-canonical.ts` from `pool.query()` (pg.Pool) to `neon()` HTTP client
- Added numeric normalization for Neon HTTP decimal columns (returned as strings)
- The neon HTTP driver is the recommended serverless-safe approach and matches the pattern used by the working API endpoints

## Testing
- Typecheck: ✅
- Build: ✅
- Vitest: ✅ 10/10 (structured data tests)