### PR TITLE
feat: Size category hub pages at /yachts/by-size/[sizeCategory] (P19.2)

### DIFF
--- a/app/[locale]/yachts/by-size/[sizeCategory]/SizeCategoryHubClient.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/SizeCategoryHubClient.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { localePath } from "@/lib/i18n-paths";
+import type { YachtListItem } from "@/lib/yachts";
+
+interface SizeCategoryHubClientProps {
+  yachts: YachtListItem[];
+  locale: string;
+}
+
+export function SizeCategoryHubClient({
+  yachts,
+  locale,
+}: SizeCategoryHubClientProps) {
+  if (yachts.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        {locale === "fr"
+          ? "Aucun voilier trouvé dans cette catégorie."
+          : "No yachts found in this size category."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {yachts.map((yacht) => {
+        const loa = yacht.lengthOverall
+          ? typeof yacht.lengthOverall === "number"
+            ? yacht.lengthOverall
+            : parseFloat(String(yacht.lengthOverall))
+          : null;
+        const loaFt = loa ? Math.round(loa * 3.28084) : null;
+
+        return (
+          <Link
+            key={yacht.id}
+            href={localePath(locale, `/yachts/${yacht.slug}`)}
+            className="group bg-white rounded-lg border border-gray-200 overflow-hidden hover:border-blue-300 hover:shadow-md transition-all"
+          >
+            <div className="p-4">
+              <div className="text-xs text-blue-600 font-medium mb-1">
+                {yacht.manufacturer}
+              </div>
+              <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+                {yacht.modelName}
+              </h3>
+              {yacht.year && (
+                <p className="text-sm text-gray-500">{yacht.year}</p>
+              )}
+
+              {/* Key Specs Grid */}
+              <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                {loa && (
+                  <div>
+                    <span className="text-gray-500">LOA</span>
+                    <p className="font-medium">
+                      {loa.toFixed(1)}m{loaFt ? ` (${loaFt}&apos;)` : ""}
+                    </p>
+                  </div>
+                )}
+                {yacht.beam && (
+                  <div>
+                    <span className="text-gray-500">Beam</span>
+                    <p className="font-medium">
+                      {typeof yacht.beam === "number"
+                        ? yacht.beam.toFixed(1)
+                        : String(yacht.beam)}
+                      m
+                    </p>
+                  </div>
+                )}
+                {yacht.cabins !== null && (
+                  <div>
+                    <span className="text-gray-500">Cabins</span>
+                    <p className="font-medium">{yacht.cabins}</p>
+                  </div>
+                )}
+                {yacht.berths !== null && (
+                  <div>
+                    <span className="text-gray-500">Berths</span>
+                    <p className="font-medium">{yacht.berths}</p>
+                  </div>
+                )}
+              </div>
+
+              {/* Tags */}
+              <div className="mt-3 flex flex-wrap gap-1">
+                {yacht.rigType && (
+                  <span className="text-xs bg-sky-50 text-sky-700 px-2 py-0.5 rounded-full">
+                    {yacht.rigType}
+                  </span>
+                )}
+                {yacht.keelType && (
+                  <span className="text-xs bg-gray-50 text-gray-600 px-2 py-0.5 rounded-full">
+                    {yacht.keelType}
+                  </span>
+                )}
+              </div>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/[locale]/yachts/by-size/[sizeCategory]/error.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    console.error("Size category page error:", error);
+  }, [error]);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+      <h2 className="text-2xl font-bold text-gray-900 mb-4">
+        Something went wrong
+      </h2>
+      <p className="text-gray-600 mb-6">
+        We couldn&apos;t load the yachts for this size category. Please try again.
+      </p>
+      <a
+        href="/yachts"
+        className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        Browse All Yachts
+      </a>
+    </div>
+  );
+}

--- a/app/[locale]/yachts/by-size/[sizeCategory]/loading.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-pulse">
+      {/* Header skeleton */}
+      <div className="bg-gray-100 rounded-lg h-12 w-3/4 mx-auto mb-4" />
+      <div className="bg-gray-100 rounded-lg h-6 w-1/2 mx-auto mb-8" />
+
+      <div className="flex flex-col lg:flex-row gap-8">
+        {/* Sidebar skeleton */}
+        <div className="lg:w-64 flex-shrink-0 space-y-4">
+          <div className="bg-gray-100 rounded-lg h-48" />
+          <div className="bg-gray-100 rounded-lg h-40" />
+        </div>
+
+        {/* Grid skeleton */}
+        <div className="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="bg-gray-100 rounded-lg h-48" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
@@ -1,0 +1,316 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getSizeCategoryHubData } from "@/lib/size-category-hub";
+import { getSizeCategorySlugs } from "@/lib/size-categories";
+import {
+  getSiteUrl,
+  generateBreadcrumbJsonLd,
+  generateCollectionPageJsonLd,
+  generateItemListJsonLd,
+  buildLocaleAlternates,
+  buildOgImageUrl,
+} from "@/lib/seo";
+import { localePath } from "@/lib/i18n-paths";
+import { SizeCategoryHubClient } from "./SizeCategoryHubClient";
+
+// Revalidate every 60 minutes
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all size categories that have yachts.
+ */
+export async function generateStaticParams() {
+  const slugs = getSizeCategorySlugs();
+  return slugs.map((sizeCategory) => ({ sizeCategory }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Record<string, string | undefined>>;
+}): Promise<Metadata> {
+  const rawParams = await params;
+  const sizeCategory = rawParams.sizeCategory;
+  if (!sizeCategory) notFound();
+
+  const locale = rawParams.locale || "en";
+  const data = await getSizeCategoryHubData(sizeCategory);
+  if (!data) notFound();
+
+  const sizeLabel =
+    locale === "fr" ? data.sizeCategory.labelFr : data.sizeCategory.labelEn;
+  const title = `${sizeLabel} Sailboats — All Manufacturers | Specs & Reviews`;
+  const description =
+    locale === "fr"
+      ? data.sizeCategory.descriptionFr("all manufacturers", data.yachts.length)
+      : data.sizeCategory.descriptionEn("all manufacturers", data.yachts.length);
+
+  const path = `/yachts/by-size/${sizeCategory}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: getSiteUrl(path),
+      type: "website",
+      siteName: "Sailing Yacht Info",
+      images: [
+        {
+          url: buildOgImageUrl({
+            type: "default",
+            title: `${sizeLabel} Sailboats`,
+            description: `${data.yachts.length} sailboats from ${data.topManufacturers.length} manufacturers`,
+          }),
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+    alternates: buildLocaleAlternates(path),
+  };
+}
+
+export default async function SizeCategoryHubPage({
+  params,
+}: {
+  params: Promise<Record<string, string | undefined>>;
+}) {
+  const rawParams = await params;
+  const sizeCategory = rawParams.sizeCategory;
+  if (!sizeCategory) notFound();
+
+  const locale = rawParams.locale || "en";
+  const data = await getSizeCategoryHubData(sizeCategory);
+  if (!data) notFound();
+
+  const sizeLabel =
+    locale === "fr" ? data.sizeCategory.labelFr : data.sizeCategory.labelEn;
+
+  const description =
+    locale === "fr"
+      ? data.sizeCategory.descriptionFr("all manufacturers", data.yachts.length)
+      : data.sizeCategory.descriptionEn("all manufacturers", data.yachts.length);
+
+  // JSON-LD: BreadcrumbList
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd(
+    [
+      { name: "Home", path: "/" },
+      { name: "Yachts", path: "/yachts" },
+      { name: "By Size", path: "/yachts/by-size" },
+      { name: sizeLabel, path: `/yachts/by-size/${sizeCategory}` },
+    ],
+    locale
+  );
+
+  // JSON-LD: CollectionPage
+  const collectionJsonLd = generateCollectionPageJsonLd({
+    name: `${sizeLabel} Sailboats`,
+    description,
+    url: getSiteUrl(`/yachts/by-size/${sizeCategory}`),
+    itemCount: data.yachts.length,
+  });
+
+  // JSON-LD: ItemList
+  const itemListJsonLd = generateItemListJsonLd({
+    name: `${sizeLabel} Sailboats`,
+    description,
+    items: data.yachts.slice(0, 20).map((y) => ({
+      name: `${y.manufacturer} ${y.modelName}`,
+      url: getSiteUrl(`/yachts/${y.slug}`),
+    })),
+  });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(collectionJsonLd),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(itemListJsonLd),
+        }}
+      />
+
+      {/* Breadcrumbs */}
+      <nav aria-label="Breadcrumb" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+        <ol className="flex items-center gap-2 text-sm text-muted-foreground">
+          <li>
+            <Link href={localePath(locale, "/")} className="hover:text-foreground transition-colors">
+              Home
+            </Link>
+          </li>
+          <li>
+            <span className="mx-1">/</span>
+            <Link href={localePath(locale, "/yachts")} className="hover:text-foreground transition-colors">
+              Yachts
+            </Link>
+          </li>
+          <li>
+            <span className="mx-1">/</span>
+            <Link href={localePath(locale, "/yachts/by-size/35-40ft")} className="hover:text-foreground transition-colors">
+              By Size
+            </Link>
+          </li>
+          <li>
+            <span className="mx-1">/</span>
+            <span className="text-foreground font-medium">{sizeLabel}</span>
+          </li>
+        </ol>
+      </nav>
+
+      {/* Page Header */}
+      <section className="bg-gradient-to-b from-sky-50 to-white py-12 px-4">
+        <div className="max-w-5xl mx-auto text-center">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            {sizeLabel}{" "}
+            {locale === "fr" ? "Voiliers" : "Sailboats"}
+          </h1>
+          <p className="text-lg text-gray-600 max-w-3xl mx-auto">
+            {description}
+          </p>
+          <div className="mt-4 flex justify-center gap-3">
+            <span className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 px-4 py-2 rounded-full text-sm font-medium">
+              <span className="text-lg">⛵</span>
+              {data.yachts.length}{" "}
+              {locale === "fr" ? "voiliers" : "sailboats"}
+            </span>
+            <span className="inline-flex items-center gap-2 bg-green-50 text-green-700 px-4 py-2 rounded-full text-sm font-medium">
+              {data.topManufacturers.length}{" "}
+              {locale === "fr" ? "constructeurs" : "manufacturers"}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Main Content */}
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col lg:flex-row gap-8">
+          {/* Sidebar */}
+          <aside className="lg:w-64 flex-shrink-0">
+            {/* Other Size Categories */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4 mb-4">
+              <h3 className="text-sm font-semibold text-gray-900 mb-3 uppercase tracking-wider">
+                {locale === "fr" ? "Tailles" : "Sizes"}
+              </h3>
+              <ul className="space-y-2">
+                {data.otherSizes.map((sc) => (
+                  <li key={sc.slug}>
+                    {sc.count > 0 ? (
+                      <Link
+                        href={localePath(locale, `/yachts/by-size/${sc.slug}`)}
+                        className="flex items-center justify-between text-sm text-gray-600 hover:text-blue-600 transition-colors"
+                      >
+                        <span>{locale === "fr" ? sc.labelFr : sc.labelEn}</span>
+                        <span className="text-xs bg-gray-100 px-2 py-0.5 rounded-full">
+                          {sc.count}
+                        </span>
+                      </Link>
+                    ) : (
+                      <span className="flex items-center justify-between text-sm text-gray-300">
+                        <span>{locale === "fr" ? sc.labelFr : sc.labelEn}</span>
+                        <span className="text-xs">0</span>
+                      </span>
+                    )}
+                  </li>
+                ))}
+                {/* Current size */}
+                <li>
+                  <span className="flex items-center justify-between text-sm text-blue-600 font-medium">
+                    <span>{sizeLabel}</span>
+                    <span className="text-xs bg-blue-100 px-2 py-0.5 rounded-full">
+                      {data.yachts.length}
+                    </span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+
+            {/* Top Manufacturers in this size */}
+            {data.topManufacturers.length > 0 && (
+              <div className="bg-white rounded-lg border border-gray-200 p-4">
+                <h3 className="text-sm font-semibold text-gray-900 mb-3 uppercase tracking-wider">
+                  {locale === "fr"
+                    ? "Constructeurs populaires"
+                    : "Top Manufacturers"}
+                </h3>
+                <ul className="space-y-2">
+                  {data.topManufacturers.map((m) => (
+                    <li key={m.slug}>
+                      <Link
+                        href={localePath(
+                          locale,
+                          `/manufacturers/${m.slug}/${sizeCategory}`
+                        )}
+                        className="flex items-center justify-between text-sm text-gray-600 hover:text-blue-600 transition-colors"
+                      >
+                        <span>{m.name}</span>
+                        <span className="text-xs bg-gray-100 px-2 py-0.5 rounded-full">
+                          {m.count}
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </aside>
+
+          {/* Yacht Grid */}
+          <div className="flex-1">
+            <SizeCategoryHubClient yachts={data.yachts} locale={locale} />
+          </div>
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="bg-gray-50 py-8 px-4">
+        <div className="max-w-5xl mx-auto text-center">
+          <p className="text-gray-600 mb-4">
+            {locale === "fr"
+              ? "Explorez par constructeur ou comparez des voiliers"
+              : "Explore by manufacturer or compare sailboats"}
+          </p>
+          <div className="flex justify-center gap-4">
+            <Link
+              href={localePath(locale, "/manufacturers")}
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+            >
+              {locale === "fr"
+                ? "Tous les constructeurs"
+                : "All Manufacturers"}
+            </Link>
+            <Link
+              href={localePath(locale, "/yachts")}
+              className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+            >
+              {locale === "fr" ? "Tous les voiliers" : "All Yachts"}
+            </Link>
+            <Link
+              href={localePath(locale, "/compare")}
+              className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+            >
+              {locale === "fr" ? "Comparer" : "Compare"}
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/lib/size-category-hub.ts
+++ b/lib/size-category-hub.ts
@@ -1,0 +1,141 @@
+/**
+ * Data layer for size category hub pages.
+ * Route: /yachts/by-size/[sizeCategory]
+ */
+
+import { db, yachtModels, manufacturers } from "@/lib/db";
+import { eq, and, sql, count, asc } from "drizzle-orm";
+import { SIZE_CATEGORIES, type SizeCategory } from "@/lib/size-categories";
+import type { YachtListItem } from "@/lib/yachts";
+import { slugify } from "@/lib/utils/slugify";
+
+export interface SizeCategoryHubData {
+  sizeCategory: SizeCategory;
+  yachts: YachtListItem[];
+  otherSizes: Array<{
+    slug: string;
+    labelEn: string;
+    labelFr: string;
+    count: number;
+  }>;
+  topManufacturers: Array<{
+    name: string;
+    slug: string;
+    count: number;
+  }>;
+}
+
+/**
+ * Fetch all data for a size category hub page.
+ */
+export async function getSizeCategoryHubData(
+  sizeCategorySlug: string
+): Promise<SizeCategoryHubData | null> {
+  const sizeCategory = SIZE_CATEGORIES.find((c) => c.slug === sizeCategorySlug);
+  if (!sizeCategory) return null;
+
+  // Get yachts in this size range, across all manufacturers
+  const yachts = await db
+    .select({
+      id: yachtModels.id,
+      manufacturer: manufacturers.name,
+      modelName: yachtModels.modelName,
+      year: yachtModels.year,
+      slug: yachtModels.slug,
+      lengthOverall: yachtModels.lengthOverall,
+      beam: yachtModels.beam,
+      draft: yachtModels.draft,
+      displacement: yachtModels.displacement,
+      ballast: yachtModels.ballast,
+      sailAreaMain: yachtModels.sailAreaMain,
+      rigType: yachtModels.rigType,
+      keelType: yachtModels.keelType,
+      hullMaterial: yachtModels.hullMaterial,
+      cabins: yachtModels.cabins,
+      berths: yachtModels.berths,
+      heads: yachtModels.heads,
+      maxOccupancy: yachtModels.maxOccupancy,
+      engineHp: yachtModels.engineHp,
+      engineType: yachtModels.engineType,
+      fuelCapacity: yachtModels.fuelCapacity,
+      waterCapacity: yachtModels.waterCapacity,
+      description: yachtModels.description,
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(
+      and(
+        sql`${yachtModels.lengthOverall}::numeric >= ${sizeCategory.loaMin}`,
+        sql`${yachtModels.lengthOverall}::numeric < ${sizeCategory.loaMax}`
+      )
+    )
+    .orderBy(yachtModels.modelName);
+
+  if (yachts.length === 0) return null;
+
+  // Get counts for other size categories
+  const otherSizes = await Promise.all(
+    SIZE_CATEGORIES.filter((sc) => sc.slug !== sizeCategorySlug).map(
+      async (sc) => {
+        const result = await db
+          .select({ cnt: count() })
+          .from(yachtModels)
+          .where(
+            and(
+              sql`${yachtModels.lengthOverall}::numeric >= ${sc.loaMin}`,
+              sql`${yachtModels.lengthOverall}::numeric < ${sc.loaMax}`
+            )
+          );
+        return {
+          slug: sc.slug,
+          labelEn: sc.labelEn,
+          labelFr: sc.labelFr,
+          count: result[0]?.cnt ?? 0,
+        };
+      }
+    )
+  );
+
+  // Get top manufacturers in this size range with counts
+  const allMfrs = await db
+    .select({
+      id: manufacturers.id,
+      name: manufacturers.name,
+    })
+    .from(manufacturers);
+
+  const topManufacturers = (
+    await Promise.all(
+      allMfrs.map(async (m: { id: number; name: string }) => {
+        const result = await db
+          .select({ cnt: count() })
+          .from(yachtModels)
+          .innerJoin(
+            manufacturers,
+            eq(yachtModels.manufacturerId, manufacturers.id)
+          )
+          .where(
+            and(
+              eq(manufacturers.id, m.id),
+              sql`${yachtModels.lengthOverall}::numeric >= ${sizeCategory.loaMin}`,
+              sql`${yachtModels.lengthOverall}::numeric < ${sizeCategory.loaMax}`
+            )
+          );
+        return {
+          name: m.name,
+          slug: slugify(m.name),
+          count: result[0]?.cnt ?? 0,
+        };
+      })
+    )
+  )
+    .filter((m) => m.count > 0)
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    sizeCategory,
+    yachts,
+    otherSizes,
+    topManufacturers,
+  };
+}

--- a/tests/size-category-hub.test.ts
+++ b/tests/size-category-hub.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { getSizeCategorySlugs, SIZE_CATEGORIES } from "@/lib/size-categories";
+
+describe("size-category-hub", () => {
+  describe("size category hub routes", () => {
+    it("all 6 size categories have valid slugs for hub pages", () => {
+      const slugs = getSizeCategorySlugs();
+      expect(slugs).toEqual([
+        "under-30ft",
+        "30-35ft",
+        "35-40ft",
+        "40-45ft",
+        "45-50ft",
+        "over-50ft",
+      ]);
+    });
+
+    it("hub route pattern /yachts/by-size/:slug is valid for each category", () => {
+      const slugs = getSizeCategorySlugs();
+      for (const slug of slugs) {
+        const path = `/yachts/by-size/${slug}`;
+        expect(path).toMatch(/^\/yachts\/by-size\/[a-z0-9-]+$/);
+      }
+    });
+
+    it("each category description works with 'all manufacturers' context", () => {
+      for (const cat of SIZE_CATEGORIES) {
+        const descEn = cat.descriptionEn("all manufacturers", 50);
+        expect(descEn).toContain("50");
+        expect(descEn.length).toBeGreaterThan(50);
+
+        const descFr = cat.descriptionFr("all manufacturers", 50);
+        expect(descFr).toContain("50");
+        expect(descFr.length).toBeGreaterThan(50);
+      }
+    });
+  });
+
+  describe("hub page metadata", () => {
+    it("generates valid title for each size category", () => {
+      for (const cat of SIZE_CATEGORIES) {
+        const title = `${cat.labelEn} Sailboats — All Manufacturers | Specs & Reviews`;
+        expect(title).toContain(cat.labelEn);
+        expect(title.length).toBeGreaterThan(20);
+        expect(title.length).toBeLessThan(70);
+      }
+    });
+
+    it("generates valid French title for each size category", () => {
+      for (const cat of SIZE_CATEGORIES) {
+        const title = `${cat.labelFr} Voiliers — Tous les constructeurs`;
+        expect(title).toContain(cat.labelFr);
+      }
+    });
+  });
+
+  describe("hub to manufacturer+size cross-linking", () => {
+    it("manufacturer+size route can be constructed from hub data", () => {
+      const mfrSlug = "beneteau";
+      const sizeSlug = "40-45ft";
+      const path = `/manufacturers/${mfrSlug}/${sizeSlug}`;
+      expect(path).toBe("/manufacturers/beneteau/40-45ft");
+    });
+
+    it("all hub pages link to corresponding manufacturer+size sub-pages", () => {
+      const slugs = getSizeCategorySlugs();
+      for (const sizeSlug of slugs) {
+        // Hub page should construct manufacturer+size links
+        const exampleMfrPath = `/manufacturers/beneteau/${sizeSlug}`;
+        expect(exampleMfrPath).toMatch(
+          /^\/manufacturers\/[a-z0-9-]+\/[a-z0-9-]+$/
+        );
+      }
+    });
+  });
+
+  describe("generateStaticParams", () => {
+    it("returns params for all 6 size categories", () => {
+      const slugs = getSizeCategorySlugs();
+      const params = slugs.map((sizeCategory) => ({ sizeCategory }));
+      expect(params).toHaveLength(6);
+      expect(params[0]).toEqual({ sizeCategory: "under-30ft" });
+      expect(params[5]).toEqual({ sizeCategory: "over-50ft" });
+    });
+  });
+});


### PR DESCRIPTION
## P19.2 — Size Category Hub Pages

Closes #329

### What's new
- **Route:** `/yachts/by-size/[sizeCategory]` — 6 hub pages (under-30ft, 30-35ft, 35-40ft, 40-45ft, 45-50ft, over-50ft)
- Aggregates all yachts across manufacturers for a given LOA range
- Sidebar: links to other size categories with counts
- Sidebar: top manufacturers in this size range with links to manufacturer+size sub-pages (P19.1)
- Full SEO: OG image, JSON-LD (BreadcrumbList, CollectionPage, ItemList), locale alternates
- i18n support (en + fr)
- Loading skeleton + error boundary
- 8 new unit tests

### Files changed
- `lib/size-category-hub.ts` — data fetching for hub pages
- `app/[locale]/yachts/by-size/[sizeCategory]/page.tsx` — server page
- `app/[locale]/yachts/by-size/[sizeCategory]/SizeCategoryHubClient.tsx` — client grid
- `app/[locale]/yachts/by-size/[sizeCategory]/loading.tsx` — skeleton
- `app/[locale]/yachts/by-size/[sizeCategory]/error.tsx` — error boundary
- `tests/size-category-hub.test.ts` — unit tests

### Verification
- ✅ Typecheck passes
- ✅ Build passes (SSG prerendered)
- ✅ 8/8 new tests pass