### PR TITLE
feat(seo): internal linking mesh for programmatic SEO pages (closes #337)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -52,7 +52,7 @@
 - **P19.2 — Size category hub pages** *(completed 2026-05-25 — PR #330-#332, Issue #329, 8 tests)* — Route `/yachts/by-size/[sizeCategory]` aggregating all manufacturers for a size range. Internal links to manufacturer+size sub-pages.
 - **P19.3 — Use-case landing pages** *(completed 2026-05-26 — PR #334, Issue #333, 10 tests)* — Route `/yachts/[useCase]` (e.g., `/yachts/bluewater-cruising`, `/yachts/racing`, `/yachts/family-cruising`) with curated yacht selections, guide links, and SEO content.
 - **P19.4 — Sitemap integration for programmatic pages** *(completed 2026-05-26 — Issue #335)* — Add all generated landing pages to sitemap-programmatic.xml with proper `<lastmod>`, `<changefreq>`, and `<priority>` values.
-- **P19.5 — Internal linking mesh** — Cross-link from yacht detail pages to their manufacturer+size and use-case pages. Add "Related Categories" section on manufacturer detail pages.
+- **P19.5 — Internal linking mesh** *(completed 2026-05-26 — Issue #337)* — Cross-link from yacht detail pages to manufacturer+size, size hub, and use-case pages. Add "Related Categories" section on manufacturer detail and size hub pages.
 
 ### Phase 20 — Content Enrichment & Authority Building (Priority: Medium) — 🔲 PLANNED
 

--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
 import { getCountryFlag } from "@/lib/utils/country-flags";
 import { getSpotlightByManufacturerId } from "@/lib/manufacturer-spotlights";
 import { ManufacturerComparisons } from "./ManufacturerComparisons";
+import { SIZE_CATEGORIES } from "@/lib/size-categories";
 import ManufacturerLogo from "@/components/manufacturer-logo";
 import { localePath } from "@/lib/i18n-paths";
 import dynamic from "next/dynamic";
@@ -278,25 +279,19 @@ export default async function ManufacturerPage({
         )}
 
 
-        {/* Cross-linking: Browse by Size */}
+        {/* Cross-linking: Browse by Size — links to manufacturer+size category pages */}
         <section className="mt-10 sm:mt-12 bg-muted/30 rounded-xl p-6">
           <h2 className="text-lg font-semibold mb-4">{t("detail.browseBySize.title", { name: manufacturer.name })}</h2>
           <div className="flex flex-wrap gap-3">
-            <Link href={localePath(locale, "/yachts?minLength=0&maxLength=30")} className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors">
-              {t("detail.browseBySize.under30")}
-            </Link>
-            <Link href={localePath(locale, "/yachts?minLength=30&maxLength=35")} className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors">
-              {t("detail.browseBySize.range3035")}
-            </Link>
-            <Link href={localePath(locale, "/yachts?minLength=35&maxLength=40")} className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors">
-              {t("detail.browseBySize.range3540")}
-            </Link>
-            <Link href={localePath(locale, "/yachts?minLength=40&maxLength=50")} className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors">
-              {t("detail.browseBySize.range4050")}
-            </Link>
-            <Link href={localePath(locale, "/yachts?minLength=50")} className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors">
-              {t("detail.browseBySize.over50")}
-            </Link>
+            {SIZE_CATEGORIES.map((sc) => (
+              <Link
+                key={sc.slug}
+                href={localePath(locale, `/manufacturers/${slug}/${sc.slug}`)}
+                className="inline-flex items-center rounded-full bg-background border border-border px-4 py-2 text-sm hover:bg-accent transition-colors"
+              >
+                {locale === "fr" ? sc.labelFr : sc.labelEn}
+              </Link>
+            ))}
           </div>
         </section>
 

--- a/app/[locale]/yachts/[slug]/RelatedCategories.tsx
+++ b/app/[locale]/yachts/[slug]/RelatedCategories.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
+import { Tag, Ruler, Compass } from "lucide-react";
+import { getSizeCategoryForLoa } from "@/lib/size-categories";
+import { slugify } from "@/lib/utils/slugify";
+import {
+  assignUseCaseTags,
+  type YachtSpecForTags,
+} from "@/lib/use-case-tags";
+import { USE_CASES } from "@/lib/use-case-meta";
+
+interface RelatedCategoriesProps {
+  manufacturer: string;
+  lengthOverall: number | string | null;
+  displacement: number | string | null;
+  sailAreaMain: number | string | null;
+  beam: number | string | null;
+  draft: number | string | null;
+  ballast: number | string | null;
+  hullMaterial: string | null;
+  cabins: number | string | null;
+  berths: number | string | null;
+  rigType: string | null;
+  keelType: string | null;
+}
+
+function parseNum(v: number | string | null): number | null {
+  if (v == null) return null;
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return isNaN(n) ? null : n;
+}
+
+export function RelatedCategories({
+  manufacturer,
+  lengthOverall,
+  displacement,
+  sailAreaMain,
+  beam,
+  draft,
+  ballast,
+  hullMaterial,
+  cabins,
+  berths,
+  rigType,
+  keelType,
+}: RelatedCategoriesProps) {
+  const t = useTranslations("RelatedCategories");
+  const locale = useLocale();
+  const links: Array<{ href: string; label: string; icon: React.ReactNode }> = [];
+
+  const loa = parseNum(lengthOverall);
+  const mfrSlug = slugify(manufacturer);
+
+  // 1. Manufacturer + size category page
+  if (loa) {
+    const sc = getSizeCategoryForLoa(loa);
+    if (sc) {
+      links.push({
+        href: `/${locale}/manufacturers/${mfrSlug}/${sc.slug}`,
+        label: locale === "fr" ? `${sc.labelFr} ${manufacturer}` : `${manufacturer} ${sc.labelEn}`,
+        icon: <Tag className="w-4 h-4" />,
+      });
+
+      // 2. Size category hub page
+      links.push({
+        href: `/${locale}/yachts/by-size/${sc.slug}`,
+        label: locale === "fr" ? sc.labelFr : sc.labelEn,
+        icon: <Ruler className="w-4 h-4" />,
+      });
+    }
+  }
+
+  // 3. Use-case pages based on yacht specs
+  const specForTags: YachtSpecForTags = {
+    lengthOverall: loa,
+    displacement: parseNum(displacement),
+    sailAreaMain: parseNum(sailAreaMain),
+    beam: parseNum(beam),
+    draft: parseNum(draft),
+    ballast: parseNum(ballast),
+    cabins: parseNum(cabins),
+    berths: parseNum(berths),
+    rigType,
+    keelType,
+  };
+
+  const useCaseTags = assignUseCaseTags(specForTags);
+  for (const tag of useCaseTags) {
+    const uc = USE_CASES.find((u) => u.id === tag);
+    if (uc) {
+      links.push({
+        href: `/${locale}/yachts/for/${uc.slug}`,
+        label: locale === "fr" ? uc.labelFr : uc.labelEn,
+        icon: <Compass className="w-4 h-4" />,
+      });
+    }
+  }
+
+  if (links.length === 0) return null;
+
+  return (
+    <div className="related-categories-section mt-6 no-print">
+      <h3 className="text-lg font-semibold text-foreground mb-3">
+        {t("title")}
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+          >
+            {link.icon}
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -17,6 +17,7 @@ import { SimilarYachts } from "./SimilarYachts";
 import { UsersAlsoViewed } from "./UsersAlsoViewed";
 import { SameSizeAlternatives } from "./SameSizeAlternatives";
 import { RelatedManufacturers } from "./RelatedManufacturers";
+import { RelatedCategories } from "./RelatedCategories";
 import { RelatedGuides } from "./RelatedGuides";
 import { RelatedArticles } from "./RelatedArticles";
 import AffiliateRecommendations from "@/app/components/AffiliateRecommendations";
@@ -799,6 +800,22 @@ export default function YachtDetailClient() {
                   aria-hidden="true" />
               </div>
             )}
+
+            {/* Related Categories (size, use-case links) */}
+            <RelatedCategories
+              manufacturer={yacht.manufacturer}
+              lengthOverall={yacht.lengthOverall}
+              displacement={yacht.displacement}
+              sailAreaMain={yacht.sailAreaMain}
+              beam={yacht.beam}
+              draft={yacht.draft}
+              ballast={yacht.ballast}
+              hullMaterial={yacht.hullMaterial}
+              cabins={yacht.cabins}
+              berths={yacht.berths}
+              rigType={yacht.rigType}
+              keelType={yacht.keelType}
+            />
           </div>
 
           {/* Users Also Viewed */}

--- a/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/seo";
 import { localePath } from "@/lib/i18n-paths";
 import { SizeCategoryHubClient } from "./SizeCategoryHubClient";
+import { USE_CASES } from "@/lib/use-case-meta";
 
 // Force dynamic rendering — DB queries must run at request time
 export const dynamic = "force-dynamic";
@@ -263,6 +264,26 @@ export default async function SizeCategoryHubPage({
                 </ul>
               </div>
             )}
+
+            {/* Related Use Cases */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4 mt-4">
+              <h3 className="text-sm font-semibold text-gray-900 mb-3 uppercase tracking-wider">
+                {locale === "fr" ? "Cas d\'utilisation" : "Use Cases"}
+              </h3>
+              <ul className="space-y-2">
+                {USE_CASES.map((uc) => (
+                  <li key={uc.slug}>
+                    <Link
+                      href={localePath(locale, `/yachts/for/${uc.slug}`)}
+                      className="flex items-center gap-2 text-sm text-gray-600 hover:text-blue-600 transition-colors"
+                    >
+                      <span>{uc.emoji}</span>
+                      <span>{locale === "fr" ? uc.labelFr : uc.labelEn}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </aside>
 
           {/* Yacht Grid */}

--- a/lib/use-case-meta.ts
+++ b/lib/use-case-meta.ts
@@ -1,0 +1,78 @@
+/**
+ * Use-case tag IDs and metadata.
+ * Shared between client and server — no DB imports.
+ */
+
+export type UseCaseTagId =
+  | "bluewater-cruiser"
+  | "weekend-sailor"
+  | "racing"
+  | "liveaboard"
+  | "family-cruiser"
+  | "light-wind-performer";
+
+export const USE_CASE_IDS: UseCaseTagId[] = [
+  "bluewater-cruiser",
+  "weekend-sailor",
+  "racing",
+  "liveaboard",
+  "family-cruiser",
+  "light-wind-performer",
+];
+
+export interface UseCaseMeta {
+  id: UseCaseTagId;
+  slug: string;
+  labelEn: string;
+  labelFr: string;
+  emoji: string;
+}
+
+export const USE_CASES: UseCaseMeta[] = [
+  {
+    id: "bluewater-cruiser",
+    slug: "bluewater-cruiser",
+    labelEn: "Bluewater Cruising",
+    labelFr: "Croisière Hauturière",
+    emoji: "🌊",
+  },
+  {
+    id: "weekend-sailor",
+    slug: "weekend-sailor",
+    labelEn: "Weekend Sailing",
+    labelFr: "Sorties Week-end",
+    emoji: "⛵",
+  },
+  {
+    id: "racing",
+    slug: "racing",
+    labelEn: "Racing",
+    labelFr: "Régate",
+    emoji: "🏆",
+  },
+  {
+    id: "liveaboard",
+    slug: "liveaboard",
+    labelEn: "Liveaboard",
+    labelFr: "Habitable",
+    emoji: "🏠",
+  },
+  {
+    id: "family-cruiser",
+    slug: "family-cruiser",
+    labelEn: "Family Cruising",
+    labelFr: "Croisière Familiale",
+    emoji: "👨‍👩‍👧‍👦",
+  },
+  {
+    id: "light-wind-performer",
+    slug: "light-wind-performer",
+    labelEn: "Light Wind Performance",
+    labelFr: "Performance vents légers",
+    emoji: "🌤️",
+  },
+];
+
+export function getUseCaseMeta(slug: string): UseCaseMeta | undefined {
+  return USE_CASES.find((uc) => uc.slug === slug);
+}

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,59 +1,55 @@
 # Sailing Yachts Builder Session Summary
 
-**Date:** 2026-05-25 (evening session)
+**Date:** 2026-05-26 (10:20 PM session)
 **Session type:** Automated feature rollout loop (cron)
 
 ## Issues Worked On
 
-### P19.2 — Size Category Hub Pages (Issue #329, PRs #330, #331, #332)
-- **Route:** `/yachts/by-size/[sizeCategory]` — 6 hub pages
-- **Size categories:** under-30ft, 30-35ft, 35-40ft, 40-45ft, 45-50ft, over-50ft
-- **Features:** Yacht grid across all manufacturers, sidebar (other sizes + top manufacturers), full SEO (OG images, JSON-LD BreadcrumbList/CollectionPage/ItemList), i18n (en+fr), loading skeleton, error boundary
-- **8 new unit tests** for hub page logic
-- **Issues found & fixed:**
-  - Initial SSG approach caused 404 (DB not available at build time) → switched to dynamic rendering
-  - N+1 DB queries per manufacturer caused 500 → optimized with GROUP BY
+### P19.4 — Sitemap Integration for Programmatic Pages (Issue #335, PR #336)
+- **New route:** `sitemap-programmatic.xml` — dynamic sitemap for all programmatic SEO landing pages
+- **Pages included:**
+  - Manufacturer+size (`/manufacturers/[slug]/[sizeCategory]`) — from DB with graceful fallback
+  - Size category hubs (`/yachts/by-size/[sizeCategory]`) — 6 × 2 locales = 12 URLs
+  - Use-case pages (`/yachts/for/[useCase]`) — 6 × 2 locales = 12 URLs
+- **Also fixed:** Made `sitemap.xml` index and `feed.xml` dynamic (`force-dynamic`) to resolve CI build failures from Neon DB compute quota exceeded errors
+- **Registered** in sitemap index and robots.txt (7 sub-sitemaps total now)
 
 ## Build/Test Results
 - **Typecheck:** ✅ Pass
 - **Build:** ✅ Pass
-- **Vitest:** ✅ 1303/1303 (8 new hub tests)
+- **Vitest:** ✅ 2/2 unit tests pass
+- **CI (GitHub Actions):** ✅ Build + Lint + TypeScript + Performance Budgets all pass
 
 ## Deploy Status
-- **PR #330** (initial SSG): ❌ 404 on live
-- **PR #331** (dynamic rendering): ❌ 500 (N+1 queries)
-- **PR #332** (GROUP BY optimization): ✅ Merged, deployed, verified
+- **PR #336:** ✅ Merged via squash, deployed to Vercel
+- **Production deployment:** ✅ Ready (info.sailboats.fr)
 
 ## Live Verification Results
 - **/**: ✅ OK
 - **/yachts**: ✅ OK
 - **/search**: ✅ OK
 - **/compare**: ✅ OK
-- **/api/yachts**: ✅ OK (243 yachts)
-- **/yachts/by-size/under-30ft**: ✅ OK
-- **/yachts/by-size/30-35ft**: ✅ OK
-- **/yachts/by-size/35-40ft**: ✅ OK
-- **/yachts/by-size/40-45ft**: ✅ OK (verified cross-links to manufacturer+size pages)
-- **/yachts/by-size/45-50ft**: ✅ OK
-- **/yachts/by-size/over-50ft**: ✅ OK
-- **/manufacturers/beneteau/40-45ft**: ✅ OK (still works)
-- **French locale (/fr/yachts/by-size/40-45ft)**: ✅ OK
+- **/sitemap.xml**: ✅ OK (7 sub-sitemaps including new sitemap-programmatic.xml)
+- **/sitemap-programmatic.xml**: ✅ OK (24 URLs: size hubs + use-case pages)
+- **/en/yachts/for/bluewater-cruiser**: ✅ OK
+- **/en/yachts/by-size/40-45ft**: ✅ OK
+- **API /api/yachts**: ❌ 500 (Neon DB quota exceeded — infrastructure issue, not code issue)
 
 ## Phase Status
 - Phase 14–18: ✅ COMPLETE
 - Phase 19 (Programmatic SEO Landing Pages): 🔄 ACTIVE
   - P19.1: ✅ COMPLETE (manufacturer+size category pages)
   - P19.2: ✅ COMPLETE (size category hub pages)
-  - P19.3–P19.5: 🔲 TODO
+  - P19.3: ✅ COMPLETE (use-case landing pages)
+  - P19.4: ✅ COMPLETE (sitemap integration for programmatic pages)
+  - P19.5: 🔲 TODO (internal linking mesh)
 - Phase 20–27: 🔲 PLANNED
 
 ## Technical Notes
-- Size category hub pages must be dynamic (`export const dynamic = "force-dynamic"`) — DB queries fail at build time
-- Use GROUP BY instead of N+1 queries for manufacturer counts — avoids Neon HTTP timeout
-- Hub pages cross-link to manufacturer+size sub-pages via sidebar
-- `buildOgImageUrl` type param `default` works for hub pages
+- Neon DB compute quota exceeded — affects build-time static generation and API responses
+- `force-dynamic` on routes that query DB prevents build-time failures
+- Manufacturer+size URLs in sitemap will populate once DB quota resets (graceful degradation)
+- Sitemap-programmatic.xml uses `unstable_cache` with 1-hour revalidation for runtime performance
 
 ## Next Recommended Tasks
-- **P19.3** — Use-case landing pages (`/yachts/[useCase]`) — e.g., bluewater-cruising, racing, family-cruising
-- **P19.4** — Sitemap integration for programmatic pages
-- **P19.5** — Internal linking mesh
+- **P19.5** — Internal linking mesh (cross-link yacht detail pages to use-case + size pages)

--- a/messages/en.json
+++ b/messages/en.json
@@ -1215,5 +1215,8 @@
   "TableOfContents": {
     "label": "Page sections",
     "heading": "On This Page"
+  },
+  "RelatedCategories": {
+    "title": "Related Categories"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1215,5 +1215,8 @@
   "TableOfContents": {
     "label": "Sections de la page",
     "heading": "Sur cette page"
+  },
+  "RelatedCategories": {
+    "title": "Catégories associées"
   }
 }

--- a/tests/related-categories.unit.test.ts
+++ b/tests/related-categories.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { getSizeCategoryForLoa } from "@/lib/size-categories";
+import { assignUseCaseTags } from "@/lib/use-case-tags";
+import { USE_CASES } from "@/lib/use-case-meta";
+
+describe("RelatedCategories logic", () => {
+  it("should find size category for a 12m yacht (40ft range)", () => {
+    const sc = getSizeCategoryForLoa(12);
+    expect(sc).toBeDefined();
+    expect(sc?.slug).toBe("35-40ft");
+  });
+
+  it("should find size category for a 14m yacht (45-50ft range)", () => {
+    const sc = getSizeCategoryForLoa(14);
+    expect(sc).toBeDefined();
+    expect(sc?.slug).toBe("45-50ft");
+  });
+
+  it("should assign bluewater-cruiser tag for heavy 42ft yacht", () => {
+    const tags = assignUseCaseTags({
+      lengthOverall: 13, // ~42ft
+      displacement: 12000,
+      ballast: 4000,
+      sailAreaMain: 80,
+      beam: 4.2,
+      draft: 2.1,
+      cabins: 3,
+      berths: 6,
+      rigType: "Sloop",
+      keelType: "Fin",
+    });
+    expect(tags).toContain("bluewater-cruiser");
+  });
+
+  it("should assign family-cruiser tag for 38ft with 3 cabins", () => {
+    const tags = assignUseCaseTags({
+      lengthOverall: 11.5,
+      displacement: 7000,
+      ballast: 2000,
+      sailAreaMain: 70,
+      beam: 3.9,
+      draft: 1.8,
+      cabins: 3,
+      berths: 6,
+      rigType: "Sloop",
+      keelType: "Fin",
+    });
+    expect(tags).toContain("family-cruiser");
+  });
+
+  it("should map use-case tags to USE_CASES metadata", () => {
+    const tags = ["bluewater-cruiser", "family-cruiser"];
+    const labels = tags
+      .map((tag) => USE_CASES.find((u) => u.id === tag))
+      .filter(Boolean)
+      .map((uc) => uc!.labelEn);
+    expect(labels).toContain("Bluewater Cruising");
+    expect(labels).toContain("Family Cruising");
+  });
+
+  it("USE_CASES should have 6 entries with required fields", () => {
+    expect(USE_CASES).toHaveLength(6);
+    for (const uc of USE_CASES) {
+      expect(uc.slug).toBeTruthy();
+      expect(uc.labelEn).toBeTruthy();
+      expect(uc.labelFr).toBeTruthy();
+      expect(uc.emoji).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
- Add RelatedCategories component on yacht detail pages linking to
  manufacturer+size, size hub, and use-case landing pages
- Update manufacturer detail 'Browse by Size' to link to proper
  manufacturer+size category pages instead of search queries
- Add 'Related Use Cases' sidebar section on size category hub pages
- Extract shared use-case metadata to lib/use-case-meta.ts for
  client/server compatibility
- Add translations (en+fr) for RelatedCategories namespace
- Add 6 unit tests for category assignment and metadata mapping
