### PR TITLE
feat(seo): manufacturer comparison pages at /compare-manufacturers/slugA-vs-slugB (closes #341)

### DIFF
--- a/app/[locale]/compare-manufacturers/[slugA]-vs-[slugB]/ManufacturerCompareClient.tsx
+++ b/app/[locale]/compare-manufacturers/[slugA]-vs-[slugB]/ManufacturerCompareClient.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { localePath } from "@/lib/i18n-paths";
+import type { ManufacturerCompareStats } from "@/lib/manufacturer-compare";
+import ManufacturerLogo from "@/components/manufacturer-logo";
+import { getCountryFlag } from "@/lib/utils/country-flags";
+import {
+  ArrowRight,
+  BarChart3,
+  Calendar,
+  Flag,
+  Ruler,
+  Ship,
+  Weight,
+} from "lucide-react";
+
+interface ManufacturerCompareClientProps {
+  data: { mfrA: ManufacturerCompareStats; mfrB: ManufacturerCompareStats };
+  locale: string;
+}
+
+function formatNullable(value: number | null, suffix = ""): string {
+  return value !== null ? `${value}${suffix}` : "—";
+}
+
+function ComparisonRow({
+  label,
+  icon: Icon,
+  valueA,
+  valueB,
+  highlight = "none",
+}: {
+  label: string;
+  icon: React.ElementType;
+  valueA: string;
+  valueB: string;
+  highlight?: "a" | "b" | "none";
+}) {
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr] gap-4 items-center py-3 border-b border-border/50 last:border-b-0">
+      <div
+        className={`text-right font-medium ${highlight === "a" ? "text-green-700 dark:text-green-400" : ""}`}
+      >
+        {valueA}
+      </div>
+      <div className="flex items-center gap-2 text-muted-foreground text-sm justify-center">
+        <Icon className="h-4 w-4" aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+      <div
+        className={`text-left font-medium ${highlight === "b" ? "text-green-700 dark:text-green-400" : ""}`}
+      >
+        {valueB}
+      </div>
+    </div>
+  );
+}
+
+export function ManufacturerCompareClient({
+  data,
+  locale,
+}: ManufacturerCompareClientProps) {
+  const t = useTranslations("ManufacturerCompare");
+  const { mfrA, mfrB } = data;
+
+  // Determine which manufacturer has "better" stats for highlighting
+  const fleetHighlight = mfrA.yachtCount > mfrB.yachtCount ? "a" : mfrB.yachtCount > mfrA.yachtCount ? "b" : "none";
+
+  return (
+    <>
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          {mfrA.name} <span className="text-muted-foreground">vs</span>{" "}
+          {mfrB.name}
+        </h1>
+        <p className="text-muted-foreground">
+          {t("subtitle", { a: mfrA.name, b: mfrB.name })}
+        </p>
+      </div>
+
+      {/* Side-by-side cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+        {[mfrA, mfrB].map((mfr, idx) => (
+          <div
+            key={mfr.id}
+            className="rounded-xl border border-border bg-white dark:bg-gray-900 p-6 shadow-sm"
+          >
+            <div className="flex items-center gap-4 mb-4">
+              <ManufacturerLogo
+                name={mfr.name}
+                logoUrl={mfr.logoUrl}
+                size={48}
+              />
+              <div>
+                <h2 className="text-xl font-bold">{mfr.name}</h2>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  {mfr.country && (
+                    <span>
+                      {getCountryFlag(mfr.country)} {mfr.country}
+                    </span>
+                  )}
+                  {mfr.foundedYear && (
+                    <span>
+                      · {t("founded")} {mfr.foundedYear}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {mfr.description && (
+              <p className="text-sm text-muted-foreground mb-4 line-clamp-3">
+                {mfr.description}
+              </p>
+            )}
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="bg-muted/50 rounded-lg p-3">
+                <div className="text-muted-foreground text-xs mb-1">
+                  {t("fleetSize")}
+                </div>
+                <div className="font-bold text-lg">{mfr.yachtCount}</div>
+              </div>
+              <div className="bg-muted/50 rounded-lg p-3">
+                <div className="text-muted-foreground text-xs mb-1">
+                  {t("yearRange")}
+                </div>
+                <div className="font-bold">
+                  {mfr.minYear && mfr.maxYear
+                    ? `${mfr.minYear}–${mfr.maxYear}`
+                    : "—"}
+                </div>
+              </div>
+              <div className="bg-muted/50 rounded-lg p-3">
+                <div className="text-muted-foreground text-xs mb-1">
+                  {t("lengthRange")}
+                </div>
+                <div className="font-bold">
+                  {mfr.minLength && mfr.maxLength
+                    ? `${mfr.minLength}–${mfr.maxLength}m`
+                    : "—"}
+                </div>
+              </div>
+              <div className="bg-muted/50 rounded-lg p-3">
+                <div className="text-muted-foreground text-xs mb-1">
+                  {t("avgLength")}
+                </div>
+                <div className="font-bold">
+                  {mfr.avgLength ? `${mfr.avgLength.toFixed(1)}m` : "—"}
+                </div>
+              </div>
+            </div>
+
+            {mfr.websiteUrl && (
+              <a
+                href={mfr.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                className="mt-4 inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400"
+              >
+                {t("visitWebsite")}
+                <ArrowRight className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Comparison table */}
+      <div className="rounded-xl border border-border bg-white dark:bg-gray-900 p-6 shadow-sm mb-10">
+        <h2 className="text-lg font-bold mb-4 flex items-center gap-2">
+          <BarChart3 className="h-5 w-5" aria-hidden="true" />
+          {t("statsComparison")}
+        </h2>
+
+        <ComparisonRow
+          label={t("fleetSize")}
+          icon={Ship}
+          valueA={String(mfrA.yachtCount)}
+          valueB={String(mfrB.yachtCount)}
+          highlight={fleetHighlight}
+        />
+        <ComparisonRow
+          label={t("yearRange")}
+          icon={Calendar}
+          valueA={
+            mfrA.minYear && mfrA.maxYear
+              ? `${mfrA.minYear}–${mfrA.maxYear}`
+              : "—"
+          }
+          valueB={
+            mfrB.minYear && mfrB.maxYear
+              ? `${mfrB.minYear}–${mfrB.maxYear}`
+              : "—"
+          }
+        />
+        <ComparisonRow
+          label={t("lengthRange")}
+          icon={Ruler}
+          valueA={
+            mfrA.minLength && mfrA.maxLength
+              ? `${mfrA.minLength}–${mfrA.maxLength}m`
+              : "—"
+          }
+          valueB={
+            mfrB.minLength && mfrB.maxLength
+              ? `${mfrB.minLength}–${mfrB.maxLength}m`
+              : "—"
+          }
+        />
+        <ComparisonRow
+          label={t("avgLength")}
+          icon={Ruler}
+          valueA={mfrA.avgLength ? `${mfrA.avgLength.toFixed(1)}m` : "—"}
+          valueB={mfrB.avgLength ? `${mfrB.avgLength.toFixed(1)}m` : "—"}
+        />
+        <ComparisonRow
+          label={t("displacementRange")}
+          icon={Weight}
+          valueA={formatNullable(mfrA.minDisplacement) !== "—" && mfrA.maxDisplacement ? `${mfrA.minDisplacement}–${mfrA.maxDisplacement}kg` : "—"}
+          valueB={formatNullable(mfrB.minDisplacement) !== "—" && mfrB.maxDisplacement ? `${mfrB.minDisplacement}–${mfrB.maxDisplacement}kg` : "—"}
+        />
+        <ComparisonRow
+          label={t("cabinsRange")}
+          icon={Ship}
+          valueA={formatNullable(mfrA.minCabins) !== "—" && mfrA.maxCabins ? `${mfrA.minCabins}–${mfrA.maxCabins}` : "—"}
+          valueB={formatNullable(mfrB.minCabins) !== "—" && mfrB.maxCabins ? `${mfrB.minCabins}–${mfrB.maxCabins}` : "—"}
+        />
+        <ComparisonRow
+          label={t("country")}
+          icon={Flag}
+          valueA={mfrA.country ? `${getCountryFlag(mfrA.country)} ${mfrA.country}` : "—"}
+          valueB={mfrB.country ? `${getCountryFlag(mfrB.country)} ${mfrB.country}` : "—"}
+        />
+        <ComparisonRow
+          label={t("founded")}
+          icon={Calendar}
+          valueA={mfrA.foundedYear ? String(mfrA.foundedYear) : "—"}
+          valueB={mfrB.foundedYear ? String(mfrB.foundedYear) : "—"}
+        />
+      </div>
+
+      {/* Popular models */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+        {[mfrA, mfrB].map((mfr) => (
+          <div
+            key={mfr.id}
+            className="rounded-xl border border-border bg-white dark:bg-gray-900 p-6 shadow-sm"
+          >
+            <h3 className="text-lg font-bold mb-4">
+              {t("popularModels", { name: mfr.name })}
+            </h3>
+            {mfr.popularModels.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t("noModels")}</p>
+            ) : (
+              <ul className="space-y-2">
+                {mfr.popularModels.map((model) => (
+                  <li key={model.id}>
+                    <Link
+                      href={localePath(
+                        locale,
+                        `/yachts/${model.slug}`,
+                      )}
+                      className="flex items-center justify-between rounded-lg p-3 bg-muted/30 hover:bg-muted/60 transition-colors"
+                    >
+                      <div>
+                        <div className="font-medium text-sm">
+                          {model.modelName}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {model.year}
+                          {model.lengthOverall
+                            ? ` · ${model.lengthOverall}m`
+                            : ""}
+                        </div>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* CTA links */}
+      <div className="text-center">
+        <Link
+          href={localePath(locale, "/manufacturers")}
+          className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400"
+        >
+          ← {t("allManufacturers")}
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/app/[locale]/compare-manufacturers/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare-manufacturers/[slugA]-vs-[slugB]/page.tsx
@@ -1,0 +1,151 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { getManufacturerCompareData } from "@/lib/manufacturer-compare";
+import {
+  getSiteUrl,
+  generateBreadcrumbJsonLd,
+  buildLocaleAlternates,
+  buildOgImageUrl,
+} from "@/lib/seo";
+import { localePath } from "@/lib/i18n-paths";
+import { ManufacturerCompareClient } from "./ManufacturerCompareClient";
+
+export const dynamic = "force-dynamic";
+
+function parseCompareParams(
+  rawParams: Record<string, string | undefined>,
+): { slugA: string; slugB: string } | null {
+  for (const value of Object.values(rawParams)) {
+    if (value && value.includes("-vs-")) {
+      const idx = value.indexOf("-vs-");
+      return {
+        slugA: value.substring(0, idx),
+        slugB: value.substring(idx + 4),
+      };
+    }
+  }
+  return null;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Record<string, string | undefined>>;
+}): Promise<Metadata> {
+  const rawParams = await params;
+  const parsed = parseCompareParams(rawParams);
+  if (!parsed) notFound();
+
+  const data = await getManufacturerCompareData(parsed.slugA, parsed.slugB);
+  if (!data) notFound();
+
+  const title = `${data.mfrA.name} vs ${data.mfrB.name} — Manufacturer Comparison`;
+  const description = `Compare ${data.mfrA.name} (${data.mfrA.yachtCount} models) vs ${data.mfrB.name} (${data.mfrB.yachtCount} models): fleet size, yacht ranges, and popular models side by side.`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      data.mfrA.name,
+      data.mfrB.name,
+      "manufacturer comparison",
+      "sailing yachts",
+      "boat brands",
+    ],
+    openGraph: {
+      title,
+      description,
+      url: getSiteUrl(`/compare-manufacturers/${parsed.slugA}-vs-${parsed.slugB}`),
+      type: "website",
+      siteName: "Sailing Yacht Info",
+      images: [
+        {
+          url: buildOgImageUrl({
+            type: "compare",
+            title: `${data.mfrA.name} vs ${data.mfrB.name}`,
+            description: "Manufacturer comparison",
+          }),
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    alternates: buildLocaleAlternates(
+      `/compare-manufacturers/${parsed.slugA}-vs-${parsed.slugB}`,
+    ),
+  };
+}
+
+export default async function ManufacturerComparePage({
+  params,
+}: {
+  params: Promise<Record<string, string | undefined>>;
+}) {
+  const rawParams = await params;
+  const parsed = parseCompareParams(rawParams);
+  if (!parsed) notFound();
+
+  const data = await getManufacturerCompareData(parsed.slugA, parsed.slugB);
+  if (!data) notFound();
+
+  const { locale: localePromise } = { locale: (await params).locale ?? "en" };
+  const locale = localePromise as string;
+  const t = await getTranslations({ locale, namespace: "ManufacturerCompare" });
+
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd(
+    [
+      { name: "Home", path: "/" },
+      { name: "Manufacturers", path: "/manufacturers" },
+      {
+        name: `${data.mfrA.name} vs ${data.mfrB.name}`,
+        path: `/compare-manufacturers/${parsed.slugA}-vs-${parsed.slugB}`,
+      },
+    ],
+    locale,
+  );
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-12">
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-6 text-sm text-muted-foreground"
+        >
+          <ol className="flex flex-wrap items-center gap-1.5">
+            <li>
+              <Link
+                href={localePath(locale, "/")}
+                className="hover:text-foreground transition-colors"
+              >
+                {t("breadcrumb.home")}
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href={localePath(locale, "/manufacturers")}
+                className="hover:text-foreground transition-colors"
+              >
+                {t("breadcrumb.manufacturers")}
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li aria-current="page" className="text-foreground font-medium">
+              {data.mfrA.name} vs {data.mfrB.name}
+            </li>
+          </ol>
+        </nav>
+
+        <ManufacturerCompareClient data={data} locale={locale} />
+      </div>
+    </>
+  );
+}

--- a/lib/manufacturer-compare.ts
+++ b/lib/manufacturer-compare.ts
@@ -1,0 +1,120 @@
+import { db, manufacturers, yachtModels } from "@/lib/db";
+import { slugify } from "@/lib/utils/slugify";
+import { eq, count, min, max, avg, sql } from "drizzle-orm";
+
+export interface ManufacturerCompareStats {
+  id: number;
+  name: string;
+  slug: string;
+  country: string | null;
+  foundedYear: number | null;
+  logoUrl: string | null;
+  description: string | null;
+  websiteUrl: string | null;
+  yachtCount: number;
+  minYear: number | null;
+  maxYear: number | null;
+  minLength: number | null;
+  maxLength: number | null;
+  avgLength: number | null;
+  minDisplacement: number | null;
+  maxDisplacement: number | null;
+  minCabins: number | null;
+  maxCabins: number | null;
+  popularModels: Array<{
+    id: number;
+    slug: string | null;
+    modelName: string;
+    year: number;
+    lengthOverall: number | null;
+  }>;
+}
+
+function parseNum(v: string | number | null): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function getManufacturerCompareData(
+  slugA: string,
+  slugB: string,
+): Promise<{ mfrA: ManufacturerCompareStats; mfrB: ManufacturerCompareStats } | null> {
+  // Get all manufacturers
+  const allMfrs = await db.select().from(manufacturers);
+
+  const mfrA = allMfrs.find((m: any) => slugify(m.name) === slugA);
+  const mfrB = allMfrs.find((m: any) => slugify(m.name) === slugB);
+
+  if (!mfrA || !mfrB) return null;
+
+  const [statsA, statsB] = await Promise.all([
+    getStatsForManufacturer(mfrA),
+    getStatsForManufacturer(mfrB),
+  ]);
+
+  return { mfrA: statsA, mfrB: statsB };
+}
+
+async function getStatsForManufacturer(mfr: any): Promise<ManufacturerCompareStats> {
+  // Get aggregate stats
+  const aggResult = await db
+    .select({
+      yachtCount: count(yachtModels.id),
+      minYear: min(yachtModels.year),
+      maxYear: max(yachtModels.year),
+      minLength: min(yachtModels.lengthOverall),
+      maxLength: max(yachtModels.lengthOverall),
+      avgLength: avg(yachtModels.lengthOverall),
+      minDisplacement: min(yachtModels.displacement),
+      maxDisplacement: max(yachtModels.displacement),
+      minCabins: min(yachtModels.cabins),
+      maxCabins: max(yachtModels.cabins),
+    })
+    .from(yachtModels)
+    .where(eq(yachtModels.manufacturerId, mfr.id));
+
+  const agg = aggResult[0];
+
+  // Get top 5 popular models (by completeness score or recent)
+  const popularModels = await db
+    .select({
+      id: yachtModels.id,
+      slug: yachtModels.slug,
+      modelName: yachtModels.modelName,
+      year: yachtModels.year,
+      lengthOverall: yachtModels.lengthOverall,
+    })
+    .from(yachtModels)
+    .where(eq(yachtModels.manufacturerId, mfr.id))
+    .orderBy(sql`COALESCE(${yachtModels.completenessScore}, 0) DESC, ${yachtModels.year} DESC`)
+    .limit(5);
+
+  return {
+    id: mfr.id,
+    name: mfr.name,
+    slug: slugify(mfr.name),
+    country: mfr.country,
+    foundedYear: mfr.foundedYear,
+    logoUrl: mfr.logoUrl,
+    description: mfr.description,
+    websiteUrl: mfr.websiteUrl,
+    yachtCount: Number(agg?.yachtCount ?? 0),
+    minYear: agg?.minYear ?? null,
+    maxYear: agg?.maxYear ?? null,
+    minLength: parseNum(agg?.minLength),
+    maxLength: parseNum(agg?.maxLength),
+    avgLength: parseNum(agg?.avgLength),
+    minDisplacement: parseNum(agg?.minDisplacement),
+    maxDisplacement: parseNum(agg?.maxDisplacement),
+    minCabins: agg?.minCabins ?? null,
+    maxCabins: agg?.maxCabins ?? null,
+    popularModels: popularModels.map((m: any) => ({
+      id: m.id,
+      slug: m.slug,
+      modelName: m.modelName,
+      year: m.year,
+      lengthOverall: parseNum(m.lengthOverall),
+    })),
+  };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1218,5 +1218,25 @@
   },
   "RelatedCategories": {
     "title": "Related Categories"
+  },
+  "ManufacturerCompare": {
+    "breadcrumb": {
+      "home": "Home",
+      "manufacturers": "Manufacturers"
+    },
+    "subtitle": "Side-by-side comparison of {a} and {b} — fleet size, yacht ranges, and popular models",
+    "fleetSize": "Fleet Size",
+    "yearRange": "Year Range",
+    "lengthRange": "Length Range",
+    "avgLength": "Avg. Length",
+    "displacementRange": "Displacement Range",
+    "cabinsRange": "Cabins Range",
+    "country": "Country",
+    "founded": "Founded",
+    "statsComparison": "Stats Comparison",
+    "popularModels": "Popular {name} Models",
+    "noModels": "No models found.",
+    "visitWebsite": "Visit website",
+    "allManufacturers": "Browse all manufacturers"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1218,5 +1218,25 @@
   },
   "RelatedCategories": {
     "title": "Catégories associées"
+  },
+  "ManufacturerCompare": {
+    "breadcrumb": {
+      "home": "Accueil",
+      "manufacturers": "Constructeurs"
+    },
+    "subtitle": "Comparaison côte à côte de {a} et {b} — taille de flotte, gammes et modèles populaires",
+    "fleetSize": "Taille de la flotte",
+    "yearRange": "Années",
+    "lengthRange": "Gamme de longueurs",
+    "avgLength": "Longueur moy.",
+    "displacementRange": "Déplacement",
+    "cabinsRange": "Cabines",
+    "country": "Pays",
+    "founded": "Fondé",
+    "statsComparison": "Comparaison des statistiques",
+    "popularModels": "Modèles {name} populaires",
+    "noModels": "Aucun modèle trouvé.",
+    "visitWebsite": "Visiter le site",
+    "allManufacturers": "Tous les constructeurs"
   }
 }

--- a/tests/manufacturer-compare.unit.test.ts
+++ b/tests/manufacturer-compare.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { slugify } from "@/lib/utils/slugify";
+
+describe("Manufacturer Compare — unit tests", () => {
+  it("slugifies manufacturer names for URLs", () => {
+    expect(slugify("Jeanneau")).toBe("jeanneau");
+    expect(slugify("Hallberg-Rassy")).toBe("hallberg-rassy");
+    expect(slugify("Bavaria Yachts")).toBe("bavaria-yachts");
+  });
+
+  it("slugify strips accented characters (JS \\w limitation)", () => {
+    expect(slugify("Bénéteau")).toBe("bnteau");
+    expect(slugify("  Bavaria Yachts  ")).toBe("bavaria-yachts");
+  });
+
+  it("slugify handles empty input", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("manufacturer comparison URL format is correct", () => {
+    const slugA = slugify("Jeanneau");
+    const slugB = slugify("Hallberg-Rassy");
+    const path = `/compare-manufacturers/${slugA}-vs-${slugB}`;
+    expect(path).toBe("/compare-manufacturers/jeanneau-vs-hallberg-rassy");
+    expect(path).toContain("-vs-");
+  });
+
+  it("parses comparison slug correctly", () => {
+    const rawParam = "jeanneau-vs-hallberg-rassy";
+    const idx = rawParam.indexOf("-vs-");
+    const slugA = rawParam.substring(0, idx);
+    const slugB = rawParam.substring(idx + 4);
+    expect(slugA).toBe("jeanneau");
+    expect(slugB).toBe("hallberg-rassy");
+  });
+
+  it("handles edge case: both manufacturers with hyphens", () => {
+    const slugA = slugify("Hallberg-Rassy");
+    const slugB = slugify("X-Yachts");
+    const rawParam = `${slugA}-vs-${slugB}`;
+    const idx = rawParam.indexOf("-vs-");
+    const parsedA = rawParam.substring(0, idx);
+    const parsedB = rawParam.substring(idx + 4);
+    expect(parsedA).toBe("hallberg-rassy");
+    expect(parsedB).toBe("x-yachts");
+  });
+});


### PR DESCRIPTION
- Dynamic route for head-to-head manufacturer comparison
- Side-by-side stats: fleet size, year range, length range, displacement, cabins
- Popular models with links to yacht detail pages
- Bilingual content (en + fr) with i18n translations
- SEO metadata with OG image and breadcrumb structured data
- Unit tests for URL parsing and slug generation
