### PR TITLE
feat(seo): click-to-play video embeds with i18n for yacht pages (closes #344)

### DIFF
--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import {
   Image as ImageIcon,
   PlayCircle,
@@ -16,6 +17,7 @@ import {
   Download,
   Video,
 } from "lucide-react";
+import VideoEmbed from "@/components/VideoEmbed";
 
 export interface MediaAsset {
   id: number;
@@ -40,17 +42,6 @@ interface MediaGalleryProps {
 
 type TabKey = "photos" | "videos" | "brochures" | "more";
 
-const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
-  { key: "photos", label: "Photos", icon: <ImageIcon className="h-4 w-4"  aria-hidden="true" /> },
-  { key: "videos", label: "Videos", icon: <PlayCircle className="h-4 w-4"  aria-hidden="true" /> },
-  {
-    key: "brochures",
-    label: "Brochures & Plans",
-    icon: <FileText className="h-4 w-4"  aria-hidden="true" />,
-  },
-  { key: "more", label: "More", icon: <Box className="h-4 w-4"  aria-hidden="true" /> },
-];
-
 function groupByType(assets: MediaAsset[]) {
   const groups: Record<string, MediaAsset[]> = {};
   for (const a of assets) {
@@ -69,6 +60,7 @@ function formatFileSize(bytes: number | null): string {
 }
 
 export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
+  const t = useTranslations("MediaGallery");
   const [activeTab, setActiveTab] = useState<TabKey>("photos");
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
@@ -97,6 +89,13 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
     more: more.length,
   };
 
+  const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+    { key: "photos", label: t("tabs.photos"), icon: <ImageIcon className="h-4 w-4" aria-hidden="true" /> },
+    { key: "videos", label: t("tabs.videos"), icon: <PlayCircle className="h-4 w-4" aria-hidden="true" /> },
+    { key: "brochures", label: t("tabs.brochures"), icon: <FileText className="h-4 w-4" aria-hidden="true" /> },
+    { key: "more", label: t("tabs.more"), icon: <Box className="h-4 w-4" aria-hidden="true" /> },
+  ];
+
   const currentLightboxPhotos = photos;
   const currentPhoto =
     lightboxIndex !== null ? currentLightboxPhotos[lightboxIndex] : null;
@@ -109,7 +108,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
   // Tab keyboard navigation handler
   const handleTabKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const currentIndex = availableTabs.findIndex((t) => t.key === activeTab);
+      const currentIndex = availableTabs.findIndex((tb) => tb.key === activeTab);
       if (currentIndex === -1) return;
 
       if (e.key === "ArrowRight" || e.key === "ArrowDown") {
@@ -165,7 +164,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
 
   return (
     <section className="mt-10 sm:mt-12" data-testid="media-gallery">
-      <h2 className="text-lg sm:text-xl font-bold mb-4">Media Gallery</h2>
+      <h2 className="text-lg sm:text-xl font-bold mb-4">{t("heading")}</h2>
 
       {/* Tabs with keyboard navigation */}
       <div
@@ -212,11 +211,12 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
           <PhotoGrid
             photos={photos}
             onPhotoClick={(idx) => setLightboxIndex(idx)}
+            primaryLabel={t("primary")}
           />
         )}
-        {activeTab === "videos" && <VideoList videos={videos}  aria-hidden="true" />}
-        {activeTab === "brochures" && <BrochureList items={brochures}  aria-hidden="true" />}
-        {activeTab === "more" && <MoreList items={more}  aria-hidden="true" />}
+        {activeTab === "videos" && <VideoList videos={videos} />}
+        {activeTab === "brochures" && <BrochureList items={brochures} />}
+        {activeTab === "more" && <MoreList items={more} />}
       </div>
 
       {/* Lightbox */}
@@ -227,14 +227,14 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
           data-testid="lightbox"
           role="dialog"
           aria-modal="true"
-          aria-label="Photo lightbox"
+          aria-label={t("lightbox.label")}
         >
           <button
             className="absolute top-4 right-4 text-white hover:text-gray-300"
             onClick={closeLightbox}
-            aria-label="Close lightbox"
+            aria-label={t("lightbox.close")}
           >
-            <X className="h-8 w-8"  aria-hidden="true" />
+            <X className="h-8 w-8" aria-hidden="true" />
           </button>
           {lightboxIndex != null && lightboxIndex > 0 && (
             <button
@@ -243,9 +243,9 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
                 e.stopPropagation();
                 setLightboxIndex(lightboxIndex! - 1);
               }}
-              aria-label="Previous photo"
+              aria-label={t("lightbox.previous")}
             >
-              <ChevronLeft className="h-10 w-10"  aria-hidden="true" />
+              <ChevronLeft className="h-10 w-10" aria-hidden="true" />
             </button>
           )}
           {lightboxIndex != null && lightboxIndex < currentLightboxPhotos.length - 1 && (
@@ -255,9 +255,9 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
                 e.stopPropagation();
                 setLightboxIndex(lightboxIndex! + 1);
               }}
-              aria-label="Next photo"
+              aria-label={t("lightbox.next")}
             >
-              <ChevronRight className="h-10 w-10"  aria-hidden="true" />
+              <ChevronRight className="h-10 w-10" aria-hidden="true" />
             </button>
           )}
           <div
@@ -271,7 +271,7 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
                 currentPhoto.altText ||
                 currentPhoto.title ||
                 currentPhoto.caption ||
-                "Yacht photo"
+                t("photoAlt")
               }
               className="max-w-full max-h-[80vh] object-contain rounded-lg"
             />
@@ -292,14 +292,18 @@ export default function MediaGallery({ mediaAssets }: MediaGalleryProps) {
 function PhotoGrid({
   photos,
   onPhotoClick,
+  primaryLabel,
 }: {
   photos: MediaAsset[];
   onPhotoClick: (idx: number) => void;
+  primaryLabel: string;
 }) {
+  const t = useTranslations("MediaGallery");
+
   if (photos.length === 0) {
     return (
       <p className="text-muted-foreground text-sm" data-testid="no-photos">
-        No photos available yet
+        {t("empty.photos")}
       </p>
     );
   }
@@ -317,14 +321,14 @@ function PhotoGrid({
           <img
             src={photo.thumbnailUrl || photo.url || ""}
             alt={
-              photo.altText || photo.title || photo.caption || "Yacht photo"
+              photo.altText || photo.title || photo.caption || t("photoAlt")
             }
             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
             loading="lazy"
           />
           {photo.isPrimary && (
             <span className="absolute top-1 left-1 bg-primary text-primary-foreground text-xs px-2 py-0.5 rounded-full">
-              Primary
+              {primaryLabel}
             </span>
           )}
           {photo.title && (
@@ -341,10 +345,12 @@ function PhotoGrid({
 }
 
 function VideoList({ videos }: { videos: MediaAsset[] }) {
+  const t = useTranslations("MediaGallery");
+
   if (videos.length === 0) {
     return (
       <p className="text-muted-foreground text-sm" data-testid="no-videos">
-        No videos available yet
+        {t("empty.videos")}
       </p>
     );
   }
@@ -358,21 +364,19 @@ function VideoList({ videos }: { videos: MediaAsset[] }) {
           data-testid="media-video-card"
         >
           {video.embedUrl ? (
-            <div className="aspect-video">
-              <iframe
-                src={video.embedUrl}
-                title={video.title || "Video"}
-                className="w-full h-full"
-                allowFullScreen
-                loading="lazy"
-              />
-            </div>
+            <VideoEmbed
+              embedUrl={video.embedUrl}
+              thumbnailUrl={video.thumbnailUrl}
+              title={video.title || t("videoDefaultTitle")}
+              altText={video.altText}
+              playLabel={t("playVideo")}
+            />
           ) : video.thumbnailUrl ? (
             <div className="aspect-video relative bg-muted">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={video.thumbnailUrl}
-                alt={video.altText || video.title || "Video thumbnail"}
+                alt={video.altText || video.title || t("videoThumbnail")}
                 className="w-full h-full object-cover"
                 loading="lazy"
               />
@@ -383,17 +387,18 @@ function VideoList({ videos }: { videos: MediaAsset[] }) {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="bg-black/50 rounded-full p-3 hover:bg-black/70 transition-colors"
+                    aria-label={t("watchOnPlatform")}
                   >
-                    <PlayCircle className="h-10 w-10 text-white"  aria-hidden="true" />
+                    <PlayCircle className="h-10 w-10 text-white" aria-hidden="true" />
                   </a>
                 ) : (
-                  <Video className="h-10 w-10 text-white/50"  aria-hidden="true" />
+                  <Video className="h-10 w-10 text-white/50" aria-hidden="true" />
                 )}
               </div>
             </div>
           ) : (
             <div className="aspect-video bg-muted flex items-center justify-center">
-              <Video className="h-10 w-10 text-muted-foreground"  aria-hidden="true" />
+              <Video className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
             </div>
           )}
           <div className="p-3">
@@ -413,27 +418,26 @@ function VideoList({ videos }: { videos: MediaAsset[] }) {
 }
 
 function BrochureList({ items }: { items: MediaAsset[] }) {
+  const t = useTranslations("MediaGallery");
+
   if (items.length === 0) {
     return (
-      <p
-        className="text-muted-foreground text-sm"
-        data-testid="no-brochures"
-      >
-        No brochures or plans available yet
+      <p className="text-muted-foreground text-sm" data-testid="no-brochures">
+        {t("empty.brochures")}
       </p>
     );
   }
 
   const typeIcons: Record<string, React.ReactNode> = {
-    brochure: <FileText className="h-6 w-6"  aria-hidden="true" />,
-    deck_plan: <Map className="h-6 w-6"  aria-hidden="true" />,
-    interior_layout: <Layout className="h-6 w-6"  aria-hidden="true" />,
+    brochure: <FileText className="h-6 w-6" aria-hidden="true" />,
+    deck_plan: <Map className="h-6 w-6" aria-hidden="true" />,
+    interior_layout: <Layout className="h-6 w-6" aria-hidden="true" />,
   };
 
   const typeLabels: Record<string, string> = {
-    brochure: "Brochure",
-    deck_plan: "Deck Plan",
-    interior_layout: "Interior Layout",
+    brochure: t("typeLabels.brochure"),
+    deck_plan: t("typeLabels.deckPlan"),
+    interior_layout: t("typeLabels.interiorLayout"),
   };
 
   return (
@@ -445,7 +449,7 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
           data-testid="media-brochure-card"
         >
           <div className="shrink-0 text-primary">
-            {typeIcons[item.mediaType] || <FileText className="h-6 w-6"  aria-hidden="true" />}
+            {typeIcons[item.mediaType] || <FileText className="h-6 w-6" aria-hidden="true" />}
           </div>
           <div className="min-w-0 flex-1">
             <h4 className="font-medium text-sm truncate">
@@ -469,8 +473,8 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <Download className="h-3 w-3"  aria-hidden="true" />
-                Download
+                <Download className="h-3 w-3" aria-hidden="true" />
+                {t("download")}
               </a>
             )}
             {item.sourceUrl && !item.url && (
@@ -480,8 +484,8 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <ExternalLink className="h-3 w-3"  aria-hidden="true" />
-                View Source
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                {t("viewSource")}
               </a>
             )}
           </div>
@@ -492,10 +496,12 @@ function BrochureList({ items }: { items: MediaAsset[] }) {
 }
 
 function MoreList({ items }: { items: MediaAsset[] }) {
+  const t = useTranslations("MediaGallery");
+
   if (items.length === 0) {
     return (
       <p className="text-muted-foreground text-sm" data-testid="no-more">
-        No 360° tours or 3D models available yet
+        {t("empty.more")}
       </p>
     );
   }
@@ -521,14 +527,14 @@ function MoreList({ items }: { items: MediaAsset[] }) {
           ) : (
             <div className="aspect-video bg-muted flex flex-col items-center justify-center gap-2">
               {item.mediaType === "360_tour" ? (
-                <RotateCcw className="h-8 w-8 text-muted-foreground"  aria-hidden="true" />
+                <RotateCcw className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
               ) : (
-                <Box className="h-8 w-8 text-muted-foreground"  aria-hidden="true" />
+                <Box className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
               )}
               <span className="text-sm text-muted-foreground">
                 {item.mediaType === "360_tour"
-                  ? "360° Tour"
-                  : "3D Model Viewer"}
+                  ? t("tour360")
+                  : t("model3d")}
               </span>
             </div>
           )}
@@ -536,8 +542,8 @@ function MoreList({ items }: { items: MediaAsset[] }) {
             <h4 className="font-medium text-sm">
               {item.title ||
                 (item.mediaType === "360_tour"
-                  ? "360° Virtual Tour"
-                  : "3D Model")}
+                  ? t("tour360Title")
+                  : t("model3dTitle"))}
             </h4>
             {item.caption && (
               <p className="text-xs text-muted-foreground mt-1">
@@ -551,8 +557,8 @@ function MoreList({ items }: { items: MediaAsset[] }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
               >
-                <ExternalLink className="h-3 w-3"  aria-hidden="true" />
-                Open
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                {t("open")}
               </a>
             )}
           </div>

--- a/components/VideoEmbed.tsx
+++ b/components/VideoEmbed.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { PlayCircle, ExternalLink } from "lucide-react";
+
+interface VideoEmbedProps {
+  embedUrl: string;
+  thumbnailUrl?: string | null;
+  title: string;
+  altText?: string | null;
+  playLabel?: string;
+}
+
+/**
+ * Click-to-play video embed.
+ * Shows a thumbnail with a play button; loads the iframe only after the user clicks.
+ * Supports YouTube and Vimeo embed URLs.
+ */
+export default function VideoEmbed({
+  embedUrl,
+  thumbnailUrl,
+  title,
+  altText,
+  playLabel = "Play video",
+}: VideoEmbedProps) {
+  const [active, setActive] = useState(false);
+
+  const handlePlay = useCallback(() => {
+    setActive(true);
+  }, []);
+
+  // Derive a thumbnail from the embed URL if none provided
+  const derivedThumbnail = thumbnailUrl || deriveThumbnail(embedUrl);
+
+  if (active) {
+    // Append autoplay param for immediate playback
+    const autoplayUrl = appendAutoplay(embedUrl);
+    return (
+      <div className="aspect-video" data-testid="video-embed-iframe">
+        <iframe
+          src={autoplayUrl}
+          title={title}
+          className="w-full h-full rounded-t-lg"
+          allow="autoplay; encrypted-media; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handlePlay}
+      className="aspect-video relative w-full group cursor-pointer bg-muted rounded-t-lg overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      aria-label={playLabel}
+      data-testid="video-embed-thumbnail"
+    >
+      {derivedThumbnail ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={derivedThumbnail}
+          alt={altText || title}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-muted to-muted/50">
+          <PlayCircle className="h-16 w-16 text-muted-foreground" aria-hidden="true" />
+        </div>
+      )}
+      <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/30 transition-colors">
+        <div className="bg-white/90 rounded-full p-3 shadow-lg group-hover:scale-110 transition-transform">
+          <PlayCircle className="h-10 w-10 text-primary" aria-hidden="true" />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Try to derive a thumbnail URL from YouTube or Vimeo embed URLs.
+ */
+function deriveThumbnail(embedUrl: string): string | null {
+  try {
+    const url = new URL(embedUrl);
+    const host = url.hostname;
+    // Only derive thumbnails for YouTube
+    if (host === "www.youtube.com" || host === "youtube.com" || host === "youtu.be") {
+      const ytMatch = url.pathname.match(/\/embed\/([a-zA-Z0-9_-]+)/);
+      if (ytMatch) {
+        return `https://img.youtube.com/vi/${ytMatch[1]}/hqdefault.jpg`;
+      }
+    }
+    // Vimeo thumbnails require an API call; return null
+    if (host === "player.vimeo.com" || host === "vimeo.com") {
+      return null;
+    }
+  } catch {
+    // Invalid URL
+  }
+  return null;
+}
+
+/**
+ * Append autoplay=1 parameter to embed URL for immediate playback after click.
+ */
+function appendAutoplay(embedUrl: string): string {
+  try {
+    const url = new URL(embedUrl);
+    if (!url.searchParams.has("autoplay")) {
+      url.searchParams.set("autoplay", "1");
+    }
+    // YouTube needs mute for autoplay to work in most browsers
+    if (embedUrl.includes("youtube.com") || embedUrl.includes("youtu.be")) {
+      url.searchParams.set("mute", "1");
+    }
+    return url.toString();
+  } catch {
+    return embedUrl;
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1238,5 +1238,44 @@
     "noModels": "No models found.",
     "visitWebsite": "Visit website",
     "allManufacturers": "Browse all manufacturers"
+  },
+  "MediaGallery": {
+    "heading": "Media Gallery",
+    "tabs": {
+      "photos": "Photos",
+      "videos": "Videos",
+      "brochures": "Brochures & Plans",
+      "more": "More"
+    },
+    "primary": "Primary",
+    "photoAlt": "Yacht photo",
+    "playVideo": "Play video",
+    "videoDefaultTitle": "Video",
+    "videoThumbnail": "Video thumbnail",
+    "watchOnPlatform": "Watch on platform",
+    "download": "Download",
+    "viewSource": "View Source",
+    "open": "Open",
+    "tour360": "360° Tour",
+    "tour360Title": "360° Virtual Tour",
+    "model3d": "3D Model Viewer",
+    "model3dTitle": "3D Model",
+    "typeLabels": {
+      "brochure": "Brochure",
+      "deckPlan": "Deck Plan",
+      "interiorLayout": "Interior Layout"
+    },
+    "empty": {
+      "photos": "No photos available yet",
+      "videos": "No videos available yet",
+      "brochures": "No brochures or plans available yet",
+      "more": "No 360° tours or 3D models available yet"
+    },
+    "lightbox": {
+      "label": "Photo lightbox",
+      "close": "Close lightbox",
+      "previous": "Previous photo",
+      "next": "Next photo"
+    }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1238,5 +1238,44 @@
     "noModels": "Aucun modèle trouvé.",
     "visitWebsite": "Visiter le site",
     "allManufacturers": "Tous les constructeurs"
+  },
+  "MediaGallery": {
+    "heading": "Galerie média",
+    "tabs": {
+      "photos": "Photos",
+      "videos": "Vidéos",
+      "brochures": "Brochures & Plans",
+      "more": "Plus"
+    },
+    "primary": "Principal",
+    "photoAlt": "Photo de voilier",
+    "playVideo": "Lire la vidéo",
+    "videoDefaultTitle": "Vidéo",
+    "videoThumbnail": "Vignette vidéo",
+    "watchOnPlatform": "Regarder sur la plateforme",
+    "download": "Télécharger",
+    "viewSource": "Voir la source",
+    "open": "Ouvrir",
+    "tour360": "Visite 360°",
+    "tour360Title": "Visite virtuelle 360°",
+    "model3d": "Visualiseur 3D",
+    "model3dTitle": "Modèle 3D",
+    "typeLabels": {
+      "brochure": "Brochure",
+      "deckPlan": "Plan de pont",
+      "interiorLayout": "Agencement intérieur"
+    },
+    "empty": {
+      "photos": "Aucune photo disponible",
+      "videos": "Aucune vidéo disponible",
+      "brochures": "Aucune brochure ou plan disponible",
+      "more": "Aucune visite 360° ou modèle 3D disponible"
+    },
+    "lightbox": {
+      "label": "Visionneuse de photos",
+      "close": "Fermer la visionneuse",
+      "previous": "Photo précédente",
+      "next": "Photo suivante"
+    }
   }
 }

--- a/tests/video-embed.unit.test.ts
+++ b/tests/video-embed.unit.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const projectRoot = path.resolve(__dirname, "..");
+
+// ── VideoEmbed component file tests ──
+
+describe("VideoEmbed component", () => {
+  const filePath = path.resolve(projectRoot, "components/VideoEmbed.tsx");
+
+  it("exists", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("is a client component", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it("uses click-to-play pattern with state toggle", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    // Should have useState for active/play state
+    expect(content).toMatch(/useState.*false/);
+    // Should NOT render iframe immediately — conditional on active state
+    expect(content).toMatch(/if\s*\(active\)/);
+  });
+
+  it("derives YouTube thumbnail from embed URL", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain("img.youtube.com/vi/");
+  });
+
+  it("appends autoplay parameter on iframe load", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain("autoplay");
+    expect(content).toMatch(/appendAutoplay/);
+  });
+
+  it("handles Vimeo URLs gracefully", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toMatch(/vimeo/);
+  });
+
+  it("has proper accessibility with aria-label on play button", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toMatch(/aria-label/);
+  });
+
+  it("uses responsive aspect-video container", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain("aspect-video");
+  });
+
+  it("lazy-loads thumbnail images", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain('loading="lazy"');
+  });
+});
+
+// ── VideoEmbed logic tests ──
+
+describe("VideoEmbed thumbnail derivation", () => {
+  // Inline the deriveThumbnail logic for testing
+  function deriveThumbnail(embedUrl: string): string | null {
+    try {
+      const url = new URL(embedUrl);
+      const host = url.hostname;
+      if (host === "www.youtube.com" || host === "youtube.com" || host === "youtu.be") {
+        const ytMatch = url.pathname.match(/\/embed\/([a-zA-Z0-9_-]+)/);
+        if (ytMatch) {
+          return `https://img.youtube.com/vi/${ytMatch[1]}/hqdefault.jpg`;
+        }
+      }
+      if (host === "player.vimeo.com" || host === "vimeo.com") {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  it("derives thumbnail from YouTube embed URL", () => {
+    expect(deriveThumbnail("https://www.youtube.com/embed/abc123")).toBe(
+      "https://img.youtube.com/vi/abc123/hqdefault.jpg",
+    );
+  });
+
+  it("derives thumbnail from YouTube embed URL with params", () => {
+    expect(deriveThumbnail("https://www.youtube.com/embed/xyz789?rel=0")).toBe(
+      "https://img.youtube.com/vi/xyz789/hqdefault.jpg",
+    );
+  });
+
+  it("returns null for Vimeo URLs", () => {
+    expect(deriveThumbnail("https://player.vimeo.com/video/12345")).toBeNull();
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(deriveThumbnail("not-a-url")).toBeNull();
+  });
+
+  it("returns null for unknown embed domains", () => {
+    expect(deriveThumbnail("https://example.com/embed/abc")).toBeNull();
+  });
+});
+
+describe("VideoEmbed autoplay URL building", () => {
+  function appendAutoplay(embedUrl: string): string {
+    try {
+      const url = new URL(embedUrl);
+      if (!url.searchParams.has("autoplay")) {
+        url.searchParams.set("autoplay", "1");
+      }
+      if (embedUrl.includes("youtube.com") || embedUrl.includes("youtu.be")) {
+        url.searchParams.set("mute", "1");
+      }
+      return url.toString();
+    } catch {
+      return embedUrl;
+    }
+  }
+
+  it("appends autoplay=1 to YouTube URL", () => {
+    const result = appendAutoplay("https://www.youtube.com/embed/abc");
+    expect(result).toContain("autoplay=1");
+    expect(result).toContain("mute=1");
+  });
+
+  it("appends autoplay=1 to Vimeo URL without mute", () => {
+    const result = appendAutoplay("https://player.vimeo.com/video/123");
+    expect(result).toContain("autoplay=1");
+    expect(result).not.toContain("mute=");
+  });
+
+  it("preserves existing params", () => {
+    const result = appendAutoplay("https://www.youtube.com/embed/abc?rel=0");
+    expect(result).toContain("rel=0");
+    expect(result).toContain("autoplay=1");
+  });
+
+  it("does not double-add autoplay", () => {
+    const result = appendAutoplay("https://www.youtube.com/embed/abc?autoplay=1");
+    expect(result.match(/autoplay/g)).toHaveLength(1);
+  });
+});
+
+// ── MediaGallery component file tests ──
+
+describe("MediaGallery component", () => {
+  const filePath = path.resolve(projectRoot, "components/MediaGallery.tsx");
+
+  it("exists", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("is a client component", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toContain('"use client"');
+  });
+
+  it("imports VideoEmbed for click-to-play", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toMatch(/import.*VideoEmbed/);
+  });
+
+  it("uses useTranslations for i18n", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(content).toMatch(/useTranslations.*MediaGallery/);
+  });
+
+  it("no longer has hardcoded English labels for tabs", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    // The TABS array should use t() for labels, not hardcoded strings
+    expect(content).not.toMatch(/label:\s*["']Photos["']/);
+    expect(content).not.toMatch(/label:\s*["']Videos["']/);
+    expect(content).not.toMatch(/label:\s*["']Brochures & Plans["']/);
+  });
+
+  it("uses VideoEmbed for video assets with embedUrl", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    // VideoList should use VideoEmbed component when video has embedUrl
+    expect(content).toMatch(/video.embedUrl/);
+    expect(content).toMatch(/<VideoEmbed/);
+  });
+
+  it("does not render iframes directly in VideoList", () => {
+    const content = fs.readFileSync(filePath, "utf-8");
+    // The VideoList function should NOT contain raw iframe tags
+    const videoListSection = content.substring(
+      content.indexOf("function VideoList"),
+      content.indexOf("function BrochureList"),
+    );
+    expect(videoListSection).not.toContain("<iframe");
+  });
+});
+
+// ── i18n translation completeness ──
+
+describe("MediaGallery i18n translations", () => {
+  it("has all required English keys", () => {
+    const en = JSON.parse(fs.readFileSync(path.resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const mg = en.MediaGallery;
+    expect(mg).toBeDefined();
+    expect(mg.heading).toBeDefined();
+    expect(mg.tabs.photos).toBeDefined();
+    expect(mg.tabs.videos).toBeDefined();
+    expect(mg.tabs.brochures).toBeDefined();
+    expect(mg.tabs.more).toBeDefined();
+    expect(mg.playVideo).toBeDefined();
+    expect(mg.empty.photos).toBeDefined();
+    expect(mg.empty.videos).toBeDefined();
+    expect(mg.empty.brochures).toBeDefined();
+    expect(mg.empty.more).toBeDefined();
+    expect(mg.lightbox.label).toBeDefined();
+    expect(mg.lightbox.close).toBeDefined();
+    expect(mg.lightbox.previous).toBeDefined();
+    expect(mg.lightbox.next).toBeDefined();
+    expect(mg.typeLabels.brochure).toBeDefined();
+    expect(mg.typeLabels.deckPlan).toBeDefined();
+    expect(mg.typeLabels.interiorLayout).toBeDefined();
+  });
+
+  it("has all required French keys", () => {
+    const fr = JSON.parse(fs.readFileSync(path.resolve(projectRoot, "messages/fr.json"), "utf-8"));
+    const mg = fr.MediaGallery;
+    expect(mg).toBeDefined();
+    expect(mg.heading).toBe("Galerie média");
+    expect(mg.tabs.photos).toBe("Photos");
+    expect(mg.tabs.videos).toBe("Vidéos");
+    expect(mg.playVideo).toBe("Lire la vidéo");
+    expect(mg.empty.videos).toBe("Aucune vidéo disponible");
+    expect(mg.lightbox.close).toBe("Fermer la visionneuse");
+  });
+
+  it("EN and FR have the same key structure", () => {
+    const en = JSON.parse(fs.readFileSync(path.resolve(projectRoot, "messages/en.json"), "utf-8"));
+    const fr = JSON.parse(fs.readFileSync(path.resolve(projectRoot, "messages/fr.json"), "utf-8"));
+
+    function getKeys(obj: Record<string, unknown>, prefix = ""): string[] {
+      const keys: string[] = [];
+      for (const [key, value] of Object.entries(obj)) {
+        const fullKey = prefix ? `${prefix}.${key}` : key;
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+          keys.push(...getKeys(value as Record<string, unknown>, fullKey));
+        } else {
+          keys.push(fullKey);
+        }
+      }
+      return keys;
+    }
+
+    const enKeys = getKeys(en.MediaGallery).sort();
+    const frKeys = getKeys(fr.MediaGallery).sort();
+    expect(frKeys).toEqual(enKeys);
+  });
+});
+
+// ── VideoObject JSON-LD integration ──
+
+describe("VideoObject JSON-LD in yacht detail page", () => {
+  const pagePath = path.resolve(projectRoot, "app/[locale]/yachts/[slug]/page.tsx");
+
+  it("imports generateVideoObjectJsonLd", () => {
+    const content = fs.readFileSync(pagePath, "utf-8");
+    expect(content).toContain("generateVideoObjectJsonLd");
+  });
+
+  it("generates VideoObject for video media assets", () => {
+    const content = fs.readFileSync(pagePath, "utf-8");
+    expect(content).toMatch(/mediaType.*video/);
+    expect(content).toMatch(/generateVideoObjectJsonLd/);
+  });
+
+  it("renders media JSON-LD scripts in the page", () => {
+    const content = fs.readFileSync(pagePath, "utf-8");
+    expect(content).toContain("media-jsonld");
+    expect(content).toContain("application/ld+json");
+  });
+});


### PR DESCRIPTION
- New VideoEmbed component with click-to-play thumbnail pattern
- Derives YouTube thumbnails from embed URLs automatically
- Appends autoplay+mute params on iframe load
- Lazy-loaded: no heavy iframes on initial page load
- MediaGallery fully i18n'd (en + fr) with MediaGallery namespace
- Replaced direct iframe rendering with VideoEmbed in VideoList
- VideoObject JSON-LD already integrated in yacht detail page
- 31 unit tests covering component structure, logic, and i18n completeness
