### PR TITLE
perf: Enable ISR caching for by-size, use-case, and compare pages

### DIFF
--- a/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
+++ b/app/[locale]/compare/[slugA]-vs-[slugB]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { unstable_cache } from "next/cache";
 import { getYachtsBySlugs, generateComparisonIntro, generateComparisonMetadata, getPrimaryImage, type YachtComparisonData } from "@/lib/compare-canonical";
 import { getSiteUrl, generateBreadcrumbJsonLd, generateYachtJsonLd, generateComparePageJsonLd, buildLocaleAlternates, buildOgImageUrl } from "@/lib/seo";
 import { PriceTierBadge } from "@/app/components/PriceTierBadge";
@@ -8,8 +9,14 @@ import { calculatePriceTier } from "@/lib/price-tier";
 import { localePath } from "@/lib/i18n-paths";
 import { CanonicalCompareClient } from "./CanonicalCompareClient";
 
-// Force dynamic rendering
-export const dynamic = "force-dynamic";
+const getCachedYachtsBySlugs = unstable_cache(
+  async (slugA: string, slugB: string) => getYachtsBySlugs(slugA, slugB),
+  ["compare-yachts"],
+  { tags: ["yachts", "manufacturers"] }
+);
+
+// ISR: cache for 1 hour, invalidate via tags when admin updates yacht data
+export const revalidate = 3600;
 
 /**
  * Next.js treats [slugA]-vs-[slugB] as a SINGLE dynamic segment named
@@ -68,7 +75,7 @@ export async function generateMetadata({
   }
 
   const { slugA, slugB } = parsed;
-  const { yachtA, yachtB } = await getYachtsBySlugs(slugA, slugB);
+  const { yachtA, yachtB } = await getCachedYachtsBySlugs(slugA, slugB);
 
   if (!yachtA || !yachtB) {
     notFound();
@@ -126,7 +133,7 @@ export default async function CanonicalComparePage({
   }
 
   const { slugA, slugB } = parsed;
-  const { yachtA, yachtB } = await getYachtsBySlugs(slugA, slugB);
+  const { yachtA, yachtB } = await getCachedYachtsBySlugs(slugA, slugB);
 
   if (!yachtA || !yachtB) {
     notFound();

--- a/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
+++ b/app/[locale]/yachts/by-size/[sizeCategory]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { unstable_cache } from "next/cache";
 import { getSizeCategoryHubData } from "@/lib/size-category-hub";
 
 import {
@@ -15,9 +16,14 @@ import { localePath } from "@/lib/i18n-paths";
 import { SizeCategoryHubClient } from "./SizeCategoryHubClient";
 import { USE_CASES } from "@/lib/use-case-meta";
 
-// Force dynamic rendering — DB queries must run at request time
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
+// ISR: cache for 1 hour, invalidate via tags when admin updates yacht data
+export const revalidate = 3600;
+
+const getCachedSizeCategoryHubData = unstable_cache(
+  async (sizeCategorySlug: string) => getSizeCategoryHubData(sizeCategorySlug),
+  ["size-category-hub"],
+  { tags: ["yachts", "manufacturers"] }
+);
 
 export async function generateMetadata({
   params,
@@ -29,7 +35,7 @@ export async function generateMetadata({
   if (!sizeCategory) notFound();
 
   const locale = rawParams.locale || "en";
-  const data = await getSizeCategoryHubData(sizeCategory);
+  const data = await getCachedSizeCategoryHubData(sizeCategory);
   if (!data) notFound();
 
   const sizeLabel =
@@ -83,7 +89,7 @@ export default async function SizeCategoryHubPage({
   if (!sizeCategory) notFound();
 
   const locale = rawParams.locale || "en";
-  const data = await getSizeCategoryHubData(sizeCategory);
+  const data = await getCachedSizeCategoryHubData(sizeCategory);
   if (!data) notFound();
 
   const sizeLabel =

--- a/app/[locale]/yachts/for/[useCase]/page.tsx
+++ b/app/[locale]/yachts/for/[useCase]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { unstable_cache } from "next/cache";
 import { getUseCaseLandingData, USE_CASES } from "@/lib/use-case-landing";
 
 import {
@@ -14,9 +15,14 @@ import {
 import { localePath } from "@/lib/i18n-paths";
 import { UseCaseLandingClient } from "./UseCaseLandingClient";
 
-// Force dynamic rendering — DB queries must run at request time
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
+// ISR: cache for 1 hour, invalidate via tags when admin updates yacht data
+export const revalidate = 3600;
+
+const getCachedUseCaseLandingData = unstable_cache(
+  async (useCaseSlug: string) => getUseCaseLandingData(useCaseSlug),
+  ["use-case-landing"],
+  { tags: ["yachts", "manufacturers"] }
+);
 
 export async function generateMetadata({
   params,
@@ -28,7 +34,7 @@ export async function generateMetadata({
   if (!useCaseSlug) notFound();
 
   const locale = rawParams.locale || "en";
-  const data = await getUseCaseLandingData(useCaseSlug);
+  const data = await getCachedUseCaseLandingData(useCaseSlug);
   if (!data) notFound();
 
   const useCaseLabel =
@@ -82,7 +88,7 @@ export default async function UseCaseLandingPage({
   if (!useCaseSlug) notFound();
 
   const locale = rawParams.locale || "en";
-  const data = await getUseCaseLandingData(useCaseSlug);
+  const data = await getCachedUseCaseLandingData(useCaseSlug);
   if (!data) notFound();
 
   const useCaseLabel =


### PR DESCRIPTION
## Summary

Closes #348

Three high-traffic page types were configured as `force-dynamic` with `revalidate = 0`, causing every page request to query the database. This PR enables ISR (Incremental Static Regeneration) with 1-hour cache TTL and tag-based on-demand revalidation.

## Changes

### Pages converted to ISR
- **`/yachts/by-size/[sizeCategory]`** — Size category hub pages
- **`/yachts/for/[useCase]`** — Use-case landing pages  
- **`/compare/[slugA]-vs-[slugB]`** — Yacht comparison pages

### Implementation details
- Removed `export const dynamic = "force-dynamic"` and `export const revalidate = 0`
- Added `export const revalidate = 3600` (1-hour ISR)
- Wrapped data fetching with `unstable_cache()` and cache tags `["yachts", "manufacturers"]`
- Admin mutation endpoints already call `revalidateTag('yachts')` / `revalidateTag(`yacht:${slug}`)` on data changes, so cached pages are invalidated automatically

## Performance impact
- **Before:** Every request → DB query (Neon HTTP call)
- **After:** First request → DB query, subsequent requests → cached for up to 1 hour
- Admin changes trigger immediate cache invalidation via existing `revalidateTag()` calls

## Verification
- [x] Typecheck passes
- [x] Build passes
- [ ] Live verification after deploy
