### PR TITLE
feat: enhance spec glossary tooltips with keyboard a11y and shared data module (closes #356)

### DIFF
--- a/app/[locale]/yachts/[slug]/SpecTooltip.tsx
+++ b/app/[locale]/yachts/[slug]/SpecTooltip.tsx
@@ -1,137 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useId } from "react";
 import Link from "next/link";
 import { useLocale } from "next-intl";
 import { Info } from "lucide-react";
-
-/**
- * Mapping from spec category labels (as they appear in the UI) to glossary slugs.
- * The tooltip shows the glossary definition; clicking navigates to the full page.
- */
-const SPEC_TO_GLOSSARY: Record<string, string> = {
-  LOA: "loa",
-  "Length Overall": "loa",
-  Beam: "beam",
-  Draft: "draft",
-  Displacement: "displacement",
-  Ballast: "ballast",
-  "Ballast Ratio": "ballast-ratio",
-  "Sail Area": "sail-area",
-  "Sail Area / Displacement": "sa-disp-ratio",
-  "SA/D Ratio": "sa-disp-ratio",
-  "Displacement / Length": "disp-len-ratio",
-  "D/L Ratio": "disp-len-ratio",
-  LWL: "lwl",
-  "Waterline Length": "lwl",
-  "Hull Speed": "hull-speed",
-  "Keel Type": "keel-type",
-  "Rig Type": "rig-type",
-  "Fin Keel": "fin-keel",
-  "Wing Keel": "wing-keel",
-  "Sloop Rig": "sloop-rig",
-  "Cutter Rig": "cutter-rig",
-  "Ketch Rig": "ketch-rig",
-  "Shoal Draft": "shoal-draft",
-  Cabin: "cabin",
-  Cabins: "cabin",
-  Berth: "berth",
-  Berths: "berth",
-  Head: "head",
-  Heads: "head",
-  "Hull Material": "hull-material",
-  Engine: "engine",
-  "Engine HP": "engine",
-  "Fuel Capacity": "fuel-capacity",
-  "Water Capacity": "water-capacity",
-};
-
-/**
- * Brief tooltip definitions for common spec labels.
- * These are short versions; clicking leads to the full glossary page.
- */
-const TOOLTIP_DEFS: Record<string, { en: string; fr: string }> = {
-  LOA: {
-    en: "Maximum length from bow to stern",
-    fr: "Longueur maximale de la proue à la poupe",
-  },
-  Beam: {
-    en: "Maximum width of the yacht",
-    fr: "Largeur maximale du yacht",
-  },
-  Draft: {
-    en: "Depth from waterline to keel bottom",
-    fr: "Profondeur de la ligne de flottaison au bas de la quille",
-  },
-  Displacement: {
-    en: "Total weight of the yacht in water",
-    fr: "Poids total du yacht dans l'eau",
-  },
-  Ballast: {
-    en: "Weight in the keel for stability",
-    fr: "Poids dans la quille pour la stabilité",
-  },
-  "Ballast Ratio": {
-    en: "Ballast ÷ Displacement — stability indicator",
-    fr: "Lest ÷ Déplacement — indicateur de stabilité",
-  },
-  "Sail Area": {
-    en: "Total sail area (mainsail + headsail)",
-    fr: "Surface totale de la voilure",
-  },
-  "SA/D Ratio": {
-    en: "Sail power relative to displacement",
-    fr: "Puissance de voilure par rapport au déplacement",
-  },
-  "D/L Ratio": {
-    en: "Weight relative to waterline length",
-    fr: "Poids par rapport à la longueur de flottaison",
-  },
-  LWL: {
-    en: "Length at the waterline",
-    fr: "Longueur à la ligne de flottaison",
-  },
-  "Hull Speed": {
-    en: "Theoretical max speed for this hull",
-    fr: "Vitesse maximale théorique de la coque",
-  },
-  "Keel Type": {
-    en: "Shape and configuration of the keel",
-    fr: "Forme et configuration de la quille",
-  },
-  "Rig Type": {
-    en: "Mast and sail configuration",
-    fr: "Configuration du mât et de la voilure",
-  },
-  Cabins: {
-    en: "Number of enclosed sleeping compartments",
-    fr: "Nombre de cabines fermées",
-  },
-  Berths: {
-    en: "Number of sleeping positions",
-    fr: "Nombre de places couchage",
-  },
-  Heads: {
-    en: "Number of marine toilets/bathrooms",
-    fr: "Nombre de toilettes/salles de bain",
-  },
-  "Hull Material": {
-    en: "Primary construction material",
-    fr: "Matériau principal de construction",
-  },
-  "Engine HP": {
-    en: "Auxiliary engine horsepower",
-    fr: "Puissance du moteur auxiliaire",
-  },
-  "Fuel Capacity": {
-    en: "Total fuel tank capacity",
-    fr: "Capacité totale du réservoir de carburant",
-  },
-  "Water Capacity": {
-    en: "Total fresh water tank capacity",
-    fr: "Capacité totale du réservoir d'eau douce",
-  },
-};
+import { SPEC_TO_GLOSSARY, TOOLTIP_DEFS } from "@/lib/spec-tooltip-data";
 
 interface SpecTooltipProps {
   label: string;
@@ -140,11 +13,20 @@ interface SpecTooltipProps {
 export function SpecTooltip({ label }: SpecTooltipProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const tooltipId = useId();
   const locale = useLocale();
   const glossarySlug = SPEC_TO_GLOSSARY[label];
   const def = TOOLTIP_DEFS[label];
 
-  // Close on outside click
+  // Close on outside click or Escape
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+      buttonRef.current?.focus();
+    }
+  }, []);
+
   const handleClickOutside = useCallback((e: MouseEvent) => {
     if (ref.current && !ref.current.contains(e.target as Node)) {
       setOpen(false);
@@ -154,9 +36,13 @@ export function SpecTooltip({ label }: SpecTooltipProps) {
   useEffect(() => {
     if (open) {
       document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+        document.removeEventListener("keydown", handleKeyDown);
+      };
     }
-  }, [open, handleClickOutside]);
+  }, [open, handleClickOutside, handleKeyDown]);
 
   // No glossary entry — just render the label
   if (!glossarySlug && !def) {
@@ -183,21 +69,32 @@ export function SpecTooltip({ label }: SpecTooltipProps) {
       {tooltipText && (
         <>
           <button
+            ref={buttonRef}
             type="button"
-            className="inline-flex items-center text-muted-foreground hover:text-primary transition-colors"
+            className="inline-flex items-center text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded-sm"
             onMouseEnter={() => setOpen(true)}
             onMouseLeave={() => setOpen(false)}
+            onFocus={() => setOpen(true)}
+            onBlur={(e) => {
+              // Keep open if focus moves to tooltip content (e.g., "Learn more" link)
+              if (!ref.current?.contains(e.relatedTarget as Node)) {
+                setOpen(false);
+              }
+            }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
               setOpen((v) => !v);
             }}
             aria-label={`Definition of ${label}`}
+            aria-describedby={open ? tooltipId : undefined}
+            aria-expanded={open}
           >
             <Info className="w-3.5 h-3.5" />
           </button>
           {open && (
             <span
+              id={tooltipId}
               className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 text-xs leading-relaxed rounded-lg bg-popover text-popover-foreground border border-border shadow-lg whitespace-normal z-50 w-56"
               role="tooltip"
             >

--- a/lib/spec-tooltip-data.ts
+++ b/lib/spec-tooltip-data.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared data for SpecTooltip component.
+ * Extracted for testability — tests can import from here instead of duplicating.
+ */
+
+/**
+ * Mapping from spec category labels (as they appear in the UI) to glossary slugs.
+ */
+export const SPEC_TO_GLOSSARY: Record<string, string> = {
+  LOA: "loa",
+  "Length Overall": "loa",
+  Beam: "beam",
+  Draft: "draft",
+  Displacement: "displacement",
+  Ballast: "ballast",
+  "Ballast Ratio": "ballast-ratio",
+  "Sail Area": "sail-area",
+  "Sail Area Main": "sail-area",
+  "Sail Area Jib": "sail-area",
+  "Sail Area / Displacement": "sa-disp-ratio",
+  "SA/D Ratio": "sa-disp-ratio",
+  "Displacement / Length": "disp-len-ratio",
+  "D/L Ratio": "disp-len-ratio",
+  LWL: "lwl",
+  "Waterline Length": "lwl",
+  "Hull Speed": "hull-speed",
+  "Keel Type": "keel-type",
+  "Rig Type": "rig-type",
+  "Fin Keel": "fin-keel",
+  "Wing Keel": "wing-keel",
+  "Sloop Rig": "sloop-rig",
+  "Cutter Rig": "cutter-rig",
+  "Ketch Rig": "ketch-rig",
+  "Shoal Draft": "shoal-draft",
+  Cabin: "cabin",
+  Cabins: "cabin",
+  Berth: "berth",
+  Berths: "berth",
+  Head: "head",
+  Heads: "head",
+  "Hull Material": "hull-material",
+  Engine: "engine",
+  "Engine Type": "engine",
+  "Engine HP": "engine",
+  "Fuel Capacity": "fuel-capacity",
+  "Water Capacity": "water-capacity",
+  "Max Occupancy": "max-occupancy",
+};
+
+/**
+ * Brief tooltip definitions for common spec labels.
+ * These are short versions; clicking leads to the full glossary page.
+ */
+export const TOOLTIP_DEFS: Record<string, { en: string; fr: string }> = {
+  LOA: {
+    en: "Maximum length from bow to stern",
+    fr: "Longueur maximale de la proue à la poupe",
+  },
+  Beam: {
+    en: "Maximum width of the yacht",
+    fr: "Largeur maximale du yacht",
+  },
+  Draft: {
+    en: "Depth from waterline to keel bottom",
+    fr: "Profondeur de la ligne de flottaison au bas de la quille",
+  },
+  Displacement: {
+    en: "Total weight of the yacht in water",
+    fr: "Poids total du yacht dans l'eau",
+  },
+  Ballast: {
+    en: "Weight in the keel for stability",
+    fr: "Poids dans la quille pour la stabilité",
+  },
+  "Ballast Ratio": {
+    en: "Ballast ÷ Displacement — stability indicator",
+    fr: "Lest ÷ Déplacement — indicateur de stabilité",
+  },
+  "Sail Area": {
+    en: "Total sail area (mainsail + headsail)",
+    fr: "Surface totale de la voilure",
+  },
+  "Sail Area Main": {
+    en: "Area of the mainsail alone",
+    fr: "Surface de la grand-voile seule",
+  },
+  "Sail Area Jib": {
+    en: "Area of the jib or genoa",
+    fr: "Surface du foc ou du génois",
+  },
+  "SA/D Ratio": {
+    en: "Sail power relative to displacement",
+    fr: "Puissance de voilure par rapport au déplacement",
+  },
+  "D/L Ratio": {
+    en: "Weight relative to waterline length",
+    fr: "Poids par rapport à la longueur de flottaison",
+  },
+  LWL: {
+    en: "Length at the waterline",
+    fr: "Longueur à la ligne de flottaison",
+  },
+  "Hull Speed": {
+    en: "Theoretical max speed for this hull",
+    fr: "Vitesse maximale théorique de la coque",
+  },
+  "Keel Type": {
+    en: "Shape and configuration of the keel",
+    fr: "Forme et configuration de la quille",
+  },
+  "Rig Type": {
+    en: "Mast and sail configuration",
+    fr: "Configuration du mât et de la voilure",
+  },
+  Cabins: {
+    en: "Number of enclosed sleeping compartments",
+    fr: "Nombre de cabines fermées",
+  },
+  Berths: {
+    en: "Number of sleeping positions",
+    fr: "Nombre de places couchage",
+  },
+  Heads: {
+    en: "Number of marine toilets/bathrooms",
+    fr: "Nombre de toilettes/salles de bain",
+  },
+  "Hull Material": {
+    en: "Primary construction material",
+    fr: "Matériau principal de construction",
+  },
+  Engine: {
+    en: "Auxiliary engine details",
+    fr: "Détails du moteur auxiliaire",
+  },
+  "Engine Type": {
+    en: "Type of auxiliary engine (diesel, electric, etc.)",
+    fr: "Type de moteur auxiliaire (diesel, électrique, etc.)",
+  },
+  "Engine HP": {
+    en: "Auxiliary engine horsepower",
+    fr: "Puissance du moteur auxiliaire",
+  },
+  "Fuel Capacity": {
+    en: "Total fuel tank capacity",
+    fr: "Capacité totale du réservoir de carburant",
+  },
+  "Water Capacity": {
+    en: "Total fresh water tank capacity",
+    fr: "Capacité totale du réservoir d'eau douce",
+  },
+  "Max Occupancy": {
+    en: "Maximum recommended number of people aboard",
+    fr: "Nombre maximal recommandé de personnes à bord",
+  },
+};

--- a/tests/spec-tooltip.unit.test.ts
+++ b/tests/spec-tooltip.unit.test.ts
@@ -1,34 +1,8 @@
 import { describe, it, expect } from "vitest";
-
-// Import the static mappings to test they are consistent
-// We test the data logic, not the React component (DOM testing needs browser)
-
-const SPEC_TO_GLOSSARY: Record<string, string> = {
-  LOA: "loa",
-  Beam: "beam",
-  Draft: "draft",
-  Displacement: "displacement",
-  Ballast: "ballast",
-  "Ballast Ratio": "ballast-ratio",
-  Cabins: "cabin",
-  Berths: "berth",
-  Heads: "head",
-  "Hull Material": "hull-material",
-  "Engine HP": "engine",
-  LWL: "lwl",
-  "Hull Speed": "hull-speed",
-};
-
-const TOOLTIP_DEFS: Record<string, { en: string; fr: string }> = {
-  LOA: {
-    en: "Maximum length from bow to stern",
-    fr: "Longueur maximale de la proue à la poupe",
-  },
-  Beam: {
-    en: "Maximum width of the yacht",
-    fr: "Largeur maximale du yacht",
-  },
-};
+import {
+  SPEC_TO_GLOSSARY,
+  TOOLTIP_DEFS,
+} from "@/lib/spec-tooltip-data";
 
 describe("SpecTooltip data logic", () => {
   it("should have glossary slugs for all common spec labels", () => {
@@ -38,24 +12,44 @@ describe("SpecTooltip data logic", () => {
       "Draft",
       "Displacement",
       "Ballast",
+      "Ballast Ratio",
+      "Sail Area",
+      "Sail Area Main",
+      "Sail Area Jib",
+      "SA/D Ratio",
+      "D/L Ratio",
+      "LWL",
+      "Hull Speed",
+      "Keel Type",
+      "Rig Type",
       "Cabins",
       "Berths",
+      "Heads",
+      "Hull Material",
+      "Engine",
+      "Engine Type",
+      "Engine HP",
+      "Fuel Capacity",
+      "Water Capacity",
+      "Max Occupancy",
     ];
     for (const label of commonLabels) {
-      expect(SPEC_TO_GLOSSARY[label]).toBeDefined();
+      expect(SPEC_TO_GLOSSARY[label], `Missing glossary slug for "${label}"`).toBeDefined();
     }
   });
 
-  it("should have both en and fr definitions", () => {
-    for (const [, def] of Object.entries(TOOLTIP_DEFS)) {
-      expect(def.en).toBeTruthy();
-      expect(def.fr).toBeTruthy();
+  it("should have both en and fr definitions for all tooltips", () => {
+    for (const [label, def] of Object.entries(TOOLTIP_DEFS)) {
+      expect(def.en, `Missing English definition for "${label}"`).toBeTruthy();
+      expect(def.fr, `Missing French definition for "${label}"`).toBeTruthy();
+      expect(typeof def.en).toBe("string");
+      expect(typeof def.fr).toBe("string");
     }
   });
 
-  it("should use kebab-case for glossary slugs", () => {
-    for (const [, slug] of Object.entries(SPEC_TO_GLOSSARY)) {
-      expect(slug).toMatch(/^[a-z0-9-]+$/);
+  it("should use kebab-case for all glossary slugs", () => {
+    for (const [label, slug] of Object.entries(SPEC_TO_GLOSSARY)) {
+      expect(slug, `Invalid slug format for "${label}"`).toMatch(/^[a-z0-9-]+$/);
     }
   });
 
@@ -66,5 +60,114 @@ describe("SpecTooltip data logic", () => {
     expect(slug).toBeUndefined();
     expect(def).toBeUndefined();
     // Component would just render plain text
+  });
+
+  it("should have tooltip definitions for all primary spec category labels", () => {
+    // Primary labels that appear as spec category names from the DB
+    const primaryLabels = [
+      "LOA",
+      "Beam",
+      "Draft",
+      "Displacement",
+      "Ballast",
+      "Sail Area Main",
+      "Sail Area Jib",
+      "Engine HP",
+      "Engine Type",
+      "Fuel Capacity",
+      "Water Capacity",
+      "Cabins",
+      "Berths",
+      "Heads",
+      "Hull Material",
+      "Keel Type",
+      "Rig Type",
+      "LWL",
+      "Hull Speed",
+    ];
+    for (const label of primaryLabels) {
+      // These should all have either a tooltip definition or a glossary link
+      const hasTooltip = TOOLTIP_DEFS[label] !== undefined;
+      const hasGlossary = SPEC_TO_GLOSSARY[label] !== undefined;
+      expect(hasTooltip || hasGlossary, `"${label}" should have tooltip or glossary link`).toBe(true);
+    }
+  });
+
+  it("should cover performance ratio labels", () => {
+    const performanceLabels = [
+      "SA/D Ratio",
+      "D/L Ratio",
+      "Ballast Ratio",
+      "Hull Speed",
+    ];
+    for (const label of performanceLabels) {
+      expect(TOOLTIP_DEFS[label], `Missing tooltip for performance label "${label}"`).toBeDefined();
+    }
+  });
+
+  it("should cover accommodation spec labels", () => {
+    const accommodationLabels = ["Cabins", "Berths", "Heads", "Max Occupancy"];
+    for (const label of accommodationLabels) {
+      expect(SPEC_TO_GLOSSARY[label], `Missing glossary slug for "${label}"`).toBeDefined();
+      expect(TOOLTIP_DEFS[label], `Missing tooltip for "${label}"`).toBeDefined();
+    }
+  });
+
+  it("should cover technical spec labels", () => {
+    const technicalLabels = [
+      "Engine HP",
+      "Engine Type",
+      "Fuel Capacity",
+      "Water Capacity",
+      "Hull Material",
+    ];
+    for (const label of technicalLabels) {
+      expect(SPEC_TO_GLOSSARY[label], `Missing glossary slug for "${label}"`).toBeDefined();
+      expect(TOOLTIP_DEFS[label], `Missing tooltip for "${label}"`).toBeDefined();
+    }
+  });
+
+  it("should cover dimension spec labels", () => {
+    const dimensionLabels = ["LOA", "Beam", "Draft", "Displacement", "LWL"];
+    for (const label of dimensionLabels) {
+      expect(SPEC_TO_GLOSSARY[label], `Missing glossary slug for "${label}"`).toBeDefined();
+      expect(TOOLTIP_DEFS[label], `Missing tooltip for "${label}"`).toBeDefined();
+    }
+  });
+
+  it("should cover rig and keel type labels", () => {
+    const rigKeelLabels = [
+      "Keel Type",
+      "Rig Type",
+      "Fin Keel",
+      "Wing Keel",
+      "Sloop Rig",
+      "Cutter Rig",
+      "Ketch Rig",
+      "Shoal Draft",
+    ];
+    for (const label of rigKeelLabels) {
+      expect(SPEC_TO_GLOSSARY[label], `Missing glossary slug for "${label}"`).toBeDefined();
+    }
+  });
+
+  it("should map alias labels to the same glossary slug", () => {
+    // "LOA" and "Length Overall" both go to "loa"
+    expect(SPEC_TO_GLOSSARY["LOA"]).toBe("loa");
+    expect(SPEC_TO_GLOSSARY["Length Overall"]).toBe("loa");
+    // "Cabins" and "Cabin" both go to "cabin"
+    expect(SPEC_TO_GLOSSARY["Cabins"]).toBe("cabin");
+    expect(SPEC_TO_GLOSSARY["Cabin"]).toBe("cabin");
+    // "Engine", "Engine Type", "Engine HP" all map to "engine"
+    expect(SPEC_TO_GLOSSARY["Engine"]).toBe("engine");
+    expect(SPEC_TO_GLOSSARY["Engine Type"]).toBe("engine");
+    expect(SPEC_TO_GLOSSARY["Engine HP"]).toBe("engine");
+  });
+
+  it("should have consistent data between SPEC_TO_GLOSSARY and TOOLTIP_DEFS", () => {
+    // Every entry in TOOLTIP_DEFS should have a corresponding SPEC_TO_GLOSSARY entry
+    for (const label of Object.keys(TOOLTIP_DEFS)) {
+      expect(SPEC_TO_GLOSSARY[label], `TOOLTIP_DEFS has "${label}" but SPEC_TO_GLOSSARY doesn't`).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
- Extract SPEC_TO_GLOSSARY and TOOLTIP_DEFS to shared lib/spec-tooltip-data.ts
- Add keyboard accessibility: Escape to close, focus/blur, aria-describedby, aria-expanded
- Add missing spec labels: Sail Area Main, Sail Area Jib, Engine Type, Max Occupancy
- Add French tooltip definitions for all new labels
- Add focus-visible ring style for keyboard navigation
- Rewrite tests to import from shared module (12 tests, up from 4)
- Tests cover dimensions, performance, accommodation, technical, rig/keel labels
- Tests verify en/fr coverage, slug format, alias mapping, and data consistency
