### PR TITLE
feat: add year/model variant tracking with selector on yacht detail page (closes #360)

### DIFF
--- a/app/[locale]/yachts/[slug]/VariantSelector.tsx
+++ b/app/[locale]/yachts/[slug]/VariantSelector.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { Calendar, Ruler } from "lucide-react";
+import { localePath } from "@/lib/i18n-paths";
+
+export interface YachtVariant {
+  id: number;
+  slug: string | null;
+  modelName: string;
+  year: number;
+  lengthOverall: string | null;
+  cabins: number | null;
+  displacement: string | null;
+}
+
+interface VariantSelectorProps {
+  variants: YachtVariant[];
+  currentYear: number;
+}
+
+function toNum(v: string | number | null): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+export default function VariantSelector({ variants, currentYear }: VariantSelectorProps) {
+  const t = useTranslations("YachtDetail");
+  const locale = useLocale();
+  const params = useParams();
+  const currentSlug = params.slug as string;
+
+  if (!variants || variants.length === 0) return null;
+
+  // Sort by year desc
+  const sorted = [...variants].sort((a, b) => b.year - a.year);
+
+  return (
+    <div className="rounded-lg border bg-card p-4" data-testid="variant-selector">
+      <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex items-center gap-2">
+        <Calendar className="h-4 w-4" aria-hidden="true" />
+        {t("yearVariants")}
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {sorted.map((variant) => {
+          const isCurrent = variant.slug === currentSlug;
+          const loa = toNum(variant.lengthOverall);
+
+          if (isCurrent) {
+            return (
+              <span
+                key={variant.id}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground"
+              >
+                {variant.year}
+                <span className="text-xs opacity-75">(current)</span>
+              </span>
+            );
+          }
+
+          return (
+            <Link
+              key={variant.id}
+              href={localePath(locale, `/yachts/${variant.slug}`)}
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {variant.year}
+              {loa && (
+                <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                  <Ruler className="h-3 w-3" aria-hidden="true" />
+                  {loa}m
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -89,6 +89,10 @@ const SpecBarsChart = dynamic(
   { ssr: false, loading: () => null },
 );
 
+const VariantSelector = dynamic(() => import("./VariantSelector").then((m) => ({ default: m.default })), {
+  ssr: false,
+  loading: () => null,
+});
 interface SpecGroup {
   [group: string]: Array<{
     category: string;
@@ -196,6 +200,7 @@ export default function YachtDetailClient() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<string>("");
+  const [variants, setVariants] = useState<Array<import("./VariantSelector").YachtVariant>>([]);
 
   // Translation-aware GROUP_LABELS
   const GROUP_LABELS: Record<string, string> = {
@@ -281,6 +286,19 @@ export default function YachtDetailClient() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [slug, t]);
+
+  useEffect(() => {
+    if (!slug) return;
+    fetch(`/api/yachts/${slug}/variants`)
+      .then((r) => {
+        if (!r.ok) return null;
+        return r.json();
+      })
+      .then((data) => {
+        if (data?.variants) setVariants(data.variants);
+      })
+      .catch(() => {}); // silent fail — variants are non-critical
+  }, [slug]);
 
   const handlePrint = () => {
     window.print();
@@ -515,6 +533,12 @@ export default function YachtDetailClient() {
               {/* Real price data from DB */}
               <PriceInsightBlock yachtId={yacht.id} modelName={yacht.modelName} aria-hidden="true" />
 
+              {/* Year Variants */}
+              {variants.length > 0 && (
+                <div className="mt-4">
+                  <VariantSelector variants={variants} currentYear={yacht.year} />
+                </div>
+              )}
               {/* Admin links */}
               {yacht.adminLinks && yacht.adminLinks.length > 0 && (
                 <div className="admin-links flex flex-wrap gap-2 sm:gap-3 mt-4 no-print">

--- a/app/api/yachts/[slug]/variants/route.ts
+++ b/app/api/yachts/[slug]/variants/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { getYachtVariants } from "@/lib/yachts";
+import { db, yachtModels } from "@/lib/db-edge";
+import { eq } from "drizzle-orm";
+
+export const revalidate = 3600;
+export const runtime = "edge";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await params;
+
+    const cached = unstable_cache(
+      async () => {
+        // First get the current yacht to find its manufacturer and model name
+        const yachtResult = await db
+          .select({
+            id: yachtModels.id,
+            manufacturerId: yachtModels.manufacturerId,
+            modelName: yachtModels.modelName,
+          })
+          .from(yachtModels)
+          .where(eq(yachtModels.slug, slug))
+          .limit(1);
+
+        if (yachtResult.length === 0) return null;
+
+        const { id, manufacturerId, modelName } = yachtResult[0];
+        return getYachtVariants(id, manufacturerId, modelName);
+      },
+      [`yacht-variants:${slug}`],
+      { tags: [`yacht:${slug}`, "yachts"], revalidate: 3600 },
+    )();
+
+    const variants = await cached;
+    if (variants === null) {
+      return NextResponse.json({ error: "Yacht not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ variants });
+  } catch (error) {
+    console.error("Error fetching yacht variants:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch variants" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/yachts.ts
+++ b/lib/yachts.ts
@@ -339,3 +339,37 @@ export async function getPrimaryImage(slug: string): Promise<string | null> {
   const primaryImage = yachtImages.find((img: typeof images.$inferSelect) => img.isPrimary) || yachtImages[0];
   return primaryImage?.url || null;
 }
+
+/**
+ * Get year variants for a yacht model — other models from the same manufacturer
+ * with the same base model name but different years.
+ */
+export interface YachtVariant {
+  id: number;
+  slug: string | null;
+  modelName: string;
+  year: number;
+  lengthOverall: string | null;
+  cabins: number | null;
+  displacement: string | null;
+}
+
+export async function getYachtVariants(yachtId: number, manufacturerId: number, modelName: string): Promise<YachtVariant[]> {
+  const variants = await db
+    .select({
+      id: yachtModels.id,
+      slug: yachtModels.slug,
+      modelName: yachtModels.modelName,
+      year: yachtModels.year,
+      lengthOverall: yachtModels.lengthOverall,
+      cabins: yachtModels.cabins,
+      displacement: yachtModels.displacement,
+    })
+    .from(yachtModels)
+    .where(
+      sql`${yachtModels.manufacturerId} = ${manufacturerId} AND ${yachtModels.modelName} = ${modelName} AND ${yachtModels.id} != ${yachtId}`
+    )
+    .orderBy(desc(yachtModels.year));
+
+  return variants;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -551,7 +551,8 @@
       "relatedGuides": "Related Guides",
       "contact": "Contact & Inquiries"
     },
-    "autoDescriptionBadge": "Auto-generated from specifications"
+    "autoDescriptionBadge": "Auto-generated from specifications",
+    "yearVariants": "Year Variants"
   },
   "YachtDetailSub": {
     "similarYachts": "Similar Yachts",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -551,7 +551,8 @@
       "relatedGuides": "Guides associés",
       "contact": "Contact & demandes"
     },
-    "autoDescriptionBadge": "Généré automatiquement à partir des spécifications"
+    "autoDescriptionBadge": "Généré automatiquement à partir des spécifications",
+    "yearVariants": "Variantes par année"
   },
   "YachtDetailSub": {
     "similarYachts": "Yachts similaires",

--- a/tests/yacht-variants.test.ts
+++ b/tests/yacht-variants.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the db-edge module
+vi.mock("@/lib/db-edge", () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn(),
+  },
+  yachtModels: {
+    id: "id",
+    slug: "slug",
+    modelName: "model_name",
+    year: "year",
+    manufacturerId: "manufacturer_id",
+    lengthOverall: "length_overall",
+    cabins: "cabins",
+    displacement: "displacement",
+  },
+}));
+
+// Mock drizzle-orm
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  desc: vi.fn(),
+  asc: vi.fn(),
+  sql: vi.fn((strings, ...values) => ({ sql: strings.join("?"), values })),
+  inArray: vi.fn(),
+  count: vi.fn(),
+  isNotNull: vi.fn(),
+}));
+
+import { getYachtVariants, type YachtVariant } from "@/lib/yachts";
+import { db } from "@/lib/db-edge";
+
+describe("getYachtVariants", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return variants for the same model name and manufacturer", async () => {
+    const mockVariants: YachtVariant[] = [
+      {
+        id: 2,
+        slug: "oceanis-40-1-2023",
+        modelName: "Oceanis 40.1",
+        year: 2023,
+        lengthOverall: "12.43",
+        cabins: 3,
+        displacement: "8300",
+      },
+      {
+        id: 3,
+        slug: "oceanis-40-1-2019",
+        modelName: "Oceanis 40.1",
+        year: 2019,
+        lengthOverall: "12.43",
+        cabins: 2,
+        displacement: "7900",
+      },
+    ];
+
+    // Chain the mock to return data
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue(mockVariants),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const result = await getYachtVariants(1, 10, "Oceanis 40.1");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].slug).toBe("oceanis-40-1-2023");
+    expect(result[1].slug).toBe("oceanis-40-1-2019");
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it("should return empty array when no variants exist", async () => {
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue([]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const result = await getYachtVariants(1, 10, "Unique Model");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should exclude the current yacht by id", async () => {
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue([]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    await getYachtVariants(42, 10, "Oceanis 40.1");
+
+    // The sql template should have been used in the where clause
+    expect(chain.where).toHaveBeenCalled();
+    expect(chain.from).toHaveBeenCalled();
+  });
+
+  it("should order variants by year descending", async () => {
+    const mockVariants: YachtVariant[] = [
+      { id: 3, slug: "test-2025", modelName: "Test", year: 2025, lengthOverall: null, cabins: null, displacement: null },
+      { id: 2, slug: "test-2020", modelName: "Test", year: 2020, lengthOverall: null, cabins: null, displacement: null },
+    ];
+
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue(mockVariants),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const result = await getYachtVariants(1, 10, "Test");
+
+    expect(result[0].year).toBe(2025);
+    expect(result[1].year).toBe(2020);
+  });
+});


### PR DESCRIPTION
- Add getYachtVariants() query to find same model/different year variants
- Create VariantSelector component with year badge links (i18n en+fr)
- Add /api/yachts/[slug]/variants Edge API endpoint with ISR caching
- Lazy-loaded component, non-critical silent fail on fetch
- 4 unit tests for variant query logic
- aria-hidden on decorative icons for accessibility
