### PR TITLE
feat: add comprehensive security headers to middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,51 @@ const intlMiddleware = createMiddleware({
   localePrefix: 'always', // /en/... and /fr/...
 })
 
+/**
+ * Build security headers based on the route type.
+ * - Embed routes allow framing (used by third-party embeds)
+ * - All other routes set X-Frame-Options: DENY
+ */
+function getSecurityHeaders(pathname: string): Record<string, string> {
+  const isEmbed = pathname.startsWith('/embed/')
+
+  // Content-Security-Policy directives
+  const cspDirectives = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "img-src 'self' data: blob: https://info.sailboats.fr https://img.youtube.com https://i.vimeocdn.com https://*.googleusercontent.com",
+    "media-src 'self'",
+    "object-src 'none'",
+    isEmbed
+      ? "frame-src 'self' https://www.youtube.com https://youtube.com https://player.vimeo.com"
+      : "frame-src 'self' https://www.youtube.com https://youtube.com https://player.vimeo.com",
+    "frame-ancestors " + (isEmbed ? "'self' *" : "'none'"),
+    "connect-src 'self' https://o*.ingest.sentry.io https://*.ingest.sentry.io https://info.sailboats.fr https://speedcurve.com https://cdn.speedcurve.com",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "upgrade-insecure-requests",
+  ].join('; ')
+
+  return {
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+    'Content-Security-Policy': cspDirectives,
+    // X-Frame-Options only set for non-embed routes (CSP frame-ancestors takes priority in modern browsers)
+    ...(isEmbed ? {} : { 'X-Frame-Options': 'DENY' }),
+  }
+}
+
+function addSecurityHeaders(response: NextResponse, pathname: string): NextResponse {
+  const headers = getSecurityHeaders(pathname)
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value)
+  }
+  return response
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -29,21 +74,28 @@ export async function middleware(request: NextRequest) {
       }
     }
 
-    return NextResponse.next()
+    const response = NextResponse.next()
+    // API-specific security headers (no CSP needed for API routes)
+    response.headers.set('X-Content-Type-Options', 'nosniff')
+    response.headers.set('X-Frame-Options', 'DENY')
+    return response
   }
 
-  // ── Embed routes: no locale handling ──
+  // ── Embed routes: allow framing for embeds ──
   if (pathname.startsWith('/embed/')) {
-    return NextResponse.next()
+    const response = NextResponse.next()
+    return addSecurityHeaders(response, pathname)
   }
 
   // ── Admin routes: no locale handling ──
   if (pathname.startsWith('/admin')) {
-    return NextResponse.next()
+    const response = NextResponse.next()
+    return addSecurityHeaders(response, pathname)
   }
 
   // ── Everything else: handle with next-intl middleware ──
-  return intlMiddleware(request)
+  const response = intlMiddleware(request)
+  return addSecurityHeaders(response, pathname)
 }
 
 export const config = {


### PR DESCRIPTION
- Add Content-Security-Policy with appropriate directives for:
  - Google Fonts (style-src, font-src)
  - YouTube/Vimeo embeds (frame-src, img-src)
  - Sentry error reporting (connect-src)
  - Next.js internals (unsafe-inline, unsafe-eval)
- Add X-Content-Type-Options: nosniff
- Add Referrer-Policy: strict-origin-when-cross-origin
- Add Permissions-Policy: camera=(), microphone=(), geolocation=()
- Add X-Frame-Options: DENY for non-embed routes
- Embed routes allow framing via frame-ancestors
- API routes get minimal security headers (nosniff + DENY)
- Add upgrade-insecure-requests directive

Closes #365
