### PR TITLE
fix: use session-based auth in enrichment API routes

### DIFF
--- a/app/api/admin/enrichment/route.ts
+++ b/app/api/admin/enrichment/route.ts
@@ -1,21 +1,30 @@
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/admin-auth'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 import { getEnrichmentStatus } from '@/lib/enrichment/service'
 
 export const dynamic = 'force-dynamic'
 
+async function requireAdminApi() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user || session.user.role !== 'admin') {
+    return null
+  }
+  return session
+}
+
 export async function GET() {
   try {
-    await requireAdmin()
+    const session = await requireAdminApi()
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
     const status = await getEnrichmentStatus()
     return NextResponse.json(status)
   } catch (error) {
-    if (error instanceof Error && error.message.includes('ADMIN')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
     console.error('Enrichment status error:', error)
     return NextResponse.json(
-      { error: 'Failed to fetch enrichment status' },
+      { error: 'Failed to fetch enrichment status', details: error instanceof Error ? error.message : 'Unknown' },
       { status: 500 }
     )
   }

--- a/app/api/admin/enrichment/run/route.ts
+++ b/app/api/admin/enrichment/run/route.ts
@@ -1,12 +1,24 @@
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/admin-auth'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 import { runEnrichmentPipeline, findEnrichmentCandidates } from '@/lib/enrichment/service'
 
 export const dynamic = 'force-dynamic'
 
+async function requireAdminApi() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user || session.user.role !== 'admin') {
+    return null
+  }
+  return session
+}
+
 export async function POST(request: Request) {
   try {
-    await requireAdmin()
+    const session = await requireAdminApi()
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     const body = await request.json().catch(() => ({}))
     const { limit = 20, dryRun = false, rateLimitMs = 3000 } = body
@@ -42,9 +54,6 @@ export async function POST(request: Request) {
       stats,
     })
   } catch (error) {
-    if (error instanceof Error && error.message.includes('ADMIN')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
     console.error('Enrichment run error:', error)
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Enrichment run failed' },


### PR DESCRIPTION
Fixes auth in enrichment API endpoints. Uses getServerSession directly instead of requireAdmin (which uses redirect, incompatible with API routes).