### PR TITLE
feat: P21.4 Price data aggregation pipeline

### DIFF
--- a/app/admin/prices/aggregate/AggregationDashboard.tsx
+++ b/app/admin/prices/aggregate/AggregationDashboard.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  candidatesWithoutPrices: number;
+}
+
+export default function AggregationDashboard({ candidatesWithoutPrices }: Props) {
+  const [running, setRunning] = useState(false);
+  const [dryRunResult, setDryRunResult] = useState<any>(null);
+  const [runResult, setRunResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDryRun() {
+    setRunning(true);
+    setError(null);
+    setDryRunResult(null);
+    try {
+      const res = await fetch('/api/admin/prices/aggregate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true, limit: 250 }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed');
+      setDryRunResult(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function handleRun() {
+    if (!confirm(`Generate estimated prices for ${candidatesWithoutPrices} yachts? This will create new price records.`)) return;
+    setRunning(true);
+    setError(null);
+    setRunResult(null);
+    try {
+      const res = await fetch('/api/admin/prices/aggregate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: 250 }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed');
+      setRunResult(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Price Estimation Pipeline</h2>
+      <p className="text-sm text-gray-600 mb-4">
+        Generate estimated prices for yachts based on their specifications (length, displacement, age, manufacturer).
+        Prices are estimated in EUR with conservative ranges.
+      </p>
+
+      <div className="bg-blue-50 border border-blue-200 rounded-md p-3 mb-4">
+        <div className="text-sm text-blue-800">
+          <strong>{candidatesWithoutPrices}</strong> yachts eligible for price estimation
+        </div>
+      </div>
+
+      <div className="flex gap-3 mb-4">
+        <button
+          onClick={handleDryRun}
+          disabled={running}
+          className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+        >
+          {running && !runResult ? 'Running...' : '🔍 Dry Run Preview'}
+        </button>
+        <button
+          onClick={handleRun}
+          disabled={running}
+          className="px-4 py-2 border border-transparent rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+        >
+          {running ? 'Running...' : '▶ Run Estimation'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-md p-3 mb-4">
+          <div className="text-sm text-red-800">Error: {error}</div>
+        </div>
+      )}
+
+      {dryRunResult && (
+        <div className="bg-gray-50 border border-gray-200 rounded-md p-4 mb-4">
+          <h3 className="text-sm font-medium text-gray-700 mb-2">Dry Run Results</h3>
+          <div className="text-sm text-gray-600">
+            <div>Candidates: {dryRunResult.candidatesTotal}</div>
+            <div>Price estimates generated: {dryRunResult.resultsFound}</div>
+            <div>Status: {dryRunResult.status}</div>
+          </div>
+        </div>
+      )}
+
+      {runResult && (
+        <div className="bg-green-50 border border-green-200 rounded-md p-4">
+          <h3 className="text-sm font-medium text-green-800 mb-2">✅ Run Complete</h3>
+          <div className="text-sm text-green-700">
+            <div>Candidates evaluated: {runResult.candidatesTotal}</div>
+            <div>Estimates generated: {runResult.resultsFound}</div>
+            <div>Prices created: {runResult.pricesCreated}</div>
+            <div>Prices updated: {runResult.pricesUpdated}</div>
+            {runResult.errors.length > 0 && (
+              <div className="mt-2 text-red-600">
+                Errors: {runResult.errors.join('; ')}
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-3 text-sm text-blue-600 hover:text-blue-800"
+          >
+            Refresh to see updated stats →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/prices/aggregate/page.tsx
+++ b/app/admin/prices/aggregate/page.tsx
@@ -1,0 +1,183 @@
+import { requireAdmin } from '@/lib/admin-auth'
+export const dynamic = 'force-dynamic';
+
+import { pool } from '@/lib/db';
+import AggregationDashboard from './AggregationDashboard';
+
+export const metadata = { title: 'Price Aggregation — Admin' };
+
+async function getStatus() {
+  const [totalYachts, yachtsWithPrices, byCondition, byCurrency, bySource] = await Promise.all([
+    pool.query(`SELECT COUNT(*) as count FROM yacht_models WHERE length_overall IS NOT NULL`),
+    pool.query(`
+      SELECT COUNT(DISTINCT yp.yacht_model_id) as count
+      FROM yacht_prices yp
+      JOIN yacht_models ym ON yp.yacht_model_id = ym.id
+      WHERE yp.is_active = true
+    `),
+    pool.query(`
+      SELECT condition, COUNT(*) as count FROM yacht_prices WHERE is_active = true GROUP BY condition
+    `),
+    pool.query(`
+      SELECT currency, COUNT(*) as count FROM yacht_prices WHERE is_active = true GROUP BY currency
+    `),
+    pool.query(`
+      SELECT source, COUNT(*) as count, MIN(price_min) as min_price, MAX(price_max) as max_price
+      FROM yacht_prices WHERE is_active = true GROUP BY source ORDER BY count DESC
+    `),
+  ]);
+
+  const total = parseInt(totalYachts.rows[0]?.count || '0', 10);
+  const withPrices = parseInt(yachtsWithPrices.rows[0]?.count || '0', 10);
+
+  return {
+    totalYachts: total,
+    yachtsWithPrices: withPrices,
+    yachtsWithoutPrices: total - withPrices,
+    coveragePercent: total > 0 ? Math.round((withPrices / total) * 100) : 0,
+    byCondition: Object.fromEntries(byCondition.rows.map((r: any) => [r.condition, parseInt(r.count, 10)])),
+    byCurrency: Object.fromEntries(byCurrency.rows.map((r: any) => [r.currency, parseInt(r.count, 10)])),
+    bySource: bySource.rows.map((r: any) => ({
+      source: r.source,
+      count: parseInt(r.count, 10),
+      minPrice: r.min_price ? parseFloat(r.min_price) : null,
+      maxPrice: r.max_price ? parseFloat(r.max_price) : null,
+    })),
+  };
+}
+
+async function getCandidatesWithoutPrices() {
+  const result = await pool.query(`
+    SELECT ym.id, ym.slug, ym.model_name, ym.year, ym.length_overall, m.name as manufacturer_name
+    FROM yacht_models ym
+    JOIN manufacturers m ON ym.manufacturer_id = m.id
+    LEFT JOIN yacht_prices yp ON yp.yacht_model_id = ym.id AND yp.is_active = true
+    WHERE yp.id IS NULL AND ym.length_overall IS NOT NULL AND ym.year IS NOT NULL
+    ORDER BY ym.length_overall DESC
+    LIMIT 20
+  `);
+  return result.rows;
+}
+
+export default async function AdminPriceAggregationPage() {
+  await requireAdmin()
+  const [status, candidates] = await Promise.all([getStatus(), getCandidatesWithoutPrices()]);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Price Aggregation</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Aggregate and estimate price data for yachts based on specifications
+        </p>
+      </div>
+
+      {/* Coverage Overview */}
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-6">
+        <div className="bg-white rounded-lg shadow p-4">
+          <div className="text-sm text-gray-500">Total Yachts</div>
+          <div className="text-2xl font-bold text-gray-900">{status.totalYachts}</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-4">
+          <div className="text-sm text-gray-500">With Prices</div>
+          <div className="text-2xl font-bold text-green-600">{status.yachtsWithPrices}</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-4">
+          <div className="text-sm text-gray-500">Missing Prices</div>
+          <div className="text-2xl font-bold text-red-600">{status.yachtsWithoutPrices}</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-4">
+          <div className="text-sm text-gray-500">Coverage</div>
+          <div className="text-2xl font-bold text-blue-600">{status.coveragePercent}%</div>
+          <div className="mt-2 bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-blue-600 rounded-full h-2 transition-all"
+              style={{ width: `${status.coveragePercent}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Condition Breakdown */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        {Object.entries(status.byCondition).map(([condition, count]) => (
+          <div key={condition} className="bg-white rounded-lg shadow p-4">
+            <div className="text-sm text-gray-500 capitalize">{condition} Prices</div>
+            <div className="text-xl font-bold text-gray-900">{count as number}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Source Breakdown */}
+      {status.bySource.length > 0 && (
+        <div className="bg-white shadow rounded-lg overflow-hidden mb-6">
+          <div className="px-4 py-3 bg-gray-50 border-b">
+            <h2 className="text-sm font-medium text-gray-700">Price Sources</h2>
+          </div>
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Source</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Records</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Price Range</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {status.bySource.map((s: any) => (
+                <tr key={s.source} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm text-gray-900">{s.source}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{s.count}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">
+                    {s.minPrice && s.maxPrice
+                      ? `€${Math.round(s.minPrice / 1000)}K – €${Math.round(s.maxPrice / 1000)}K`
+                      : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Aggregation Actions */}
+      <AggregationDashboard candidatesWithoutPrices={candidates.length} />
+
+      {/* Candidates Without Prices */}
+      {candidates.length > 0 && (
+        <div className="bg-white shadow rounded-lg overflow-hidden mt-6">
+          <div className="px-4 py-3 bg-gray-50 border-b">
+            <h2 className="text-sm font-medium text-gray-700">
+              Yachts Missing Prices (Top 20 by Length)
+            </h2>
+          </div>
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Yacht</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Year</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">LOA</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {candidates.map((c: any) => (
+                <tr key={c.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm">
+                    <div className="font-medium text-gray-900">{c.model_name}</div>
+                    <div className="text-gray-500 text-xs">{c.manufacturer_name}</div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{c.year}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{c.length_overall}m</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-4 flex gap-4">
+        <a href="/admin/prices" className="text-sm text-blue-600 hover:text-blue-800">← Price Management</a>
+        <a href="/admin" className="text-sm text-blue-600 hover:text-blue-800">← Admin Dashboard</a>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/prices/page.tsx
+++ b/app/admin/prices/page.tsx
@@ -64,6 +64,12 @@ export default async function AdminPricesPage() {
         </div>
         <div className="flex gap-3">
           <a
+            href="/admin/prices/aggregate"
+            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+          >
+            🔄 Aggregation
+          </a>
+          <a
             href="/admin/prices/import"
             className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           >

--- a/app/api/admin/prices/aggregate/route.ts
+++ b/app/api/admin/prices/aggregate/route.ts
@@ -1,0 +1,50 @@
+/**
+ * P21.4: Admin API for price aggregation
+ * GET  — aggregation status
+ * POST — trigger aggregation pipeline
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { getAggregationStatus, runAggregationPipeline } from '@/lib/price-aggregation/service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    // Check admin auth
+    const session = await getServerSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const status = await getAggregationStatus();
+    return NextResponse.json(status);
+  } catch (error: any) {
+    console.error('Error fetching aggregation status:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Check admin auth
+    const session = await getServerSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const options = {
+      provider: body.provider as string | undefined,
+      dryRun: body.dryRun === true,
+      limit: body.limit ? parseInt(body.limit, 10) : 200,
+      overwrite: body.overwrite === true,
+    };
+
+    const result = await runAggregationPipeline(options);
+    return NextResponse.json(result);
+  } catch (error: any) {
+    console.error('Error running price aggregation:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/prices/estimate/route.ts
+++ b/app/api/prices/estimate/route.ts
@@ -1,0 +1,73 @@
+/**
+ * P21.4: Price estimation API for public use
+ * GET /api/prices/estimate?slug=beneteau-oceanis-40-1
+ *
+ * Returns estimated price range for a yacht based on specs.
+ * Used by yacht detail pages to show price estimates.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { estimatePrice } from '@/lib/price-aggregation/estimated-provider';
+import { pool } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const slug = request.nextUrl.searchParams.get('slug');
+  if (!slug) {
+    return NextResponse.json({ error: 'slug parameter required' }, { status: 400 });
+  }
+
+  try {
+    // Fetch yacht specs
+    const result = await pool.query(`
+      SELECT ym.id, ym.slug, ym.model_name, ym.year, ym.length_overall, ym.displacement,
+             m.name as manufacturer_name
+      FROM yacht_models ym
+      JOIN manufacturers m ON ym.manufacturer_id = m.id
+      WHERE ym.slug = $1
+    `, [slug]);
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Yacht not found' }, { status: 404 });
+    }
+
+    const row = result.rows[0];
+    const candidate = {
+      id: row.id,
+      slug: row.slug,
+      modelName: row.model_name,
+      manufacturerName: row.manufacturer_name,
+      year: row.year,
+      lengthOverall: row.length_overall ? parseFloat(row.length_overall) : null,
+      displacement: row.displacement ? parseFloat(row.displacement) : null,
+      beam: null,
+      cabins: null,
+      existingPriceCount: 0,
+    };
+
+    const newEstimate = estimatePrice(candidate, 'new');
+    const usedEstimate = estimatePrice(candidate, 'used');
+
+    return NextResponse.json({
+      slug,
+      estimates: {
+        new: newEstimate ? {
+          priceMin: newEstimate.priceMin,
+          priceMax: newEstimate.priceMax,
+          currency: newEstimate.currency,
+          confidence: newEstimate.confidenceScore,
+        } : null,
+        used: usedEstimate ? {
+          priceMin: usedEstimate.priceMin,
+          priceMax: usedEstimate.priceMax,
+          currency: usedEstimate.currency,
+          confidence: usedEstimate.confidenceScore,
+        } : null,
+      },
+      disclaimer: 'Prices are estimates based on yacht specifications and market data. Actual prices may vary.',
+    });
+  } catch (error: any) {
+    console.error('Error estimating price:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/lib/price-aggregation/estimated-provider.ts
+++ b/lib/price-aggregation/estimated-provider.ts
@@ -1,0 +1,191 @@
+/**
+ * P21.4: Estimated Price Provider
+ *
+ * Generates estimated prices based on yacht specifications.
+ * Uses known market rates per length range, adjusted for age and manufacturer.
+ *
+ * This is the primary provider since external listing sites block automated access.
+ * Estimates are conservative and clearly marked with lower confidence scores.
+ */
+
+import type { PriceCandidate, PriceProviderResult, PriceCondition } from './types';
+
+// Market price reference data (EUR, based on 2024-2025 market data)
+// Key: length range (LOA in meters) → base price per meter for new yachts
+const PRICE_PER_METER: Array<{ minLen: number; maxLen: number; newMinPerM: number; newMaxPerM: number }> = [
+  { minLen: 0, maxLen: 8, newMinPerM: 8000, newMaxPerM: 14000 },      // Under 27ft
+  { minLen: 8, maxLen: 10, newMinPerM: 10000, newMaxPerM: 18000 },    // 27-33ft
+  { minLen: 10, maxLen: 12, newMinPerM: 14000, newMaxPerM: 24000 },   // 33-40ft
+  { minLen: 12, maxLen: 14, newMinPerM: 18000, newMaxPerM: 30000 },   // 40-46ft
+  { minLen: 14, maxLen: 16, newMinPerM: 24000, newMaxPerM: 38000 },   // 46-52ft
+  { minLen: 16, maxLen: 18, newMinPerM: 30000, newMaxPerM: 48000 },   // 52-59ft
+  { minLen: 18, maxLen: 30, newMinPerM: 38000, newMaxPerM: 60000 },   // 59ft+
+];
+
+// Manufacturer premium multipliers (1.0 = average)
+const MANUFACTURER_PREMIUM: Record<string, { min: number; max: number }> = {
+  // Premium brands
+  'halberg-rassy': { min: 1.6, max: 2.0 },
+  'swan': { min: 2.5, max: 3.5 },
+  'oyo': { min: 1.8, max: 2.2 },
+  'amels': { min: 3.0, max: 5.0 },
+  'contest': { min: 1.5, max: 1.8 },
+  'x-yachts': { min: 1.4, max: 1.7 },
+  'grand-soleil': { min: 1.3, max: 1.6 },
+  'dehler': { min: 1.2, max: 1.5 },
+  'elans': { min: 1.0, max: 1.2 },
+  // Mainstream brands
+  'beneteau': { min: 0.9, max: 1.1 },
+  'jeanneau': { min: 0.85, max: 1.05 },
+  'bavaria': { min: 0.75, max: 0.95 },
+  'hanse': { min: 0.8, max: 1.0 },
+  'lagoon': { min: 1.0, max: 1.3 },
+  'leopard': { min: 1.0, max: 1.2 },
+  // Value brands
+  'hunter': { min: 0.7, max: 0.9 },
+  'macgregor': { min: 0.5, max: 0.7 },
+};
+
+// Age depreciation factors (multiplier on new price)
+function getAgeDepreciation(year: number, currentYear: number = new Date().getFullYear()): number {
+  const age = currentYear - year;
+  if (age <= 0) return 1.0;  // Current year model or newer
+  if (age <= 2) return 0.85; // 1-2 years: 15% depreciation
+  if (age <= 5) return 0.70; // 3-5 years: 30% depreciation
+  if (age <= 10) return 0.55; // 6-10 years: 45% depreciation
+  if (age <= 15) return 0.40; // 11-15 years: 60% depreciation
+  if (age <= 20) return 0.30; // 16-20 years: 70% depreciation
+  return 0.20;                // 20+ years: 80% depreciation
+}
+
+// Displacement-based adjustment
+// Heavier yachts for their length tend to be more expensive (cruiser vs racer)
+function getDisplacementAdjustment(lengthM: number, displacementKg: number | null): number {
+  if (!displacementKg || displacementKg <= 0) return 1.0;
+
+  // Typical D/L ratio: heavier = higher price
+  const dlRatio = (displacementKg / 1000) / Math.pow(lengthM * 0.3048 * 3.281 / 10, 3);
+  if (dlRatio > 300) return 1.15;  // Heavy displacement cruiser
+  if (dlRatio > 200) return 1.05;  // Medium displacement
+  if (dlRatio < 100) return 0.90;  // Light/racing - slightly less expensive
+  return 1.0;
+}
+
+function getBasePricePerMeter(lengthM: number): { minPerM: number; maxPerM: number } {
+  for (const tier of PRICE_PER_METER) {
+    if (lengthM >= tier.minLen && lengthM < tier.maxLen) {
+      return { minPerM: tier.newMinPerM, maxPerM: tier.newMaxPerM };
+    }
+  }
+  // Fallback for very large yachts
+  const lastTier = PRICE_PER_METER[PRICE_PER_METER.length - 1];
+  return { minPerM: lastTier.newMinPerM, maxPerM: lastTier.newMaxPerM };
+}
+
+function getManufacturerMultiplier(manufacturerName: string): { min: number; max: number } {
+  const key = manufacturerName.toLowerCase().replace(/[^a-z0-9]/g, '-');
+  if (MANUFACTURER_PREMIUM[key]) return MANUFACTURER_PREMIUM[key];
+
+  // Check partial matches
+  for (const [k, v] of Object.entries(MANUFACTURER_PREMIUM)) {
+    if (key.includes(k) || k.includes(key)) return v;
+  }
+
+  return { min: 0.9, max: 1.1 }; // Default average
+}
+
+/**
+ * Estimate price for a yacht based on its specifications
+ */
+export function estimatePrice(
+  candidate: PriceCandidate,
+  condition: PriceCondition = 'used'
+): Omit<PriceProviderResult, 'provider' | 'fetchedAt' | 'listingCount'> | null {
+  const lengthM = candidate.lengthOverall;
+  if (!lengthM || lengthM <= 0) return null;
+
+  const currentYear = new Date().getFullYear();
+  const age = currentYear - candidate.year;
+  if (age < -5) return null; // Skip if year is unreasonably in the future
+
+  // Get base price per meter for this length
+  const { minPerM, maxPerM } = getBasePricePerMeter(lengthM);
+
+  // Calculate base new price range
+  const baseNewMin = lengthM * minPerM;
+  const baseNewMax = lengthM * maxPerM;
+
+  // Apply manufacturer premium
+  const manufMult = getManufacturerMultiplier(candidate.manufacturerName);
+  const adjustedNewMin = baseNewMin * manufMult.min;
+  const adjustedNewMax = baseNewMax * manufMult.max;
+
+  // Apply displacement adjustment
+  const dispAdj = getDisplacementAdjustment(lengthM, candidate.displacement);
+  const newMin = Math.round(adjustedNewMin * dispAdj);
+  const newMax = Math.round(adjustedNewMax * dispAdj);
+
+  if (condition === 'new') {
+    const ageFactor = age <= 0 ? 1.0 : 0.95; // Slight discount for "new old stock"
+    return {
+      yachtSlug: candidate.slug,
+      yachtModelId: candidate.id,
+      modelName: candidate.modelName,
+      manufacturerName: candidate.manufacturerName,
+      year: candidate.year,
+      priceMin: Math.round(newMin * ageFactor),
+      priceMax: Math.round(newMax * ageFactor),
+      currency: 'EUR',
+      condition: 'new',
+      sourceUrl: null,
+      confidenceScore: age <= 2 ? 45 : 30, // Lower confidence for older "new" estimates
+    };
+  }
+
+  // Used price: apply depreciation
+  const depreciation = getAgeDepreciation(candidate.year, currentYear);
+  const usedMin = Math.round(newMin * depreciation * 0.85); // 15% spread
+  const usedMax = Math.round(newMax * depreciation * 1.0);
+
+  return {
+    yachtSlug: candidate.slug,
+    yachtModelId: candidate.id,
+    modelName: candidate.modelName,
+    manufacturerName: candidate.manufacturerName,
+    year: candidate.year,
+    priceMin: usedMin,
+    priceMax: usedMax,
+    currency: 'EUR',
+    condition: 'used',
+    sourceUrl: null,
+    confidenceScore: age <= 5 ? 50 : 35, // Moderate confidence
+  };
+}
+
+/**
+ * Batch estimate prices for multiple candidates
+ */
+export function estimatePrices(candidates: PriceCandidate[]): PriceProviderResult[] {
+  const results: PriceProviderResult[] = [];
+  const now = new Date();
+
+  for (const candidate of candidates) {
+    // Generate both new and used estimates
+    for (const condition of ['new', 'used'] as PriceCondition[]) {
+      const estimate = estimatePrice(candidate, condition);
+      if (estimate) {
+        results.push({
+          ...estimate,
+          provider: 'estimated',
+          listingCount: 0,
+          fetchedAt: now,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+export const PROVIDER_NAME = 'estimated';
+export const PROVIDER_DESCRIPTION = 'Price estimation based on yacht specs (length, age, manufacturer, displacement)';

--- a/lib/price-aggregation/service.ts
+++ b/lib/price-aggregation/service.ts
@@ -1,0 +1,261 @@
+/**
+ * P21.4: Price Aggregation Service
+ *
+ * Orchestrates price data aggregation from multiple providers.
+ * Stores results in the yacht_prices table with proper attribution.
+ */
+
+import { pool } from '@/lib/db';
+import { estimatePrices, PROVIDER_NAME as ESTIMATED_PROVIDER } from './estimated-provider';
+import type {
+  PriceCandidate,
+  PriceProviderResult,
+  PriceCondition,
+  AggregationRun,
+  AggregationStatus,
+} from './types';
+
+// --- Candidate Discovery ---
+
+export async function findPriceCandidates(limit = 200): Promise<PriceCandidate[]> {
+  const result = await pool.query(`
+    SELECT
+      ym.id,
+      ym.slug,
+      ym.model_name,
+      ym.year,
+      ym.length_overall,
+      ym.displacement,
+      ym.beam,
+      ym.cabins,
+      m.name as manufacturer_name,
+      COALESCE(pc.price_count, 0) as existing_price_count
+    FROM yacht_models ym
+    JOIN manufacturers m ON ym.manufacturer_id = m.id
+    LEFT JOIN (
+      SELECT yacht_model_id, COUNT(*) as price_count
+      FROM yacht_prices
+      WHERE is_active = true
+      GROUP BY yacht_model_id
+    ) pc ON pc.yacht_model_id = ym.id
+    WHERE ym.length_overall IS NOT NULL
+      AND ym.year IS NOT NULL
+    ORDER BY
+      CASE WHEN pc.price_count IS NULL OR pc.price_count = 0 THEN 0 ELSE 1 END,
+      ym.length_overall DESC
+    LIMIT $1
+  `, [limit]);
+
+  return result.rows.map((row: any) => ({
+    id: row.id,
+    slug: row.slug,
+    modelName: row.model_name,
+    manufacturerName: row.manufacturer_name,
+    year: row.year,
+    lengthOverall: row.length_overall ? parseFloat(row.length_overall) : null,
+    displacement: row.displacement ? parseFloat(row.displacement) : null,
+    beam: row.beam ? parseFloat(row.beam) : null,
+    cabins: row.cabins,
+    existingPriceCount: parseInt(row.existing_price_count, 10),
+  }));
+}
+
+// --- Price Storage ---
+
+async function storePriceResult(result: PriceProviderResult): Promise<'created' | 'updated' | 'skipped'> {
+  // Check for existing active price from same provider for this yacht+condition
+  const existing = await pool.query(`
+    SELECT id, price_min, price_max
+    FROM yacht_prices
+    WHERE yacht_model_id = $1
+      AND condition = $2
+      AND source = $3
+      AND source_type = 'scraper'
+      AND is_active = true
+    ORDER BY effective_date DESC
+    LIMIT 1
+  `, [result.yachtModelId, result.condition, `Aggregated: ${result.provider}`]);
+
+  const sourceName = `Aggregated: ${result.provider}`;
+
+  if (existing.rows.length > 0) {
+    const existingRow = existing.rows[0];
+    const existingMin = parseFloat(existingRow.price_min);
+    const existingMax = parseFloat(existingRow.price_max);
+
+    // Update if price changed significantly (>20% difference)
+    const minChange = Math.abs(existingMin - result.priceMin) / existingMin;
+    const maxChange = Math.abs(existingMax - result.priceMax) / existingMax;
+
+    if (minChange > 0.2 || maxChange > 0.2) {
+      // Create snapshot of old price
+      await pool.query(`
+        INSERT INTO price_snapshots (yacht_model_id, price_min, price_max, currency, condition, source_type, confidence_score, snapshot_reason)
+        VALUES ($1, $2, $3, $4, $5, 'scraper', 50, 'price_update')
+      `, [result.yachtModelId, existingRow.price_min, existingRow.price_max, result.currency, result.condition]);
+
+      // Update existing price
+      await pool.query(`
+        UPDATE yacht_prices
+        SET price_min = $2, price_max = $3, confidence_score = $4, source_url = $5, updated_at = NOW()
+        WHERE id = $1
+      `, [existingRow.id, result.priceMin, result.priceMax, result.confidenceScore, result.sourceUrl]);
+
+      return 'updated';
+    }
+
+    return 'skipped';
+  }
+
+  // Create new price record
+  await pool.query(`
+    INSERT INTO yacht_prices (yacht_model_id, price_min, price_max, currency, condition, year, source, source_type, source_url, confidence_score, notes, effective_date, is_active)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, 'scraper', $8, $9, $10, NOW(), true)
+  `, [
+    result.yachtModelId,
+    result.priceMin,
+    result.priceMax,
+    result.currency,
+    result.condition,
+    result.year,
+    sourceName,
+    result.sourceUrl,
+    result.confidenceScore,
+    `Auto-estimated from specs. Provider: ${result.provider}`,
+  ]);
+
+  return 'created';
+}
+
+// --- Aggregation Pipeline ---
+
+export async function runAggregationPipeline(options: {
+  provider?: string;
+  dryRun?: boolean;
+  limit?: number;
+  overwrite?: boolean;
+}): Promise<AggregationRun> {
+  const runId = `agg-${Date.now()}`;
+  const run: AggregationRun = {
+    id: runId,
+    startedAt: new Date(),
+    completedAt: null,
+    status: 'running',
+    provider: options.provider || 'all',
+    candidatesTotal: 0,
+    resultsFound: 0,
+    pricesCreated: 0,
+    pricesUpdated: 0,
+    errors: [],
+  };
+
+  try {
+    // Find candidates (prioritize yachts without prices)
+    const candidates = await findPriceCandidates(options.limit || 200);
+    run.candidatesTotal = candidates.length;
+
+    if (candidates.length === 0) {
+      run.status = 'completed';
+      run.completedAt = new Date();
+      return run;
+    }
+
+    // Run providers
+    let allResults: PriceProviderResult[] = [];
+
+    if (!options.provider || options.provider === ESTIMATED_PROVIDER) {
+      allResults = estimatePrices(candidates);
+    }
+
+    run.resultsFound = allResults.length;
+
+    if (options.dryRun) {
+      run.status = 'completed';
+      run.completedAt = new Date();
+      return run;
+    }
+
+    // Store results
+    for (const result of allResults) {
+      try {
+        const action = await storePriceResult(result);
+        if (action === 'created') run.pricesCreated++;
+        else if (action === 'updated') run.pricesUpdated++;
+      } catch (err: any) {
+        run.errors.push(`Failed to store price for ${result.yachtSlug}: ${err.message}`);
+      }
+    }
+
+    run.status = 'completed';
+  } catch (err: any) {
+    run.status = 'failed';
+    run.errors.push(`Pipeline error: ${err.message}`);
+  }
+
+  run.completedAt = new Date();
+  return run;
+}
+
+// --- Status ---
+
+export async function getAggregationStatus(): Promise<AggregationStatus> {
+  const [totalYachts, yachtsWithPrices, byCondition, byCurrency, byProvider] = await Promise.all([
+    pool.query(`SELECT COUNT(*) as count FROM yacht_models WHERE length_overall IS NOT NULL`),
+    pool.query(`
+      SELECT COUNT(DISTINCT yp.yacht_model_id) as count
+      FROM yacht_prices yp
+      JOIN yacht_models ym ON yp.yacht_model_id = ym.id
+      WHERE yp.is_active = true
+    `),
+    pool.query(`
+      SELECT condition, COUNT(*) as count
+      FROM yacht_prices
+      WHERE is_active = true
+      GROUP BY condition
+    `),
+    pool.query(`
+      SELECT currency, COUNT(*) as count
+      FROM yacht_prices
+      WHERE is_active = true
+      GROUP BY currency
+    `),
+    pool.query(`
+      SELECT source, COUNT(*) as count
+      FROM yacht_prices
+      WHERE is_active = true
+      GROUP BY source
+    `),
+  ]);
+
+  const total = parseInt(totalYachts.rows[0]?.count || '0', 10);
+  const withPrices = parseInt(yachtsWithPrices.rows[0]?.count || '0', 10);
+
+  return {
+    totalYachts: total,
+    yachtsWithPrices: withPrices,
+    yachtsWithoutPrices: total - withPrices,
+    coveragePercent: total > 0 ? Math.round((withPrices / total) * 100) : 0,
+    byCondition: Object.fromEntries(
+      byCondition.rows.map((r: any) => [r.condition, parseInt(r.count, 10)])
+    ) as Record<PriceCondition, number>,
+    byCurrency: Object.fromEntries(
+      byCurrency.rows.map((r: any) => [r.currency, parseInt(r.count, 10)])
+    ),
+    byProvider: Object.fromEntries(
+      byProvider.rows.map((r: any) => [r.source, parseInt(r.count, 10)])
+    ),
+    recentRuns: [], // In-memory for now; could persist to DB later
+  };
+}
+
+// --- Price display helpers ---
+
+export function formatPriceRange(min: number, max: number, currency: string = 'EUR'): string {
+  const fmt = (n: number) => {
+    if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+    if (n >= 1000) return `${Math.round(n / 1000)}K`;
+    return n.toString();
+  };
+  const symbol = currency === 'EUR' ? '€' : currency === 'USD' ? '$' : currency;
+  return `${symbol}${fmt(min)} – ${fmt(max)}`;
+}

--- a/lib/price-aggregation/types.ts
+++ b/lib/price-aggregation/types.ts
@@ -1,0 +1,68 @@
+/**
+ * P21.4: Price Aggregation Types
+ *
+ * Types for the price data aggregation pipeline.
+ */
+
+export type PriceCondition = 'new' | 'used' | 'broker';
+
+export interface PriceProviderResult {
+  provider: string;
+  yachtSlug: string;
+  yachtModelId: number;
+  modelName: string;
+  manufacturerName: string;
+  year: number;
+  priceMin: number;
+  priceMax: number;
+  currency: string;
+  condition: PriceCondition;
+  sourceUrl: string | null;
+  confidenceScore: number;
+  listingCount: number;
+  fetchedAt: Date;
+}
+
+export interface PriceProvider {
+  name: string;
+  description: string;
+  isAvailable(): Promise<boolean>;
+  fetchPrices(candidates: PriceCandidate[]): Promise<PriceProviderResult[]>;
+}
+
+export interface PriceCandidate {
+  id: number;
+  slug: string;
+  modelName: string;
+  manufacturerName: string;
+  year: number;
+  lengthOverall: number | null;
+  displacement: number | null;
+  beam: number | null;
+  cabins: number | null;
+  existingPriceCount: number;
+}
+
+export interface AggregationRun {
+  id: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  status: 'running' | 'completed' | 'failed';
+  provider: string;
+  candidatesTotal: number;
+  resultsFound: number;
+  pricesCreated: number;
+  pricesUpdated: number;
+  errors: string[];
+}
+
+export interface AggregationStatus {
+  totalYachts: number;
+  yachtsWithPrices: number;
+  yachtsWithoutPrices: number;
+  coveragePercent: number;
+  byCondition: Record<PriceCondition, number>;
+  byCurrency: Record<string, number>;
+  byProvider: Record<string, number>;
+  recentRuns: AggregationRun[];
+}

--- a/tests/price-aggregation.test.ts
+++ b/tests/price-aggregation.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for P21.4: Price Aggregation Pipeline
+ */
+import { describe, it, expect } from 'vitest';
+import { estimatePrice, estimatePrices } from '../lib/price-aggregation/estimated-provider';
+import type { PriceCandidate } from '../lib/price-aggregation/types';
+
+// --- Test fixtures ---
+
+const makeCandidate = (overrides: Partial<PriceCandidate> = {}): PriceCandidate => ({
+  id: 1,
+  slug: 'beneteau-oceanis-40-1',
+  modelName: 'Oceanis 40.1',
+  manufacturerName: 'Beneteau',
+  year: 2022,
+  lengthOverall: 12.43,
+  displacement: 6400,
+  beam: null,
+  cabins: 3,
+  existingPriceCount: 0,
+  ...overrides,
+});
+
+// --- Estimated Price Provider Tests ---
+
+describe('estimatePrice', () => {
+  it('should estimate new price for a standard yacht', () => {
+    const candidate = makeCandidate();
+    const result = estimatePrice(candidate, 'new');
+
+    expect(result).not.toBeNull();
+    expect(result!.priceMin).toBeGreaterThan(0);
+    expect(result!.priceMax).toBeGreaterThan(result!.priceMin);
+    expect(result!.currency).toBe('EUR');
+    expect(result!.condition).toBe('new');
+    expect(result!.confidenceScore).toBeGreaterThan(0);
+    expect(result!.confidenceScore).toBeLessThanOrEqual(50);
+  });
+
+  it('should estimate used price for a standard yacht', () => {
+    const candidate = makeCandidate();
+    const result = estimatePrice(candidate, 'used');
+
+    expect(result).not.toBeNull();
+    expect(result!.condition).toBe('used');
+    // Used price should be lower than new
+    const newResult = estimatePrice(candidate, 'new');
+    expect(result!.priceMax).toBeLessThan(newResult!.priceMax);
+  });
+
+  it('should return null for yachts without length', () => {
+    const candidate = makeCandidate({ lengthOverall: null });
+    const result = estimatePrice(candidate, 'used');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for yachts with zero length', () => {
+    const candidate = makeCandidate({ lengthOverall: 0 });
+    const result = estimatePrice(candidate, 'used');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for yachts with unreasonable future year', () => {
+    const candidate = makeCandidate({ year: 2040 });
+    const result = estimatePrice(candidate, 'used');
+    expect(result).toBeNull();
+  });
+
+  it('should estimate higher prices for premium manufacturers', () => {
+    const standardCandidate = makeCandidate({ manufacturerName: 'Bavaria' });
+    const premiumCandidate = makeCandidate({
+      manufacturerName: 'Halberg-Rassy',
+      slug: 'halberg-rassy-40c',
+      modelName: 'HR 40C',
+    });
+
+    const standardResult = estimatePrice(standardCandidate, 'new');
+    const premiumResult = estimatePrice(premiumCandidate, 'new');
+
+    expect(premiumResult!.priceMin).toBeGreaterThan(standardResult!.priceMin);
+    expect(premiumResult!.priceMax).toBeGreaterThan(standardResult!.priceMax);
+  });
+
+  it('should apply age depreciation for older yachts', () => {
+    const newCandidate = makeCandidate({ year: 2025 });
+    const oldCandidate = makeCandidate({ year: 2010 });
+
+    const newResult = estimatePrice(newCandidate, 'used');
+    const oldResult = estimatePrice(oldCandidate, 'used');
+
+    expect(oldResult!.priceMax).toBeLessThan(newResult!.priceMax);
+  });
+
+  it('should give higher used estimates for newer yachts', () => {
+    const currentCandidate = makeCandidate({ year: 2024 });
+    const oldCandidate = makeCandidate({ year: 2005 });
+
+    const currentResult = estimatePrice(currentCandidate, 'used');
+    const oldResult = estimatePrice(oldCandidate, 'used');
+
+    expect(currentResult!.confidenceScore).toBeGreaterThan(oldResult!.confidenceScore);
+  });
+
+  it('should handle very large yachts', () => {
+    const candidate = makeCandidate({
+      lengthOverall: 20,
+      displacement: 25000,
+      manufacturerName: 'Oyster',
+      modelName: '625',
+      slug: 'oyster-625',
+    });
+    const result = estimatePrice(candidate, 'new');
+
+    expect(result).not.toBeNull();
+    expect(result!.priceMin).toBeGreaterThan(100000);
+  });
+
+  it('should handle small yachts', () => {
+    const candidate = makeCandidate({
+      lengthOverall: 7,
+      displacement: 1500,
+      manufacturerName: 'Hunter',
+      modelName: '23',
+      slug: 'hunter-23',
+    });
+    const result = estimatePrice(candidate, 'new');
+
+    expect(result).not.toBeNull();
+    expect(result!.priceMin).toBeGreaterThan(0);
+    expect(result!.priceMax).toBeLessThan(500000);
+  });
+
+  it('should handle yachts without displacement data', () => {
+    const candidate = makeCandidate({ displacement: null });
+    const result = estimatePrice(candidate, 'new');
+
+    expect(result).not.toBeNull();
+    // Should use neutral adjustment factor
+    expect(result!.priceMin).toBeGreaterThan(0);
+  });
+
+  it('should work with all manufacturers including unknown ones', () => {
+    const candidate = makeCandidate({ manufacturerName: 'Unknown Brand XYZ' });
+    const result = estimatePrice(candidate, 'new');
+
+    expect(result).not.toBeNull();
+    expect(result!.priceMin).toBeGreaterThan(0);
+  });
+});
+
+describe('estimatePrices', () => {
+  it('should generate both new and used estimates for each candidate', () => {
+    const candidates = [
+      makeCandidate({ id: 1 }),
+      makeCandidate({ id: 2, modelName: 'Oceanis 35.1', lengthOverall: 10.45 }),
+    ];
+
+    const results = estimatePrices(candidates);
+
+    // 2 candidates × 2 conditions = 4 results
+    expect(results).toHaveLength(4);
+    expect(results.filter(r => r.condition === 'new')).toHaveLength(2);
+    expect(results.filter(r => r.condition === 'used')).toHaveLength(2);
+  });
+
+  it('should skip candidates without length', () => {
+    const candidates = [
+      makeCandidate({ id: 1, lengthOverall: null }),
+      makeCandidate({ id: 2 }),
+    ];
+
+    const results = estimatePrices(candidates);
+
+    // Only candidate 2 should produce results (2 estimates: new + used)
+    expect(results).toHaveLength(2);
+    expect(results.every(r => r.yachtModelId === 2)).toBe(true);
+  });
+
+  it('should set provider to estimated', () => {
+    const results = estimatePrices([makeCandidate()]);
+    expect(results.every(r => r.provider === 'estimated')).toBe(true);
+  });
+
+  it('should set listingCount to 0 for estimates', () => {
+    const results = estimatePrices([makeCandidate()]);
+    expect(results.every(r => r.listingCount === 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## P21.4: Price Data Aggregation (Closes #371)

### What
- **Price estimation engine** based on yacht specs (length, displacement, age, manufacturer)
- Market rate tables per length range with manufacturer premium multipliers
- Age depreciation factors for new/used price estimation
- **Batch aggregation service** with dry-run support, dedup, and price snapshotting
- **Admin API**: `GET/POST /api/admin/prices/aggregate` (status + trigger)
- **Public API**: `GET /api/prices/estimate?slug=<slug>` (per-yacht estimates)
- **Admin dashboard** at `/admin/prices/aggregate` with coverage stats, condition breakdown, and run controls
- Added 🔄 Aggregation link on price management page

### Architecture
- Provider pattern (`PriceProvider` interface) extensible for future data sources (YachtWorld API, boats.com API when auth is available)
- `estimated-provider.ts`: spec-based estimation (primary provider)
- `service.ts`: orchestration, storage, dedup
- Conservative confidence scores (30-50) since these are estimates

### Tests
- 16 unit tests: new/used estimates, manufacturer premiums, age depreciation, edge cases (null length, future year), batch processing
- All existing tests pass (3 pre-existing failures unrelated)

### Why Estimated Prices?
External listing sites (YachtWorld, boats.com) require authentication/API keys for data access. The estimation engine provides immediate value with spec-based pricing. When API access is obtained, additional providers can be plugged in.