### PR TITLE
feat: P20.1 Auto-generated yacht descriptions with admin review queue

### DIFF
--- a/app/admin/descriptions/DescriptionAdminClient.tsx
+++ b/app/admin/descriptions/DescriptionAdminClient.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface DescriptionStats {
+  total: number;
+  withDescription: number;
+  missing: number;
+  generated: number;
+  pending: number;
+  approved: number;
+  rejected: number;
+  manual: number;
+}
+
+interface PendingDescription {
+  id: number;
+  modelName: string;
+  slug: string | null;
+  description: string | null;
+  descriptionSource: string | null;
+  descriptionStatus: string | null;
+  descriptionGeneratedAt: string | null;
+  manufacturerName: string | null;
+}
+
+interface GenerationResult {
+  totalCandidates: number;
+  generated: number;
+  skipped: number;
+  errors: number;
+}
+
+export default function DescriptionAdminClient() {
+  const [stats, setStats] = useState<DescriptionStats | null>(null);
+  const [pending, setPending] = useState<PendingDescription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/descriptions");
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const fetchPending = useCallback(async () => {
+    try {
+      const res = await fetch(
+        "/api/admin/descriptions?action=pending&limit=50"
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setPending(data.pending || []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    Promise.all([fetchStats(), fetchPending()]).finally(() =>
+      setLoading(false)
+    );
+  }, [fetchStats, fetchPending]);
+
+  const handleGenerate = async (dryRun: boolean) => {
+    setGenerating(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/admin/descriptions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "generate",
+          limit: 50,
+          dryRun,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        const result = data as GenerationResult;
+        setMessage({
+          type: "success",
+          text: dryRun
+            ? `Dry run: ${result.generated} descriptions would be generated, ${result.skipped} skipped`
+            : `Generated ${result.generated} descriptions (${result.skipped} skipped). They are pending review.`,
+        });
+        fetchStats();
+        fetchPending();
+      } else {
+        setMessage({ type: "error", text: data.error || "Generation failed" });
+      }
+    } catch {
+      setMessage({ type: "error", text: "Network error" });
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleApprove = async (yachtId: number) => {
+    try {
+      const res = await fetch("/api/admin/descriptions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "approve", yachtId }),
+      });
+      if (res.ok) {
+        setPending((prev) => prev.filter((p) => p.id !== yachtId));
+        fetchStats();
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleReject = async (yachtId: number) => {
+    try {
+      const res = await fetch("/api/admin/descriptions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "reject", yachtId }),
+      });
+      if (res.ok) {
+        setPending((prev) => prev.filter((p) => p.id !== yachtId));
+        fetchStats();
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleApproveAll = async () => {
+    if (!confirm("Approve all pending descriptions?")) return;
+    try {
+      const res = await fetch("/api/admin/descriptions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "approve-all" }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setMessage({
+          type: "success",
+          text: `Approved ${data.approved} descriptions`,
+        });
+        fetchStats();
+        fetchPending();
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) {
+    return <div className="text-gray-500">Loading...</div>;
+  }
+
+  if (!stats) {
+    return <div className="text-red-500">Failed to load stats</div>;
+  }
+
+  const coveragePct =
+    stats.total > 0
+      ? ((stats.withDescription / stats.total) * 100).toFixed(1)
+      : "0";
+
+  return (
+    <div className="space-y-6">
+      {message && (
+        <div
+          className={`p-4 rounded-md ${message.type === "success" ? "bg-green-50 text-green-800" : "bg-red-50 text-red-800"}`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-white p-4 rounded-lg shadow-sm border">
+          <p className="text-sm text-gray-500">Total Yachts</p>
+          <p className="text-2xl font-bold">{stats.total}</p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow-sm border">
+          <p className="text-sm text-gray-500">Coverage</p>
+          <p className="text-2xl font-bold">{coveragePct}%</p>
+          <p className="text-xs text-gray-400">
+            {stats.withDescription} of {stats.total}
+          </p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow-sm border">
+          <p className="text-sm text-gray-500">Missing</p>
+          <p className="text-2xl font-bold text-orange-600">
+            {stats.missing}
+          </p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow-sm border">
+          <p className="text-sm text-gray-500">Pending Review</p>
+          <p className="text-2xl font-bold text-blue-600">{stats.pending}</p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border">
+        <h2 className="text-lg font-semibold mb-4">Generate Descriptions</h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Auto-generate descriptions from yacht spec data for yachts missing
+          descriptions. Generated descriptions go into a pending review queue.
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={() => handleGenerate(true)}
+            disabled={generating || stats.missing === 0}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {generating ? "Running..." : "Dry Run (Preview)"}
+          </button>
+          <button
+            onClick={() => handleGenerate(false)}
+            disabled={generating || stats.missing === 0}
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {generating ? "Generating..." : "Generate & Queue for Review"}
+          </button>
+        </div>
+      </div>
+
+      {/* Pending Review Queue */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">
+            Pending Review ({pending.length})
+          </h2>
+          {pending.length > 0 && (
+            <button
+              onClick={handleApproveAll}
+              className="px-3 py-1 bg-green-600 text-white text-sm rounded-md hover:bg-green-700"
+            >
+              Approve All
+            </button>
+          )}
+        </div>
+
+        {pending.length === 0 ? (
+          <p className="text-gray-500 text-sm">
+            No pending descriptions. Generate new ones or all have been
+            reviewed.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {pending.map((item) => (
+              <div
+                key={item.id}
+                className="border rounded-lg p-4 hover:bg-gray-50"
+              >
+                <div className="flex justify-between items-start mb-2">
+                  <div>
+                    <h3 className="font-medium text-gray-900">
+                      {item.manufacturerName} {item.modelName}
+                    </h3>
+                    {item.slug && (
+                      <a
+                        href={`/yachts/${item.slug}`}
+                        className="text-xs text-blue-600 hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        View yacht page →
+                      </a>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleApprove(item.id)}
+                      className="px-3 py-1 bg-green-100 text-green-800 text-sm rounded-md hover:bg-green-200"
+                    >
+                      ✓ Approve
+                    </button>
+                    <button
+                      onClick={() => handleReject(item.id)}
+                      className="px-3 py-1 bg-red-100 text-red-800 text-sm rounded-md hover:bg-red-200"
+                    >
+                      ✗ Reject
+                    </button>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  {item.description}
+                </p>
+                {item.descriptionGeneratedAt && (
+                  <p className="text-xs text-gray-400 mt-2">
+                    Generated{" "}
+                    {new Date(item.descriptionGeneratedAt).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/descriptions/page.tsx
+++ b/app/admin/descriptions/page.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from "react";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import Link from "next/link";
+import DescriptionAdminClient from "./DescriptionAdminClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function DescriptionsAdminPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || session.user.role !== "admin") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">Unauthorized. Please log in.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center gap-4 mb-8">
+          <Link
+            href="/admin"
+            className="text-blue-600 hover:text-blue-800 text-sm"
+          >
+            ← Back to Admin
+          </Link>
+        </div>
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">
+            Auto-Generated Descriptions
+          </h1>
+          <span className="text-sm text-gray-500">P20.1</span>
+        </div>
+        <Suspense fallback={<div>Loading...</div>}>
+          <DescriptionAdminClient />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -146,6 +146,16 @@ export default async function AdminPage() {
                 View Vitals Dashboard
               </a>
             </div>
+            <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Auto Descriptions</h2>
+              <p className="text-gray-600 mb-4">Generate and review auto-generated yacht descriptions from spec data.</p>
+              <a
+                href="/admin/descriptions"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                Manage Descriptions
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/api/admin/descriptions/route.ts
+++ b/app/api/admin/descriptions/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getDescriptionStats,
+  findAndGenerateDescriptions,
+  getPendingDescriptions,
+  approveDescription,
+  rejectDescription,
+  approveAllPending,
+} from "@/lib/description-service";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/admin/descriptions — stats + pending list
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const action = url.searchParams.get("action");
+
+    if (action === "pending") {
+      const limit = parseInt(url.searchParams.get("limit") || "50");
+      const offset = parseInt(url.searchParams.get("offset") || "0");
+      const pending = await getPendingDescriptions(limit, offset);
+      return NextResponse.json({ pending });
+    }
+
+    // Default: return stats
+    const stats = await getDescriptionStats();
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error("Error fetching description stats:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch stats" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/admin/descriptions — generate, approve, reject
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const { action } = body;
+
+    switch (action) {
+      case "generate": {
+        const limit = body.limit || 50;
+        const dryRun = body.dryRun !== false;
+        const result = await findAndGenerateDescriptions(limit, dryRun);
+        return NextResponse.json(result);
+      }
+
+      case "approve": {
+        const { yachtId, editedDescription } = body;
+        if (!yachtId) {
+          return NextResponse.json(
+            { error: "yachtId required" },
+            { status: 400 }
+          );
+        }
+        await approveDescription(yachtId, editedDescription);
+        return NextResponse.json({ success: true });
+      }
+
+      case "reject": {
+        const { yachtId } = body;
+        if (!yachtId) {
+          return NextResponse.json(
+            { error: "yachtId required" },
+            { status: 400 }
+          );
+        }
+        await rejectDescription(yachtId);
+        return NextResponse.json({ success: true });
+      }
+
+      case "approve-all": {
+        const result = await approveAllPending();
+        return NextResponse.json({
+          success: true,
+          approved: (result as any).rowCount || 0,
+        });
+      }
+
+      default:
+        return NextResponse.json(
+          { error: "Unknown action" },
+          { status: 400 }
+        );
+    }
+  } catch (error) {
+    console.error("Error in description action:", error);
+    return NextResponse.json(
+      { error: "Operation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -78,6 +78,9 @@ export const yachtModels = pgTable(
     // Metadata
     designNotes: text("design_notes"),
     description: text("description"),
+    descriptionSource: varchar("description_source", { length: 20 }).default("manual"),
+    descriptionStatus: varchar("description_status", { length: 20 }).default("approved"),
+    descriptionGeneratedAt: timestamp("description_generated_at", { withTimezone: true }),
     sourceUrl: varchar("source_url", { length: 500 }),
     sourceAttribution: text("source_attribution"),
     adminLinks:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -218,7 +218,7 @@ export async function ensureSchema() {
     const requiredColumns = [
       'slug', 'source_url', 'source_attribution', 'admin_links',
       'created_at', 'updated_at',
-      'data_source', 'source_confidence', 'last_verified_at', 'completeness_score'
+      'data_source', 'source_confidence', 'last_verified_at', 'completeness_score', 'description_source', 'description_status', 'description_generated_at'
     ];
 
     const missing = requiredColumns.filter(col => !existingColumns.has(col));
@@ -256,6 +256,15 @@ export async function ensureSchema() {
             break;
           case 'completeness_score':
             sql = 'ALTER TABLE yacht_models ADD COLUMN IF NOT EXISTS completeness_score INTEGER';
+            break;
+          case 'description_source':
+            sql = "ALTER TABLE yacht_models ADD COLUMN IF NOT EXISTS description_source VARCHAR(20) DEFAULT 'manual'";
+            break;
+          case 'description_status':
+            sql = "ALTER TABLE yacht_models ADD COLUMN IF NOT EXISTS description_status VARCHAR(20) DEFAULT 'approved'";
+            break;
+          case 'description_generated_at':
+            sql = 'ALTER TABLE yacht_models ADD COLUMN IF NOT EXISTS description_generated_at TIMESTAMPTZ';
             break;
         }
         if (sql) {

--- a/lib/description-service.ts
+++ b/lib/description-service.ts
@@ -1,0 +1,261 @@
+/**
+ * P20.1 — Description Generation Service
+ *
+ * Server-side service for batch-generating yacht descriptions from spec data.
+ * Stores results in the database with review status for admin approval.
+ */
+
+import { db } from "./db";
+import { yachtModels, manufacturers } from "../drizzle/schema";
+import { eq, or, sql as drizzleSql } from "drizzle-orm";
+import {
+  generateDescription,
+  scoreDescription,
+  type YachtSpecsForDescription,
+} from "./description-templates";
+
+export interface DescriptionCandidate {
+  yachtId: number;
+  modelName: string;
+  slug: string | null;
+  manufacturerName: string;
+  currentDescription: string | null;
+  generatedDescription: string;
+  descriptionScore: number;
+}
+
+export interface GenerationResult {
+  totalCandidates: number;
+  generated: number;
+  skipped: number;
+  errors: number;
+  candidates: DescriptionCandidate[];
+}
+
+export interface DescriptionStats {
+  total: number;
+  withDescription: number;
+  missing: number;
+  generated: number;
+  pending: number;
+  approved: number;
+  rejected: number;
+  manual: number;
+}
+
+/**
+ * Get description coverage stats.
+ */
+export async function getDescriptionStats(): Promise<DescriptionStats> {
+  const total = await db.select({ count: drizzleSql<number>`count(*)` }).from(yachtModels);
+  const withDesc = await db
+    .select({ count: drizzleSql<number>`count(*)` })
+    .from(yachtModels)
+    .where(drizzleSql`description IS NOT NULL AND length(description) > 50`);
+  const missing = await db
+    .select({ count: drizzleSql<number>`count(*)` })
+    .from(yachtModels)
+    .where(drizzleSql`description IS NULL OR length(COALESCE(description, '')) <= 50`);
+
+  const pending = await db
+    .select({ count: drizzleSql<number>`count(*)` })
+    .from(yachtModels)
+    .where(drizzleSql`COALESCE(description_status, 'approved') = 'pending'`);
+
+  const generated = await db
+    .select({ count: drizzleSql<number>`count(*)` })
+    .from(yachtModels)
+    .where(drizzleSql`COALESCE(description_source, 'manual') = 'generated'`);
+
+  const rejected = await db
+    .select({ count: drizzleSql<number>`count(*)` })
+    .from(yachtModels)
+    .where(drizzleSql`COALESCE(description_status, 'approved') = 'rejected'`);
+
+  return {
+    total: Number(total[0].count),
+    withDescription: Number(withDesc[0].count),
+    missing: Number(missing[0].count),
+    generated: Number(generated[0].count),
+    pending: Number(pending[0].count),
+    approved: Number(total[0].count) - Number(missing[0].count),
+    rejected: Number(rejected[0].count),
+    manual: Number(withDesc[0].count) - Number(generated[0].count),
+  };
+}
+
+/**
+ * Find yachts that need descriptions and generate them.
+ */
+export async function findAndGenerateDescriptions(
+  limit: number = 50,
+  dryRun: boolean = true
+): Promise<GenerationResult> {
+  // Find yachts missing descriptions
+  const candidates = await db
+    .select()
+    .from(yachtModels)
+    .where(drizzleSql`description IS NULL OR length(COALESCE(description, '')) <= 50`)
+    .limit(limit);
+
+  // Get all manufacturer IDs
+  const manufacturerIds = [...new Set(candidates.map((c: any) => c.manufacturerId))];
+
+  let manufacturerRows: any[] = [];
+  if (manufacturerIds.length > 0) {
+    manufacturerRows = await db
+      .select({ id: manufacturers.id, name: manufacturers.name })
+      .from(manufacturers)
+      .where(drizzleSql`${manufacturers.id} = ANY(ARRAY[${drizzleSql.join(manufacturerIds.map((id: unknown) => drizzleSql`${Number(id)}`), drizzleSql`, `)}])`);
+  }
+
+  const manufacturerMap = new Map(
+    manufacturerRows.map((m: any) => [m.id, m.name])
+  );
+
+  const results: DescriptionCandidate[] = [];
+  let generated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const yacht of candidates) {
+    const y = yacht as any;
+    const manufacturerName = manufacturerMap.get(y.manufacturerId) || "Unknown";
+
+    const specs: YachtSpecsForDescription = {
+      manufacturer: manufacturerName,
+      modelName: y.modelName,
+      year: y.year,
+      lengthOverall: y.lengthOverall,
+      beam: y.beam,
+      draft: y.draft,
+      displacement: y.displacement,
+      ballast: y.ballast,
+      sailAreaMain: y.sailAreaMain,
+      rigType: y.rigType,
+      keelType: y.keelType,
+      hullMaterial: y.hullMaterial,
+      cabins: y.cabins,
+      berths: y.berths,
+      heads: y.heads,
+      maxOccupancy: y.maxOccupancy,
+      engineHp: y.engineHp,
+      engineType: y.engineType,
+      fuelCapacity: y.fuelCapacity,
+      waterCapacity: y.waterCapacity,
+      designNotes: y.designNotes,
+    };
+
+    try {
+      const generatedDesc = generateDescription(specs, "balanced");
+
+      if (!generatedDesc || generatedDesc.trim().length < 50) {
+        skipped++;
+        continue;
+      }
+
+      const candidate: DescriptionCandidate = {
+        yachtId: y.id,
+        modelName: y.modelName,
+        slug: y.slug,
+        manufacturerName,
+        currentDescription: y.description,
+        generatedDescription: generatedDesc,
+        descriptionScore: scoreDescription(generatedDesc),
+      };
+
+      if (!dryRun) {
+        await db
+          .update(yachtModels)
+          .set({
+            description: generatedDesc,
+            descriptionSource: "generated",
+            descriptionStatus: "pending",
+            descriptionGeneratedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(yachtModels.id, y.id));
+      }
+
+      results.push(candidate);
+      generated++;
+    } catch (err) {
+      console.error(`Error generating description for yacht ${y.id}:`, err);
+      errors++;
+    }
+  }
+
+  return {
+    totalCandidates: candidates.length,
+    generated,
+    skipped,
+    errors,
+    candidates: results,
+  };
+}
+
+/**
+ * Get pending descriptions for admin review.
+ */
+export async function getPendingDescriptions(limit: number = 50, offset: number = 0) {
+  return db
+    .select({
+      id: yachtModels.id,
+      modelName: yachtModels.modelName,
+      slug: yachtModels.slug,
+      description: yachtModels.description,
+      descriptionSource: yachtModels.descriptionSource,
+      descriptionStatus: yachtModels.descriptionStatus,
+      descriptionGeneratedAt: yachtModels.descriptionGeneratedAt,
+      manufacturerName: manufacturers.name,
+    })
+    .from(yachtModels)
+    .leftJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(eq(yachtModels.descriptionStatus, "pending"))
+    .orderBy(yachtModels.descriptionGeneratedAt)
+    .limit(limit)
+    .offset(offset);
+}
+
+/**
+ * Approve a generated description.
+ */
+export async function approveDescription(yachtId: number, editedDescription?: string) {
+  const updates: Record<string, unknown> = {
+    descriptionStatus: "approved",
+    updatedAt: new Date(),
+  };
+  if (editedDescription) {
+    updates.description = editedDescription;
+  }
+  return db
+    .update(yachtModels)
+    .set(updates)
+    .where(eq(yachtModels.id, yachtId));
+}
+
+/**
+ * Reject a generated description.
+ */
+export async function rejectDescription(yachtId: number) {
+  return db
+    .update(yachtModels)
+    .set({
+      descriptionStatus: "rejected",
+      updatedAt: new Date(),
+    })
+    .where(eq(yachtModels.id, yachtId));
+}
+
+/**
+ * Batch approve all pending descriptions.
+ */
+export async function approveAllPending() {
+  return db
+    .update(yachtModels)
+    .set({
+      descriptionStatus: "approved",
+      updatedAt: new Date(),
+    })
+    .where(eq(yachtModels.descriptionStatus, "pending"));
+}

--- a/tests/description-templates.test.ts
+++ b/tests/description-templates.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateDescription,
+  generateAllStyles,
+  needsGeneratedDescription,
+  scoreDescription,
+  type YachtSpecsForDescription,
+} from "@/lib/description-templates";
+
+const baseSpecs: YachtSpecsForDescription = {
+  manufacturer: "Beneteau",
+  modelName: "Oceanis 40.1",
+  year: 2020,
+  lengthOverall: 12.43,
+  beam: 3.99,
+  draft: 2.09,
+  displacement: 8500,
+  ballast: 2100,
+  sailAreaMain: 73.5,
+  rigType: "Sloop",
+  keelType: "Fin",
+  hullMaterial: "GRP",
+  cabins: 3,
+  berths: 6,
+  heads: 1,
+  maxOccupancy: 8,
+  engineHp: 45,
+  engineType: "Yanmar diesel",
+  fuelCapacity: 200,
+  waterCapacity: 200,
+  designNotes: null,
+};
+
+describe("Description Templates", () => {
+  describe("generateDescription", () => {
+    it("generates a balanced description from full specs", () => {
+      const desc = generateDescription(baseSpecs);
+      expect(desc).toBeTruthy();
+      expect(desc.length).toBeGreaterThan(50);
+      expect(desc).toContain("Beneteau");
+      expect(desc).toContain("Oceanis 40.1");
+      expect(desc).toContain("2020");
+    });
+
+    it("generates a technical description", () => {
+      const desc = generateDescription(baseSpecs, "technical");
+      expect(desc).toBeTruthy();
+      expect(desc).toContain("12.4m");
+    });
+
+    it("generates a marketing description", () => {
+      const desc = generateDescription(baseSpecs, "marketing");
+      expect(desc).toBeTruthy();
+      expect(desc).toContain("Beneteau");
+    });
+
+    it("handles minimal specs gracefully", () => {
+      const minimal: YachtSpecsForDescription = {
+        manufacturer: "Test",
+        modelName: "Boat",
+        year: 2023,
+        lengthOverall: null,
+        beam: null,
+        draft: null,
+        displacement: null,
+        ballast: null,
+        sailAreaMain: null,
+        rigType: null,
+        keelType: null,
+        hullMaterial: null,
+        cabins: null,
+        berths: null,
+        heads: null,
+        maxOccupancy: null,
+        engineHp: null,
+        engineType: null,
+        fuelCapacity: null,
+        waterCapacity: null,
+        designNotes: null,
+      };
+      const desc = generateDescription(minimal);
+      expect(desc).toBeTruthy();
+      expect(desc).toContain("Test Boat");
+    });
+
+    it("includes design notes when present", () => {
+      const specs = {
+        ...baseSpecs,
+        designNotes: "Designed by Marc Lombard for performance cruising.",
+      };
+      const desc = generateDescription(specs);
+      expect(desc).toContain("Marc Lombard");
+    });
+
+    it("respects maxSentences parameter", () => {
+      const desc = generateDescription(baseSpecs, "balanced", 2);
+      // Should have at most 2 sentences (intro + 1 more)
+      const sentences = desc.split(/\.\s+/).filter((s) => s.length > 0)
+      expect(sentences.length).toBeLessThanOrEqual(3); // Allow for trailing period
+    });
+  });
+
+  describe("generateAllStyles", () => {
+    it("generates all three style variants", () => {
+      const styles = generateAllStyles(baseSpecs);
+      expect(styles.technical).toBeTruthy();
+      expect(styles.marketing).toBeTruthy();
+      expect(styles.balanced).toBeTruthy();
+      expect(styles.technical).not.toBe(styles.marketing);
+    });
+  });
+
+  describe("needsGeneratedDescription", () => {
+    it("returns true for null description", () => {
+      expect(needsGeneratedDescription(null)).toBe(true);
+    });
+
+    it("returns true for empty description", () => {
+      expect(needsGeneratedDescription("")).toBe(true);
+    });
+
+    it("returns true for very short description", () => {
+      expect(needsGeneratedDescription("Short text")).toBe(true);
+    });
+
+    it("returns false for adequate description", () => {
+      expect(
+        needsGeneratedDescription(
+          "This is a well-detailed yacht description that exceeds fifty characters easily."
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("scoreDescription", () => {
+    it("returns 0 for null", () => {
+      expect(scoreDescription(null)).toBe(0);
+    });
+
+    it("returns low score for very short text", () => {
+      expect(scoreDescription("Short")).toBe(10);
+    });
+
+    it("returns higher score for rich descriptions", () => {
+      const rich =
+        "The Beneteau Oceanis 40.1 is a 12.4m sailing yacht with sloop rig, " +
+        "fin keel, and GRP hull construction. She features 3 cabins, 6 berths, " +
+        "and is powered by a Yanmar diesel engine producing 45 HP. " +
+        "Designed for coastal cruising and family sailing adventures.";
+      const score = scoreDescription(rich);
+      expect(score).toBeGreaterThan(50);
+    });
+
+    it("maxes at 100", () => {
+      const superRich =
+        "A fantastic bluewater cruising yacht with spacious cabins, " +
+        "excellent sail plan with sloop rig, displacement of 8.5 tonnes, " +
+        "diesel engine with 45 HP, and a beautiful GRP hull with fin keel. " +
+        "Perfect for racing or offshore cruising with 6 berths across 3 cabins. " +
+        "This vessel offers exceptional build quality, sailing performance, " +
+        "comfort and value for money for the discerning sailor.";
+      expect(scoreDescription(superRich)).toBeLessThanOrEqual(100);
+    });
+  });
+});


### PR DESCRIPTION
## P20.1 — Auto-generated yacht summary descriptions

Closes #373

### Changes
- **DB Schema**: Added `description_source`, `description_status`, `description_generated_at` columns to `yacht_models`
- **Description Service** (`lib/description-service.ts`): Batch generation from spec data, admin review queue, stats
- **Admin Dashboard** (`/admin/descriptions`): Stats overview, generate button (dry run + live), pending review queue with approve/reject
- **Admin API** (`/api/admin/descriptions`): GET stats/pending list, POST generate/approve/reject/approve-all
- **15 unit tests** for description template engine
- Added admin dashboard navigation card

### How it works
1. Admin visits /admin/descriptions → sees 42 yachts missing descriptions
2. Clicks 'Generate & Queue for Review' → descriptions generated from specs and stored in DB as 'pending'
3. Reviews each description in the queue → Approve or Reject
4. Approved descriptions automatically appear on yacht detail pages (existing client-side code reads `yacht.description`)
5. Client-side fallback still works for any remaining gaps

### Test Results
- Typecheck: ✅ PASS
- Build: ✅ PASS
- Tests: 15/15 passed