### PR TITLE
feat: Email this yacht feature (P23.3)

### DIFF
--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -28,6 +28,10 @@ const SocialShareButtons = dynamic(() => import("@/components/SocialShareButtons
   ssr: false,
   loading: () => <div className="h-8 w-32 animate-pulse bg-muted rounded" />,
 });
+const EmailYachtButton = dynamic(() => import("@/components/EmailYachtButton").then((m) => ({ default: m.EmailYachtButton })), {
+  ssr: false,
+  loading: () => <div className="h-8 w-24 animate-pulse bg-muted rounded" />,
+});
 const MediaGallery = dynamic(() => import("@/components/MediaGallery").then(m => ({ default: m.default })), {
   ssr: false,
   loading: () => <div className="h-64 animate-pulse bg-muted rounded-lg" />,
@@ -431,6 +435,11 @@ export default function YachtDetailClient() {
             url={pageUrl}
             title={pageTitle}
             description={yacht.description || undefined}
+          />
+          <EmailYachtButton
+            yachtSlug={slug}
+            yachtName={`${yacht.manufacturer} ${yacht.modelName}`}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border border-border rounded-lg hover:bg-muted transition-colors"
           />
           <button
             onClick={handlePrint}

--- a/app/api/email-yacht/route.ts
+++ b/app/api/email-yacht/route.ts
@@ -1,0 +1,371 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendEmail } from "@/lib/email";
+import { getYachtDetailData, getPrimaryImage } from "@/lib/yachts";
+
+// In-memory rate limiter (per IP, resets on redeploy)
+const rateLimiter = new Map<string, { count: number; resetAt: number }>();
+const MAX_EMAILS_PER_HOUR = 3;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimiter.get(ip);
+
+  if (!entry || now > entry.resetAt) {
+    rateLimiter.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+
+  if (entry.count >= MAX_EMAILS_PER_HOUR) {
+    return true;
+  }
+
+  entry.count++;
+  return false;
+}
+
+// Clean up old entries periodically
+if (typeof setInterval !== "undefined") {
+  setInterval(() => {
+    const now = Date.now();
+    for (const [ip, entry] of rateLimiter.entries()) {
+      if (now > entry.resetAt) {
+        rateLimiter.delete(ip);
+      }
+    }
+  }, 5 * 60 * 1000);
+}
+
+export interface EmailYachtRequest {
+  recipientEmail: string;
+  senderName?: string;
+  message?: string;
+  yachtSlug: string;
+  locale?: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Rate limit check
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
+
+    if (isRateLimited(ip)) {
+      return NextResponse.json(
+        { error: "Rate limited", message: "Too many emails. Please wait before sending another." },
+        { status: 429 }
+      );
+    }
+
+    const body: EmailYachtRequest = await request.json();
+    const { recipientEmail, senderName, message, yachtSlug, locale } = body;
+
+    // Validate recipient email
+    if (!recipientEmail || typeof recipientEmail !== "string") {
+      return NextResponse.json(
+        { error: "Recipient email is required" },
+        { status: 400 }
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(recipientEmail.trim().toLowerCase())) {
+      return NextResponse.json(
+        { error: "Invalid email format" },
+        { status: 400 }
+      );
+    }
+
+    // Validate yacht slug
+    if (!yachtSlug || typeof yachtSlug !== "string") {
+      return NextResponse.json(
+        { error: "Yacht slug is required" },
+        { status: 400 }
+      );
+    }
+
+    // Optional message length check
+    if (message && message.length > 500) {
+      return NextResponse.json(
+        { error: "Message must be 500 characters or less" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch yacht data
+    const yachtDataResult = await getYachtDetailData(yachtSlug);
+    if (!yachtDataResult) {
+      return NextResponse.json(
+        { error: "Yacht not found" },
+        { status: 404 }
+      );
+    }
+
+    const yachtRow = yachtDataResult.yacht;
+    const manufacturerName = yachtDataResult.manufacturer;
+    const imageUrl = await getPrimaryImage(yachtSlug);
+    const lang = locale === "fr" ? "fr" : "en";
+    const siteBaseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+    const yachtUrl = `${siteBaseUrl}/${lang}/yachts/${yachtSlug}`;
+
+    const yachtDisplayName = `${manufacturerName} ${yachtRow.modelName}`;
+    const senderDisplay = senderName?.trim() || undefined;
+
+    // Parse numeric fields from string (Neon decimal columns)
+    const loa = yachtRow.lengthOverall ? parseFloat(yachtRow.lengthOverall) : null;
+    const beamVal = yachtRow.beam ? parseFloat(yachtRow.beam) : null;
+    const draftVal = yachtRow.draft ? parseFloat(yachtRow.draft) : null;
+    const dispVal = yachtRow.displacement ? parseFloat(yachtRow.displacement) : null;
+    const cabinsVal = yachtRow.cabins;
+    const berthsVal = yachtRow.berths;
+
+    // Build subject
+    const subject = senderDisplay
+      ? `${senderDisplay} recommends the ${yachtDisplayName}`
+      : `Check out the ${yachtDisplayName}`;
+
+    // Build HTML email
+    const html = buildEmailHtml({
+      manufacturer: manufacturerName,
+      modelName: yachtRow.modelName,
+      year: yachtRow.year,
+      lengthOverall: loa,
+      beam: beamVal,
+      draft: draftVal,
+      displacement: dispVal,
+      cabins: cabinsVal,
+      berths: berthsVal,
+      rigType: yachtRow.rigType,
+      hullMaterial: yachtRow.hullMaterial,
+      keelType: yachtRow.keelType,
+      yachtDisplayName,
+      yachtUrl,
+      imageUrl,
+      senderName: senderDisplay,
+      message: message?.trim() || undefined,
+      lang,
+    });
+
+    const text = buildEmailText({
+      manufacturer: manufacturerName,
+      modelName: yachtRow.modelName,
+      year: yachtRow.year,
+      lengthOverall: loa,
+      beam: beamVal,
+      draft: draftVal,
+      displacement: dispVal,
+      cabins: cabinsVal,
+      berths: berthsVal,
+      yachtDisplayName,
+      yachtUrl,
+      senderName: senderDisplay,
+      message: message?.trim() || undefined,
+      lang,
+    });
+
+    // Send email
+    const result = await sendEmail({
+      to: recipientEmail.trim().toLowerCase(),
+      subject,
+      html,
+      text,
+    });
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: "Failed to send email", details: result.error },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      messageId: result.messageId,
+    });
+  } catch (error: any) {
+    console.error("[email-yacht] Error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+interface SpecParams {
+  manufacturer: string;
+  modelName: string;
+  year: number;
+  lengthOverall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  cabins: number | null;
+  berths: number | null;
+  rigType: string | null;
+  hullMaterial: string | null;
+  keelType: string | null;
+  yachtDisplayName: string;
+  yachtUrl: string;
+  imageUrl: string | null;
+  senderName?: string;
+  message?: string;
+  lang: string;
+}
+
+function buildEmailHtml(params: SpecParams): string {
+  const { yachtDisplayName, yachtUrl, imageUrl, senderName, message, lang, year,
+    lengthOverall, beam, draft, displacement, cabins, berths, rigType, hullMaterial, keelType } = params;
+  const isFr = lang === "fr";
+
+  const specRows = [
+    { label: isFr ? "Longueur hors tout" : "Length Overall", value: lengthOverall ? `${lengthOverall} m` : null },
+    { label: isFr ? "Largeur" : "Beam", value: beam ? `${beam} m` : null },
+    { label: isFr ? "Tirant d\u2019eau" : "Draft", value: draft ? `${draft} m` : null },
+    { label: isFr ? "D\u00e9placement" : "Displacement", value: displacement ? `${displacement.toLocaleString()} kg` : null },
+    { label: isFr ? "Cabines" : "Cabins", value: cabins?.toString() || null },
+    { label: isFr ? "Couchettes" : "Berths", value: berths?.toString() || null },
+    { label: isFr ? "Gr\u00e9ement" : "Rig Type", value: rigType },
+    { label: isFr ? "Quille" : "Keel Type", value: keelType },
+    { label: isFr ? "Coque" : "Hull Material", value: hullMaterial },
+  ].filter((row) => row.value);
+
+  const greeting = senderName
+    ? (isFr ? `${senderName} vous recommande ce voilier` : `${senderName} recommends this yacht`)
+    : (isFr ? "D\u00e9couvrez ce voilier" : "Check out this yacht");
+
+  const siteBaseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${yachtDisplayName}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;background:#ffffff;">
+    <!-- Header -->
+    <tr>
+      <td style="padding:24px 32px;background:#1e3a5f;text-align:center;">
+        <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:600;">
+          \u26f5 ${greeting}
+        </h1>
+      </td>
+    </tr>
+    ${imageUrl ? `
+    <!-- Yacht Image -->
+    <tr>
+      <td style="padding:0;">
+        <img src="${imageUrl}" alt="${yachtDisplayName}" style="width:100%;max-height:300px;object-fit:cover;display:block;" />
+      </td>
+    </tr>` : ""}
+    <!-- Yacht Name -->
+    <tr>
+      <td style="padding:24px 32px 8px;">
+        <h2 style="margin:0;font-size:24px;color:#1e3a5f;">${yachtDisplayName}${year ? ` (${year})` : ""}</h2>
+      </td>
+    </tr>
+    ${message ? `
+    <!-- Personal Message -->
+    <tr>
+      <td style="padding:8px 32px 16px;">
+        <div style="background:#f0f7ff;border-left:4px solid #2563eb;padding:12px 16px;border-radius:0 8px 8px 0;font-style:italic;color:#374151;">
+          ${escapeHtml(message)}
+        </div>
+      </td>
+    </tr>` : ""}
+    <!-- Specs Table -->
+    <tr>
+      <td style="padding:8px 32px 24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+          ${specRows.map((row) => `
+          <tr>
+            <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#6b7280;font-size:14px;width:40%;">${row.label}</td>
+            <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#1f2937;font-size:14px;font-weight:500;">${row.value}</td>
+          </tr>`).join("")}
+        </table>
+      </td>
+    </tr>
+    <!-- CTA Button -->
+    <tr>
+      <td style="padding:0 32px 32px;text-align:center;">
+        <a href="${yachtUrl}" style="display:inline-block;padding:14px 32px;background:#2563eb;color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;font-size:16px;">
+          ${isFr ? "Voir les d\u00e9tails complets" : "View Full Details"} \u2192
+        </a>
+      </td>
+    </tr>
+    <!-- Footer -->
+    <tr>
+      <td style="padding:16px 32px;border-top:1px solid #e5e7eb;text-align:center;">
+        <p style="margin:0;font-size:12px;color:#9ca3af;">
+          ${isFr ? "Envoy\u00e9 via" : "Sent via"} <a href="${siteBaseUrl}" style="color:#6b7280;">Sailing Yacht Info</a>
+          ${isFr ? " \u2014 Sp\u00e9cifications d\u00e9taill\u00e9es de voiliers" : " \u2014 Detailed sailing yacht specifications"}
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+function buildEmailText(params: {
+  manufacturer: string;
+  modelName: string;
+  year: number;
+  lengthOverall: number | null;
+  beam: number | null;
+  draft: number | null;
+  displacement: number | null;
+  cabins: number | null;
+  berths: number | null;
+  yachtDisplayName: string;
+  yachtUrl: string;
+  senderName?: string;
+  message?: string;
+  lang: string;
+}): string {
+  const { yachtDisplayName, yachtUrl, senderName, message, lang, year,
+    lengthOverall, beam, draft, displacement, cabins, berths } = params;
+  const isFr = lang === "fr";
+
+  const greeting = senderName
+    ? (isFr ? `${senderName} vous recommande ce voilier` : `${senderName} recommends this yacht`)
+    : (isFr ? "D\u00e9couvrez ce voilier" : "Check out this yacht");
+
+  const lines = [
+    greeting,
+    "",
+    `${yachtDisplayName}${year ? ` (${year})` : ""}`,
+    "",
+  ];
+
+  if (lengthOverall) lines.push(`${isFr ? "Longueur" : "Length"}: ${lengthOverall} m`);
+  if (beam) lines.push(`${isFr ? "Largeur" : "Beam"}: ${beam} m`);
+  if (draft) lines.push(`${isFr ? "Tirant d\u2019eau" : "Draft"}: ${draft} m`);
+  if (displacement) lines.push(`${isFr ? "D\u00e9placement" : "Displacement"}: ${displacement.toLocaleString()} kg`);
+  if (cabins) lines.push(`${isFr ? "Cabines" : "Cabins"}: ${cabins}`);
+  if (berths) lines.push(`${isFr ? "Couchettes" : "Berths"}: ${berths}`);
+
+  lines.push("");
+  if (message) {
+    lines.push(`"${message}"`);
+    lines.push("");
+  }
+
+  lines.push(`${isFr ? "Voir les d\u00e9tails" : "View details"}: ${yachtUrl}`);
+  lines.push("");
+  lines.push(`\u2014 ${isFr ? "Envoy\u00e9 via" : "Sent via"} Sailing Yacht Info`);
+
+  return lines.join("\n");
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/components/EmailYachtButton.tsx
+++ b/components/EmailYachtButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Mail } from "lucide-react";
+import { EmailYachtDialog } from "./EmailYachtDialog";
+
+interface EmailYachtButtonProps {
+  yachtSlug: string;
+  yachtName: string;
+  className?: string;
+}
+
+export function EmailYachtButton({
+  yachtSlug,
+  yachtName,
+  className = "",
+}: EmailYachtButtonProps) {
+  const t = useTranslations("EmailYacht");
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className={`inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 ${className}`}
+        aria-label={t("button")}
+      >
+        <Mail className="h-4 w-4" />
+        <span className="hidden sm:inline">{t("button")}</span>
+      </button>
+      <EmailYachtDialog
+        yachtSlug={yachtSlug}
+        yachtName={yachtName}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </>
+  );
+}

--- a/components/EmailYachtDialog.tsx
+++ b/components/EmailYachtDialog.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { Mail, X, CheckCircle, AlertCircle, Loader2 } from "lucide-react";
+
+interface EmailYachtDialogProps {
+  yachtSlug: string;
+  yachtName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type FormState = "idle" | "sending" | "success" | "error" | "rateLimited";
+
+export function EmailYachtDialog({
+  yachtSlug,
+  yachtName,
+  isOpen,
+  onClose,
+}: EmailYachtDialogProps) {
+  const t = useTranslations("EmailYacht");
+  const [recipientEmail, setRecipientEmail] = useState("");
+  const [senderName, setSenderName] = useState("");
+  const [message, setMessage] = useState("");
+  const [formState, setFormState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  if (!isOpen) return null;
+
+  const handleClose = () => {
+    setFormState("idle");
+    setRecipientEmail("");
+    setSenderName("");
+    setMessage("");
+    setErrorMessage("");
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormState("sending");
+    setErrorMessage("");
+
+    try {
+      const locale = window.location.pathname.split("/")[1] || "en";
+      const response = await fetch("/api/email-yacht", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          recipientEmail: recipientEmail.trim(),
+          senderName: senderName.trim() || undefined,
+          message: message.trim() || undefined,
+          yachtSlug,
+          locale,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.status === 429) {
+        setFormState("rateLimited");
+        return;
+      }
+
+      if (!response.ok) {
+        setFormState("error");
+        setErrorMessage(data.error || t("errorMessage"));
+        return;
+      }
+
+      setFormState("success");
+    } catch {
+      setFormState("error");
+      setErrorMessage(t("errorMessage"));
+    }
+  };
+
+  const isValidEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipientEmail.trim());
+  const canSend = formState === "idle" && isValidEmail;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="email-yacht-title"
+        className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-900"
+      >
+        {/* Close button */}
+        <button
+          onClick={handleClose}
+          className="absolute right-4 top-4 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        {formState === "success" ? (
+          <div className="py-4 text-center">
+            <CheckCircle className="mx-auto h-12 w-12 text-green-500" />
+            <h3 className="mt-3 text-lg font-semibold text-gray-900 dark:text-white">
+              {t("successTitle")}
+            </h3>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {t("successMessage", { email: recipientEmail })}
+            </p>
+            <button
+              onClick={handleClose}
+              className="mt-4 rounded-lg bg-gray-100 px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              OK
+            </button>
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <div className="mb-4 flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30">
+                <Mail className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <h2
+                  id="email-yacht-title"
+                  className="text-lg font-semibold text-gray-900 dark:text-white"
+                >
+                  {t("dialogTitle")}
+                </h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {yachtName}
+                </p>
+              </div>
+            </div>
+
+            {formState === "rateLimited" ? (
+              <div className="rounded-lg bg-amber-50 p-4 dark:bg-amber-900/20">
+                <p className="text-sm text-amber-800 dark:text-amber-200">
+                  {t("rateLimitError")}
+                </p>
+                <button
+                  onClick={handleClose}
+                  className="mt-2 text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-300"
+                >
+                  OK
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Recipient email */}
+                <div>
+                  <label
+                    htmlFor="email-recipient"
+                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {t("recipientLabel")} *
+                  </label>
+                  <input
+                    id="email-recipient"
+                    type="email"
+                    required
+                    value={recipientEmail}
+                    onChange={(e) => setRecipientEmail(e.target.value)}
+                    placeholder={t("recipientPlaceholder")}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    disabled={formState === "sending"}
+                  />
+                </div>
+
+                {/* Sender name */}
+                <div>
+                  <label
+                    htmlFor="email-sender"
+                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {t("senderLabel")}
+                  </label>
+                  <input
+                    id="email-sender"
+                    type="text"
+                    value={senderName}
+                    onChange={(e) => setSenderName(e.target.value)}
+                    placeholder={t("senderPlaceholder")}
+                    maxLength={100}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    disabled={formState === "sending"}
+                  />
+                </div>
+
+                {/* Message */}
+                <div>
+                  <label
+                    htmlFor="email-message"
+                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {t("messageLabel")}
+                  </label>
+                  <textarea
+                    id="email-message"
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    placeholder={t("messagePlaceholder")}
+                    maxLength={500}
+                    rows={3}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    disabled={formState === "sending"}
+                  />
+                  <p className="mt-1 text-right text-xs text-gray-400">
+                    {message.length}/500
+                  </p>
+                </div>
+
+                {/* Error message */}
+                {formState === "error" && errorMessage && (
+                  <div className="flex items-start gap-2 rounded-lg bg-red-50 p-3 dark:bg-red-900/20">
+                    <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" />
+                    <p className="text-sm text-red-700 dark:text-red-300">
+                      {errorMessage}
+                    </p>
+                  </div>
+                )}
+
+                {/* Submit */}
+                <button
+                  type="submit"
+                  disabled={!canSend}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {formState === "sending" ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      {t("sending")}
+                    </>
+                  ) : (
+                    <>
+                      <Mail className="h-4 w-4" />
+                      {t("sendButton")}
+                    </>
+                  )}
+                </button>
+              </form>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1315,5 +1315,25 @@
     "submitError": "Failed to submit rating",
     "distribution": "Rating distribution",
     "thanksForRating": "Thanks for rating!"
+  },
+  "EmailYacht": {
+    "button": "Email this yacht",
+    "dialogTitle": "Send yacht details by email",
+    "recipientLabel": "Recipient email",
+    "recipientPlaceholder": "friend@example.com",
+    "recipientRequired": "Please enter a valid email address",
+    "senderLabel": "Your name",
+    "senderPlaceholder": "Your name (optional)",
+    "messageLabel": "Message",
+    "messagePlaceholder": "Add a personal note (optional)",
+    "sendButton": "Send",
+    "sending": "Sending...",
+    "successTitle": "Email sent!",
+    "successMessage": "Yacht details have been sent to {email}",
+    "errorTitle": "Could not send email",
+    "errorMessage": "Please try again later.",
+    "rateLimitError": "Too many emails sent. Please wait before sending another.",
+    "subject": "{sender} recommends the {manufacturer} {model}",
+    "subjectNoSender": "Check out the {manufacturer} {model}"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1315,5 +1315,25 @@
     "submitError": "Échec de l'envoi de la note",
     "distribution": "Répartition des notes",
     "thanksForRating": "Merci pour votre note !"
+  },
+  "EmailYacht": {
+    "button": "Envoyer par email",
+    "dialogTitle": "Envoyer les détails du voilier par email",
+    "recipientLabel": "Email du destinataire",
+    "recipientPlaceholder": "ami@exemple.com",
+    "recipientRequired": "Veuillez entrer une adresse email valide",
+    "senderLabel": "Votre nom",
+    "senderPlaceholder": "Votre nom (facultatif)",
+    "messageLabel": "Message",
+    "messagePlaceholder": "Ajoutez une note personnelle (facultatif)",
+    "sendButton": "Envoyer",
+    "sending": "Envoi en cours...",
+    "successTitle": "Email envoyé !",
+    "successMessage": "Les détails du voilier ont été envoyés à {email}",
+    "errorTitle": "Impossible d'envoyer l'email",
+    "errorMessage": "Veuillez réessayer plus tard.",
+    "rateLimitError": "Trop d'emails envoyés. Veuillez patienter avant d'en envoyer un autre.",
+    "subject": "{sender} vous recommande le {manufacturer} {model}",
+    "subjectNoSender": "Découvrez le {manufacturer} {model}"
   }
 }

--- a/tests/email-yacht.test.ts
+++ b/tests/email-yacht.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const projectRoot = resolve(__dirname, "..");
+
+describe("Email Yacht Feature — P23.3", () => {
+  // --- Components ---
+  describe("EmailYachtDialog component", () => {
+    const componentPath = resolve(projectRoot, "components/EmailYachtDialog.tsx");
+
+    it("file exists", () => {
+      expect(existsSync(componentPath)).toBe(true);
+    });
+
+    it("exports named EmailYachtDialog", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("export function EmailYachtDialog");
+    });
+
+    it("is a client component", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('"use client"');
+    });
+
+    it("uses EmailYacht translation namespace", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('useTranslations("EmailYacht")');
+    });
+
+    it("has recipient email input field", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('id="email-recipient"');
+      expect(content).toContain("type=\"email\"");
+    });
+
+    it("has sender name input field", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('id="email-sender"');
+    });
+
+    it("has optional message textarea", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('id="email-message"');
+      expect(content).toContain("maxLength={500}");
+    });
+
+    it("has form states: idle, sending, success, error, rateLimited", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('"idle"');
+      expect(content).toContain('"sending"');
+      expect(content).toContain('"success"');
+      expect(content).toContain('"error"');
+      expect(content).toContain('"rateLimited"');
+    });
+
+    it("calls POST /api/email-yacht", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('"/api/email-yacht"');
+      expect(content).toContain('"POST"');
+    });
+
+    it("sends yachtSlug in request body", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("yachtSlug");
+    });
+
+    it("shows success state with checkmark", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("CheckCircle");
+      expect(content).toContain('"success"');
+    });
+
+    it("shows loading spinner during send", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("Loader2");
+      expect(content).toContain("animate-spin");
+    });
+
+    it("has modal dialog with aria-modal", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('aria-modal="true"');
+      expect(content).toContain('role="dialog"');
+    });
+
+    it("disables submit during sending", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("disabled={formState === \"sending\"}");
+    });
+
+    it("has close button with X icon", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("aria-label=\"Close\"");
+    });
+  });
+
+  describe("EmailYachtButton component", () => {
+    const componentPath = resolve(projectRoot, "components/EmailYachtButton.tsx");
+
+    it("file exists", () => {
+      expect(existsSync(componentPath)).toBe(true);
+    });
+
+    it("exports named EmailYachtButton", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("export function EmailYachtButton");
+    });
+
+    it("is a client component", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('"use client"');
+    });
+
+    it("uses EmailYacht translation namespace", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain('useTranslations("EmailYacht")');
+    });
+
+    it("renders a mail icon", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("Mail");
+    });
+
+    it("toggles dialog on click", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("setIsOpen(true)");
+      expect(content).toContain("onClose");
+    });
+
+    it("accepts yachtSlug and yachtName props", () => {
+      const content = readFileSync(componentPath, "utf-8");
+      expect(content).toContain("yachtSlug");
+      expect(content).toContain("yachtName");
+    });
+  });
+
+  // --- API Route ---
+  describe("POST /api/email-yacht route", () => {
+    const routePath = resolve(projectRoot, "app/api/email-yacht/route.ts");
+
+    it("file exists", () => {
+      expect(existsSync(routePath)).toBe(true);
+    });
+
+    it("exports POST handler", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("export async function POST");
+    });
+
+    it("validates recipient email", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("recipientEmail");
+      expect(content).toContain("emailRegex");
+    });
+
+    it("validates message length <= 500", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("500");
+    });
+
+    it("has rate limiting", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("rateLimiter");
+      expect(content).toContain("MAX_EMAILS_PER_HOUR");
+      expect(content).toContain("429");
+    });
+
+    it("fetches yacht data for email content", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("getYachtDetailData");
+    });
+
+    it("sends email via sendEmail utility", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("sendEmail");
+    });
+
+    it("builds HTML email template", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("buildEmailHtml");
+    });
+
+    it("builds plain text email fallback", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("buildEmailText");
+    });
+
+    it("supports French locale in email content", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("fr");
+      expect(content).toContain("isFr");
+      expect(content).toContain("Longueur hors tout");
+    });
+
+    it("includes yacht specs in email", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("lengthOverall");
+      expect(content).toContain("beam");
+      expect(content).toContain("draft");
+      expect(content).toContain("displacement");
+    });
+
+    it("includes CTA link to yacht page", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("yachtUrl");
+    });
+
+    it("returns 404 for invalid yacht slug", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain('"Yacht not found"');
+      expect(content).toContain("404");
+    });
+
+    it("returns 429 when rate limited", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("429");
+    });
+
+    it("escapes HTML in message to prevent XSS", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("escapeHtml");
+    });
+
+    it("supports personal message in email", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("message");
+    });
+
+    it("gets client IP for rate limiting", () => {
+      const content = readFileSync(routePath, "utf-8");
+      expect(content).toContain("x-forwarded-for");
+    });
+  });
+
+  // --- Integration with Yacht Detail Page ---
+  describe("Yacht detail page integration", () => {
+    const detailPath = resolve(projectRoot, "app/[locale]/yachts/[slug]/YachtDetailClient.tsx");
+
+    it("lazy-loads EmailYachtButton component", () => {
+      const content = readFileSync(detailPath, "utf-8");
+      expect(content).toContain("EmailYachtButton");
+      expect(content).toContain("dynamic(");
+    });
+
+    it("passes yachtSlug and yachtName to EmailYachtButton", () => {
+      const content = readFileSync(detailPath, "utf-8");
+      expect(content).toMatch(/yachtSlug=\{slug\}/);
+      expect(content).toMatch(/yachtName=/);
+    });
+  });
+
+  // --- i18n ---
+  describe("i18n translations", () => {
+    const enPath = resolve(projectRoot, "messages/en.json");
+    const frPath = resolve(projectRoot, "messages/fr.json");
+
+    const requiredKeys = [
+      "button", "dialogTitle", "recipientLabel", "recipientPlaceholder",
+      "recipientRequired", "senderLabel", "senderPlaceholder",
+      "messageLabel", "messagePlaceholder", "sendButton", "sending",
+      "successTitle", "successMessage", "errorTitle", "errorMessage",
+      "rateLimitError", "subject", "subjectNoSender",
+    ];
+
+    it("English translations exist with all keys", () => {
+      const en = JSON.parse(readFileSync(enPath, "utf-8"));
+      const emailYacht = en.EmailYacht;
+      expect(emailYacht).toBeDefined();
+      for (const key of requiredKeys) {
+        expect(emailYacht[key]).toBeDefined();
+        expect(typeof emailYacht[key]).toBe("string");
+        expect(emailYacht[key].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("French translations exist with all keys", () => {
+      const fr = JSON.parse(readFileSync(frPath, "utf-8"));
+      const emailYacht = fr.EmailYacht;
+      expect(emailYacht).toBeDefined();
+      for (const key of requiredKeys) {
+        expect(emailYacht[key]).toBeDefined();
+        expect(typeof emailYacht[key]).toBe("string");
+        expect(emailYacht[key].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("successMessage uses {email} interpolation", () => {
+      const en = JSON.parse(readFileSync(enPath, "utf-8"));
+      expect(en.EmailYacht.successMessage).toContain("{email}");
+      const fr = JSON.parse(readFileSync(frPath, "utf-8"));
+      expect(fr.EmailYacht.successMessage).toContain("{email}");
+    });
+
+    it("subject uses interpolation", () => {
+      const en = JSON.parse(readFileSync(enPath, "utf-8"));
+      expect(en.EmailYacht.subject).toContain("{sender}");
+      expect(en.EmailYacht.subject).toContain("{manufacturer}");
+      expect(en.EmailYacht.subject).toContain("{model}");
+    });
+  });
+});


### PR DESCRIPTION
## P23.3 — Email this yacht feature

Closes #381

### Changes
- **EmailYachtDialog** component: recipient email, optional sender name, optional message (max 500 chars)
- **EmailYachtButton** trigger button on yacht detail page (lazy-loaded)
- **POST /api/email-yacht** route with:
  - Rate limiting (3 emails/hour/IP, in-memory)
  - Email validation, message length validation
  - Fetches yacht data, builds HTML + plain text email
  - Uses existing `sendEmail` (Resend API with logging fallback)
- **HTML email template**: branded header, yacht image, specs table, CTA button, footer
- **Plain text fallback**: simple format with specs and link
- **i18n**: Full English + French translations in `EmailYacht` namespace
- **Tests**: 45 tests covering components, API route, i18n, integration

### Files
- `components/EmailYachtButton.tsx` — Trigger button
- `components/EmailYachtDialog.tsx` — Dialog with form
- `app/api/email-yacht/route.ts` — API endpoint
- `messages/en.json` / `messages/fr.json` — i18n strings
- `tests/email-yacht.test.ts` — 45 tests

### Verification
- ✅ Typecheck passes
- ✅ Build passes
- ✅ 45/45 tests pass