### PR TITLE
feat: embeddable yacht comparison widget with configurator (closes #383)

### DIFF
--- a/app/embed/EmbedConfiguratorClient.tsx
+++ b/app/embed/EmbedConfiguratorClient.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from "react";
+
+interface SearchResult {
+  id: number;
+  modelName: string;
+  manufacturer: string;
+  year: number | null;
+  lengthOverall: number | null;
+  slug: string | null;
+}
+
+type LayoutMode = "full" | "compact";
+type ThemeMode = "light" | "dark" | "auto";
+
+const MAX_YACHTS = 4;
+
+export default function EmbedConfiguratorClient({ siteUrl }: { siteUrl: string }) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [selectedYachts, setSelectedYachts] = useState<SearchResult[]>([]);
+  const [layout, setLayout] = useState<LayoutMode>("compact");
+  const [theme, setTheme] = useState<ThemeMode>("light");
+  const [isSearching, setIsSearching] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [embedFormat, setEmbedFormat] = useState<"iframe" | "js">("iframe");
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Search yachts with debounce using the /api/search autocomplete endpoint
+  const searchYachts = useCallback(async (query: string) => {
+    if (query.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    setIsSearching(true);
+    try {
+      const res = await fetch(
+        `${siteUrl}/api/search?q=${encodeURIComponent(query)}&mode=autocomplete&limit=10`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const suggestions = data.suggestions || [];
+        // Filter out already selected
+        const selectedIds = new Set(selectedYachts.map((y) => y.id));
+        setSearchResults(
+          suggestions.filter((y: SearchResult) => !selectedIds.has(y.id))
+        );
+      }
+    } catch {
+      // ignore
+    } finally {
+      setIsSearching(false);
+    }
+  }, [siteUrl, selectedYachts]);
+
+  useEffect(() => {
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    searchTimeoutRef.current = setTimeout(() => searchYachts(searchQuery), 300);
+    return () => {
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    };
+  }, [searchQuery, searchYachts]);
+
+  const addYacht = (yacht: SearchResult) => {
+    if (selectedYachts.length >= MAX_YACHTS) return;
+    setSelectedYachts((prev) => [...prev, yacht]);
+    setSearchResults((prev) => prev.filter((y) => y.id !== yacht.id));
+    setSearchQuery("");
+  };
+
+  const removeYacht = (id: number) => {
+    setSelectedYachts((prev) => prev.filter((y) => y.id !== id));
+  };
+
+  const embedUrl = selectedYachts.length >= 2
+    ? `${siteUrl}/embed/compare?ids=${selectedYachts.map((y) => y.id).join(",")}&layout=${layout}&theme=${theme}`
+    : "";
+
+  const iframeCode = embedUrl
+    ? `<iframe\n  src="${embedUrl}"\n  width="100%"\n  height="${layout === "compact" ? "400" : "600"}"\n  frameBorder="0"\n  style="border: 1px solid #e5e7eb; border-radius: 8px; max-width: 900px;"\n  title="Yacht Comparison Widget"\n  loading="lazy"\n></iframe>`
+    : "";
+
+  const jsCode = embedUrl
+    ? `<!-- Sailing Yacht Comparison Widget -->\n<div id="sailing-yachts-widget"></div>\n<script>\n(function() {\n  var iframe = document.createElement('iframe');\n  iframe.src = '${embedUrl}';\n  iframe.width = '100%';\n  iframe.style.border = '1px solid #e5e7eb';\n  iframe.style.borderRadius = '8px';\n  iframe.style.maxWidth = '900px';\n  iframe.frameBorder = '0';\n  iframe.title = 'Yacht Comparison Widget';\n  iframe.loading = 'lazy';\n\n  // Auto-resize based on content height\n  window.addEventListener('message', function(e) {\n    if (e.data && e.data.type === 'sailing-yachts-embed' && e.data.height) {\n      iframe.height = e.data.height + 'px';\n    }\n  });\n\n  document.getElementById('sailing-yachts-widget').appendChild(iframe);\n})();\n</script>`
+    : "";
+
+  const embedCode = embedFormat === "iframe" ? iframeCode : jsCode;
+
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(label);
+      setTimeout(() => setCopied(null), 2000);
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white border-b">
+        <div className="max-w-4xl mx-auto px-6 py-8">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="text-3xl">⛵</span>
+            <h1 className="text-2xl font-bold text-gray-900">Embed Comparison Widget</h1>
+          </div>
+          <p className="text-gray-600 text-sm">
+            Create a customizable yacht comparison widget for your website, blog, or forum. Select yachts, choose a layout, and copy the embed code.
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-8 space-y-8">
+        {/* Step 1: Select Yachts */}
+        <section className="bg-white rounded-xl shadow-sm border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold mr-2">
+              1
+            </span>
+            Select Yachts ({selectedYachts.length}/{MAX_YACHTS})
+          </h2>
+          <p className="text-sm text-gray-500 mb-4">Search and select 2–4 yachts to compare</p>
+
+          {/* Selected Yachts Chips */}
+          {selectedYachts.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {selectedYachts.map((y) => (
+                <div
+                  key={y.id}
+                  className="inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-lg px-3 py-1.5 text-sm"
+                >
+                  <span className="font-medium text-blue-900">{y.manufacturer}</span>
+                  <span className="text-blue-700">{y.modelName}</span>
+                  {y.year && <span className="text-blue-400 text-xs">({y.year})</span>}
+                  <button
+                    onClick={() => removeYacht(y.id)}
+                    className="text-blue-400 hover:text-blue-600 transition-colors"
+                    aria-label={`Remove ${y.modelName}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Search Input */}
+          {selectedYachts.length < MAX_YACHTS && (
+            <div className="relative">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search by model or manufacturer name..."
+                className="w-full px-4 py-2.5 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+              />
+              {isSearching && (
+                <div className="absolute right-3 top-3">
+                  <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+                </div>
+              )}
+
+              {/* Search Results Dropdown */}
+              {searchResults.length > 0 && (
+                <div className="absolute z-10 w-full mt-1 bg-white border rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                  {searchResults.map((y) => (
+                    <button
+                      key={y.id}
+                      onClick={() => addYacht(y)}
+                      className="w-full px-4 py-2.5 text-left hover:bg-blue-50 transition-colors text-sm border-b last:border-0"
+                    >
+                      <span className="font-medium">{y.manufacturer}</span>{" "}
+                      <span className="text-gray-700">{y.modelName}</span>
+                      {y.year && <span className="text-gray-400 ml-1">({y.year})</span>}
+                      {y.lengthOverall && (
+                        <span className="text-gray-400 ml-2 text-xs">{Number(y.lengthOverall).toFixed(1)}m</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* Step 2: Customize */}
+        <section className="bg-white rounded-xl shadow-sm border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold mr-2">
+              2
+            </span>
+            Customize Widget
+          </h2>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            {/* Layout */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Layout</label>
+              <div className="flex gap-3">
+                {(["compact", "full"] as LayoutMode[]).map((l) => (
+                  <button
+                    key={l}
+                    onClick={() => setLayout(l)}
+                    className={`flex-1 px-4 py-2.5 rounded-lg border text-sm font-medium transition-colors ${
+                      layout === l
+                        ? "bg-blue-50 border-blue-300 text-blue-700"
+                        : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+                    }`}
+                  >
+                    {l === "compact" ? "📐 Compact" : "📊 Full"}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-400 mt-1">
+                {layout === "compact"
+                  ? "Key specs only, ~400px height. Best for sidebars and small spaces."
+                  : "All specs with extra details, ~600px height. Best for dedicated sections."}
+              </p>
+            </div>
+
+            {/* Theme */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Color Theme</label>
+              <div className="flex gap-2">
+                {(["light", "dark", "auto"] as ThemeMode[]).map((t) => (
+                  <button
+                    key={t}
+                    onClick={() => setTheme(t)}
+                    className={`flex-1 px-3 py-2.5 rounded-lg border text-sm font-medium transition-colors ${
+                      theme === t
+                        ? "bg-blue-50 border-blue-300 text-blue-700"
+                        : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+                    }`}
+                  >
+                    {t === "light" ? "☀️ Light" : t === "dark" ? "🌙 Dark" : "🔄 Auto"}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-400 mt-1">
+                {theme === "auto"
+                  ? "Adapts to the visitor's system preference."
+                  : `Fixed ${theme} color scheme.`}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 3: Preview */}
+        {selectedYachts.length >= 2 && (
+          <section className="bg-white rounded-xl shadow-sm border p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold mr-2">
+                3
+              </span>
+              Preview
+            </h2>
+            <div className="border rounded-lg overflow-hidden bg-white">
+              <iframe
+                src={embedUrl}
+                width="100%"
+                height={layout === "compact" ? "400" : "600"}
+                frameBorder="0"
+                style={{ maxWidth: 900, display: "block" }}
+                title="Widget Preview"
+              />
+            </div>
+          </section>
+        )}
+
+        {/* Step 4: Embed Code */}
+        {selectedYachts.length >= 2 && (
+          <section className="bg-white rounded-xl shadow-sm border p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold mr-2">
+                4
+              </span>
+              Get Embed Code
+            </h2>
+
+            {/* Format Tabs */}
+            <div className="flex gap-2 mb-4">
+              <button
+                onClick={() => setEmbedFormat("iframe")}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  embedFormat === "iframe"
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                &lt;iframe&gt;
+              </button>
+              <button
+                onClick={() => setEmbedFormat("js")}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  embedFormat === "js"
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                JavaScript (auto-resize)
+              </button>
+            </div>
+
+            {/* Code Block */}
+            <div className="relative">
+              <pre className="bg-gray-900 text-green-400 p-4 rounded-lg overflow-x-auto text-xs font-mono leading-relaxed whitespace-pre-wrap">
+                {embedCode}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(embedCode, "embed")}
+                className="absolute top-2 right-2 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-xs rounded-md transition-colors"
+              >
+                {copied === "embed" ? "✓ Copied!" : "Copy"}
+              </button>
+            </div>
+
+            {/* Direct Link */}
+            <div className="mt-4 pt-4 border-t">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Direct link to widget</label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  readOnly
+                  value={embedUrl}
+                  className="flex-1 px-3 py-2 border rounded-lg text-xs text-gray-600 bg-gray-50"
+                />
+                <button
+                  onClick={() => copyToClipboard(embedUrl, "url")}
+                  className="px-3 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg text-xs font-medium transition-colors"
+                >
+                  {copied === "url" ? "✓ Copied!" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            {/* Usage note */}
+            <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
+              <strong>💡 Tip:</strong> The JavaScript embed auto-resizes the iframe height based on content.
+              The iframe version uses a fixed height. For responsive layouts, set the container width to 100%.
+            </div>
+          </section>
+        )}
+
+        {/* Need more yachts prompt */}
+        {selectedYachts.length < 2 && (
+          <div className="text-center py-8 text-gray-400">
+            <p className="text-sm">Select at least 2 yachts to generate the embed code</p>
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="border-t mt-8">
+        <div className="max-w-4xl mx-auto px-6 py-4 text-center text-xs text-gray-400">
+          <a href={siteUrl} target="_blank" rel="noopener noreferrer" className="hover:text-gray-600 transition-colors">
+            Sailing Yacht Info
+          </a>{" "}
+          · Embed widgets are free to use with attribution
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/embed/compare/EmbedCompareClient.tsx
+++ b/app/embed/compare/EmbedCompareClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 import React from "react";
-
 import { useEffect } from "react";
+
+type LayoutMode = "full" | "compact";
+type ThemeMode = "light" | "dark" | "auto";
 
 interface YachtDTO {
   id: number;
@@ -48,22 +50,55 @@ interface SpecFieldGroup {
   fields: FieldDef[];
 }
 
-const COLORS = [
+const COLORS_LIGHT = [
   { bg: "#EFF6FF", border: "#93C5FD", text: "#1E40AF", dot: "#3B82F6" },
   { bg: "#ECFDF5", border: "#6EE7B7", text: "#065F46", dot: "#10B981" },
   { bg: "#FFFBEB", border: "#FCD34D", text: "#92400E", dot: "#F59E0B" },
   { bg: "#FAF5FF", border: "#C4B5FD", text: "#6B21A8", dot: "#8B5CF6" },
 ];
 
+const COLORS_DARK = [
+  { bg: "#1E3A5F", border: "#2563EB", text: "#93C5FD", dot: "#60A5FA" },
+  { bg: "#064E3B", border: "#059669", text: "#6EE7B7", dot: "#34D399" },
+  { bg: "#78350F", border: "#D97706", text: "#FCD34D", dot: "#FBBF24" },
+  { bg: "#4C1D95", border: "#7C3AED", text: "#C4B5FD", dot: "#A78BFA" },
+];
+
+function getColors(theme: ThemeMode, index: number) {
+  // Determine if we should use dark colors
+  // For 'auto', we use a media query check (client-side only)
+  const useDark =
+    theme === "dark" ||
+    (theme === "auto" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  const palette = useDark ? COLORS_DARK : COLORS_LIGHT;
+  return palette[index % palette.length];
+}
+
 export default function EmbedCompareClient({
   yachts,
   specFields,
   siteUrl,
+  layout,
+  theme,
 }: {
   yachts: YachtDTO[];
   specFields: SpecFieldGroup[];
   siteUrl: string;
+  layout: LayoutMode;
+  theme: ThemeMode;
 }) {
+  const isDark =
+    theme === "dark" ||
+    (theme === "auto" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  const textColor = isDark ? "#e5e7eb" : "#1f2937";
+  const bgColor = isDark ? "#111827" : "#ffffff";
+  const mutedText = isDark ? "#9ca3af" : "#6b7280";
+  const borderColor = isDark ? "#374151" : "#e5e7eb";
+  const rowBg = isDark ? "#1f2937" : "#f9fafb";
+  const labelColor = isDark ? "#d1d5db" : "#4b5563";
+
   // Post height to parent for auto-resize
   useEffect(() => {
     const sendHeight = () => {
@@ -124,17 +159,121 @@ export default function EmbedCompareClient({
     extraByGroup[group].push(data);
   }
 
+  // Compact layout: simpler, smaller, single-row style
+  if (layout === "compact") {
+    return (
+      <div
+        style={{
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+          maxWidth: 640,
+          margin: "0 auto",
+          padding: "12px",
+          color: textColor,
+          fontSize: 12,
+          background: bgColor,
+          borderRadius: 8,
+          border: `1px solid ${borderColor}`,
+        }}
+      >
+        {/* Compact Header */}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10, paddingBottom: 8, borderBottom: `1px solid ${borderColor}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 16 }}>⛵</span>
+            <span style={{ fontWeight: 700, fontSize: 13, color: textColor }}>Yacht Comparison</span>
+          </div>
+          <a
+            href={`${siteUrl}/compare?ids=${yachts.map((y) => y.id).join(",")}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 11, color: isDark ? "#60A5FA" : "#3B82F6", textDecoration: "none", fontWeight: 500 }}
+          >
+            Full details →
+          </a>
+        </div>
+
+        {/* Yacht columns with key specs */}
+        <div style={{ display: "grid", gridTemplateColumns: `repeat(${yachts.length}, 1fr)`, gap: 8 }}>
+          {yachts.map((y, i) => {
+            const c = getColors(theme, i);
+            return (
+              <div key={y.id} style={{ background: c.bg, border: `1px solid ${c.border}`, borderRadius: 6, padding: "8px" }}>
+                <a
+                  href={`${siteUrl}/yachts/${y.slug || y.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ textDecoration: "none", color: c.text }}
+                >
+                  <div style={{ fontWeight: 700, fontSize: 12, lineHeight: 1.3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {y.manufacturer}
+                  </div>
+                  <div style={{ fontSize: 11, fontWeight: 500, opacity: 0.85, lineHeight: 1.3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {y.modelName}
+                  </div>
+                </a>
+                {y.year && <div style={{ fontSize: 10, color: mutedText, marginTop: 1 }}>{y.year}</div>}
+                <div style={{ marginTop: 6, fontSize: 11, color: textColor, lineHeight: 1.6 }}>
+                  {y.lengthOverall != null && <div><span style={{ color: mutedText }}>LOA:</span> {formatVal(y.lengthOverall, "m")}</div>}
+                  {y.beam != null && <div><span style={{ color: mutedText }}>Beam:</span> {formatVal(y.beam, "m")}</div>}
+                  {y.draft != null && <div><span style={{ color: mutedText }}>Draft:</span> {formatVal(y.draft, "m")}</div>}
+                  {y.displacement != null && <div><span style={{ color: mutedText }}>Weight:</span> {formatVal(y.displacement, "kg")}</div>}
+                  {y.cabins != null && <div><span style={{ color: mutedText }}>Cabins:</span> {y.cabins}</div>}
+                  {y.berths != null && <div><span style={{ color: mutedText }}>Berths:</span> {y.berths}</div>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Compact Footer */}
+        <div style={{ marginTop: 8, textAlign: "center" }}>
+          <a
+            href={siteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 10, color: mutedText, textDecoration: "none" }}
+          >
+            Powered by Sailing Yacht Info
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // Full layout (existing behavior, enhanced with theme)
   return (
-    <div style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif', maxWidth: 900, margin: "0 auto", padding: "16px", color: "#1f2937", fontSize: 14 }}>
+    <div
+      style={{
+        fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+        maxWidth: 900,
+        margin: "0 auto",
+        padding: "16px",
+        color: textColor,
+        fontSize: 14,
+        background: bgColor,
+      }}
+    >
       {/* Branding Header */}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16, paddingBottom: 12, borderBottom: "2px solid #e5e7eb" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16, paddingBottom: 12, borderBottom: `2px solid ${borderColor}` }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <div style={{ width: 28, height: 28, borderRadius: 6, background: "linear-gradient(135deg, #3B82F6, #1D4ED8)", display: "flex", alignItems: "center", justifyContent: "center", color: "white", fontSize: 14, fontWeight: 700 }}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              background: "linear-gradient(135deg, #3B82F6, #1D4ED8)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "white",
+              fontSize: 14,
+              fontWeight: 700,
+            }}
+          >
             ⛵
           </div>
           <div>
-            <div style={{ fontWeight: 700, fontSize: 15, color: "#111827", lineHeight: 1.2 }}>Yacht Comparison</div>
-            <div style={{ fontSize: 11, color: "#9ca3af", lineHeight: 1.2 }}>
+            <div style={{ fontWeight: 700, fontSize: 15, color: textColor, lineHeight: 1.2 }}>Yacht Comparison</div>
+            <div style={{ fontSize: 11, color: mutedText, lineHeight: 1.2 }}>
               {yachts.length} yachts · {yachts[0]?.year ?? "—"}
             </div>
           </div>
@@ -143,7 +282,7 @@ export default function EmbedCompareClient({
           href={`${siteUrl}/compare?ids=${yachts.map((y) => y.id).join(",")}`}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ fontSize: 12, color: "#3B82F6", textDecoration: "none", fontWeight: 500 }}
+          style={{ fontSize: 12, color: isDark ? "#60A5FA" : "#3B82F6", textDecoration: "none", fontWeight: 500 }}
         >
           Full comparison →
         </a>
@@ -153,7 +292,7 @@ export default function EmbedCompareClient({
       <div style={{ display: "grid", gridTemplateColumns: `120px repeat(${yachts.length}, 1fr)`, gap: 8, marginBottom: 12 }}>
         <div />
         {yachts.map((y, i) => {
-          const c = COLORS[i];
+          const c = getColors(theme, i);
           return (
             <div key={y.id} style={{ background: c.bg, border: `1px solid ${c.border}`, borderRadius: 8, padding: "8px 10px", textAlign: "center" }}>
               <a
@@ -165,17 +304,27 @@ export default function EmbedCompareClient({
                 <div style={{ fontWeight: 700, fontSize: 13, lineHeight: 1.3 }}>{y.manufacturer}</div>
                 <div style={{ fontSize: 12, fontWeight: 500, opacity: 0.85, lineHeight: 1.3 }}>{y.modelName}</div>
               </a>
-              {y.year && (
-                <div style={{ fontSize: 10, color: "#6b7280", marginTop: 2 }}>{y.year}</div>
-              )}
+              {y.year && <div style={{ fontSize: 10, color: mutedText, marginTop: 2 }}>{y.year}</div>}
             </div>
           );
         })}
       </div>
 
       {/* Price Tier Row */}
-      <div style={{ display: "grid", gridTemplateColumns: `120px repeat(${yachts.length}, 1fr)`, gap: 8, marginBottom: 4, background: "#f9fafb", borderRadius: 6, padding: "6px 0" }}>
-        <div style={{ paddingLeft: 10, display: "flex", alignItems: "center", fontWeight: 600, fontSize: 12, color: "#6b7280" }}>Est. Price</div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `120px repeat(${yachts.length}, 1fr)`,
+          gap: 8,
+          marginBottom: 4,
+          background: rowBg,
+          borderRadius: 6,
+          padding: "6px 0",
+        }}
+      >
+        <div style={{ paddingLeft: 10, display: "flex", alignItems: "center", fontWeight: 600, fontSize: 12, color: mutedText }}>
+          Est. Price
+        </div>
         {yachts.map((y) => (
           <div key={y.id} style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 4 }}>
             <span
@@ -185,13 +334,17 @@ export default function EmbedCompareClient({
                 borderRadius: 9999,
                 fontSize: 11,
                 fontWeight: 600,
-                background: y.priceTier.bgColor.replace("bg-", "").includes("green") ? "#dcfce7" : y.priceTier.tier === "mid-range" ? "#dbeafe" : y.priceTier.tier === "premium" ? "#f3e8ff" : y.priceTier.tier === "luxury" ? "#fef3c7" : "#f3f4f6",
-                color: y.priceTier.tier === "budget" ? "#15803d" : y.priceTier.tier === "mid-range" ? "#1d4ed8" : y.priceTier.tier === "premium" ? "#7c3aed" : y.priceTier.tier === "luxury" ? "#b45309" : "#6b7280",
+                background: isDark
+                  ? y.priceTier.tier === "budget" ? "#064E3B" : y.priceTier.tier === "mid-range" ? "#1E3A5F" : y.priceTier.tier === "premium" ? "#4C1D95" : y.priceTier.tier === "luxury" ? "#78350F" : "#374151"
+                  : y.priceTier.tier === "budget" ? "#dcfce7" : y.priceTier.tier === "mid-range" ? "#dbeafe" : y.priceTier.tier === "premium" ? "#f3e8ff" : y.priceTier.tier === "luxury" ? "#fef3c7" : "#f3f4f6",
+                color: isDark
+                  ? y.priceTier.tier === "budget" ? "#6EE7B7" : y.priceTier.tier === "mid-range" ? "#93C5FD" : y.priceTier.tier === "premium" ? "#C4B5FD" : y.priceTier.tier === "luxury" ? "#FCD34D" : "#9ca3af"
+                  : y.priceTier.tier === "budget" ? "#15803d" : y.priceTier.tier === "mid-range" ? "#1d4ed8" : y.priceTier.tier === "premium" ? "#7c3aed" : y.priceTier.tier === "luxury" ? "#b45309" : "#6b7280",
               }}
             >
               {y.priceTier.label}
             </span>
-            <span style={{ fontSize: 10, color: "#9ca3af" }}>{y.priceTier.range}</span>
+            <span style={{ fontSize: 10, color: mutedText }}>{y.priceTier.range}</span>
           </div>
         ))}
       </div>
@@ -200,23 +353,17 @@ export default function EmbedCompareClient({
       <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
         <tbody>
           {specFields.map((sg) => (
-            <SpecGroupRow
-              key={sg.group}
-              group={sg.group}
-              fields={sg.fields}
-              yachts={yachts}
-              formatVal={formatVal}
-            />
+            <SpecGroupRow key={sg.group} group={sg.group} fields={sg.fields} yachts={yachts} formatVal={formatVal} labelColor={labelColor} borderColor={borderColor} textColor={textColor} />
           ))}
           {/* Extra specs from database */}
           {Object.entries(extraByGroup).map(([group, rows]) => (
             <React.Fragment key={`extra-${group}`}>
-              <GroupHeaderRow label={group} colSpan={yachts.length + 1} />
+              <GroupHeaderRow label={group} colSpan={yachts.length + 1} color={mutedText} borderColor={borderColor} />
               {rows.map((row) => (
                 <tr key={`extra-${group}-${row.name}`}>
-                  <LabelCell>{row.name}{row.unit ? ` (${row.unit})` : ""}</LabelCell>
+                  <LabelCell color={labelColor} borderColor={borderColor}>{row.name}{row.unit ? ` (${row.unit})` : ""}</LabelCell>
                   {row.values.map((v, vi) => (
-                    <ValueCell key={vi}>{v ?? "—"}</ValueCell>
+                    <ValueCell key={vi} color={textColor} borderColor={borderColor}>{v ?? "—"}</ValueCell>
                   ))}
                 </tr>
               ))}
@@ -226,15 +373,13 @@ export default function EmbedCompareClient({
       </table>
 
       {/* Footer */}
-      <div style={{ marginTop: 16, paddingTop: 10, borderTop: "1px solid #e5e7eb", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <span style={{ fontSize: 11, color: "#9ca3af" }}>
-          Data from manufacturer specifications
-        </span>
+      <div style={{ marginTop: 16, paddingTop: 10, borderTop: `1px solid ${borderColor}`, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 11, color: mutedText }}>Data from manufacturer specifications</span>
         <a
           href={siteUrl}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ fontSize: 11, color: "#6b7280", textDecoration: "none" }}
+          style={{ fontSize: 11, color: mutedText, textDecoration: "none" }}
         >
           Powered by Sailing Yacht Info
         </a>
@@ -248,20 +393,26 @@ function SpecGroupRow({
   fields,
   yachts,
   formatVal,
+  labelColor,
+  borderColor,
+  textColor,
 }: {
   group: string;
   fields: FieldDef[];
   yachts: YachtDTO[];
   formatVal: (v: any, u?: string) => string;
+  labelColor: string;
+  borderColor: string;
+  textColor: string;
 }) {
   return (
     <>
-      <GroupHeaderRow label={group} colSpan={yachts.length + 1} />
+      <GroupHeaderRow label={group} colSpan={yachts.length + 1} color={labelColor} borderColor={borderColor} />
       {fields.map((f) => (
         <tr key={f.key}>
-          <LabelCell>{f.label}</LabelCell>
+          <LabelCell color={labelColor} borderColor={borderColor}>{f.label}</LabelCell>
           {yachts.map((y) => (
-            <ValueCell key={y.id}>{formatVal(y[f.key], f.unit)}</ValueCell>
+            <ValueCell key={y.id} color={textColor} borderColor={borderColor}>{formatVal(y[f.key], f.unit)}</ValueCell>
           ))}
         </tr>
       ))}
@@ -269,7 +420,7 @@ function SpecGroupRow({
   );
 }
 
-function GroupHeaderRow({ label, colSpan }: { label: string; colSpan: number }) {
+function GroupHeaderRow({ label, colSpan, color, borderColor }: { label: string; colSpan: number; color: string; borderColor: string }) {
   return (
     <tr>
       <td
@@ -279,9 +430,9 @@ function GroupHeaderRow({ label, colSpan }: { label: string; colSpan: number }) 
           fontSize: 11,
           textTransform: "uppercase" as const,
           letterSpacing: "0.05em",
-          color: "#64748b",
+          color: color,
           padding: "10px 10px 4px",
-          borderBottom: "1px solid #e5e7eb",
+          borderBottom: `1px solid ${borderColor}`,
         }}
       >
         {label}
@@ -290,15 +441,15 @@ function GroupHeaderRow({ label, colSpan }: { label: string; colSpan: number }) 
   );
 }
 
-function LabelCell({ children }: { children: React.ReactNode }) {
+function LabelCell({ children, color, borderColor }: { children: React.ReactNode; color: string; borderColor: string }) {
   return (
     <td
       style={{
         fontWeight: 500,
-        color: "#4b5563",
+        color: color,
         padding: "5px 10px",
         whiteSpace: "nowrap",
-        borderBottom: "1px solid #f3f4f6",
+        borderBottom: `1px solid ${borderColor}`,
         fontSize: 12,
       }}
     >
@@ -307,15 +458,15 @@ function LabelCell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ValueCell({ children }: { children: React.ReactNode }) {
+function ValueCell({ children, color, borderColor }: { children: React.ReactNode; color: string; borderColor: string }) {
   return (
     <td
       style={{
         textAlign: "center",
         padding: "5px 8px",
-        borderBottom: "1px solid #f3f4f6",
+        borderBottom: `1px solid ${borderColor}`,
         fontSize: 12,
-        color: "#1f2937",
+        color: color,
       }}
     >
       {children}

--- a/app/embed/compare/page.tsx
+++ b/app/embed/compare/page.tsx
@@ -4,6 +4,9 @@ import EmbedCompareClient from "./EmbedCompareClient";
 
 export const dynamic = "force-dynamic";
 
+type LayoutMode = "full" | "compact";
+type ThemeMode = "light" | "dark" | "auto";
+
 interface YachtRow {
   id: number;
   model_name: string;
@@ -67,7 +70,7 @@ interface YachtDTO {
   priceTier: ReturnType<typeof calculatePriceTier>;
 }
 
-const SPEC_FIELDS: { group: string; fields: { key: keyof YachtDTO; label: string; unit?: string }[] }[] = [
+const SPEC_FIELDS_FULL: { group: string; fields: { key: keyof YachtDTO; label: string; unit?: string }[] }[] = [
   {
     group: "Dimensions",
     fields: [
@@ -112,14 +115,35 @@ const SPEC_FIELDS: { group: string; fields: { key: keyof YachtDTO; label: string
   },
 ];
 
+const SPEC_FIELDS_COMPACT: { group: string; fields: { key: keyof YachtDTO; label: string; unit?: string }[] }[] = [
+  {
+    group: "Key Specs",
+    fields: [
+      { key: "lengthOverall", label: "LOA", unit: "m" },
+      { key: "beam", label: "Beam", unit: "m" },
+      { key: "draft", label: "Draft", unit: "m" },
+      { key: "displacement", label: "Displacement", unit: "kg" },
+      { key: "cabins", label: "Cabins" },
+      { key: "berths", label: "Berths" },
+    ],
+  },
+];
+
 export default async function EmbedComparePage({
   searchParams,
 }: {
-  searchParams: Promise<{ ids?: string }>;
+  searchParams: Promise<{ ids?: string; layout?: string; theme?: string }>;
 }) {
   const params = await searchParams;
   const idsParam = params.ids;
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+
+  // Parse layout mode
+  const layout: LayoutMode = params.layout === "compact" ? "compact" : "full";
+
+  // Parse theme
+  const theme: ThemeMode =
+    params.theme === "dark" ? "dark" : params.theme === "light" ? "light" : "auto";
 
   if (!idsParam) {
     return (
@@ -127,6 +151,9 @@ export default async function EmbedComparePage({
         <p className="text-lg font-medium">No yachts selected</p>
         <p className="text-sm mt-1">
           Usage: <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">/embed/compare?ids=26,27</code>
+        </p>
+        <p className="text-xs mt-1 text-gray-400">
+          Options: <code>layout=compact|full</code>, <code>theme=light|dark|auto</code>
         </p>
       </div>
     );
@@ -170,32 +197,33 @@ export default async function EmbedComparePage({
     );
   }
 
-  // Fetch spec values
-  const specResult = await pool.query(
-    `SELECT sv.yacht_model_id, sv.value_text, sv.value_numeric,
-       sc.name AS category_name, sc.category_group, sc.unit
-     FROM spec_values sv
-     JOIN spec_categories sc ON sv.spec_category_id = sc.id
-     WHERE sv.yacht_model_id IN (${placeholders})
-     ORDER BY sc.category_group, sc.name`,
-    ids
-  );
-  const specRows = specResult.rows as SpecValue[];
+  // Only fetch spec values for full layout
+  let specsMap: Record<number, Record<string, { name: string; value: string; unit: string | null }[]>> = {};
+  if (layout === "full") {
+    const specResult = await pool.query(
+      `SELECT sv.yacht_model_id, sv.value_text, sv.value_numeric,
+         sc.name AS category_name, sc.category_group, sc.unit
+       FROM spec_values sv
+       JOIN spec_categories sc ON sv.spec_category_id = sc.id
+       WHERE sv.yacht_model_id IN (${placeholders})
+       ORDER BY sc.category_group, sc.name`,
+      ids
+    );
+    const specRows = specResult.rows as SpecValue[];
 
-  // Build specsByGroup per yacht
-  const specsMap: Record<number, Record<string, { name: string; value: string; unit: string | null }[]>> = {};
-  for (const sr of specRows) {
-    const yid = sr.yacht_model_id;
-    if (!specsMap[yid]) specsMap[yid] = {};
-    const group = sr.category_group || "Other";
-    if (!specsMap[yid][group]) specsMap[yid][group] = [];
-    let value = "—";
-    if (sr.value_numeric !== null) {
-      value = Number(sr.value_numeric).toLocaleString(undefined, { maximumFractionDigits: 2 });
-    } else if (sr.value_text) {
-      value = sr.value_text;
+    for (const sr of specRows) {
+      const yid = sr.yacht_model_id;
+      if (!specsMap[yid]) specsMap[yid] = {};
+      const group = sr.category_group || "Other";
+      if (!specsMap[yid][group]) specsMap[yid][group] = [];
+      let value = "—";
+      if (sr.value_numeric !== null) {
+        value = Number(sr.value_numeric).toLocaleString(undefined, { maximumFractionDigits: 2 });
+      } else if (sr.value_text) {
+        value = sr.value_text;
+      }
+      specsMap[yid][group].push({ name: sr.category_name, value, unit: sr.unit });
     }
-    specsMap[yid][group].push({ name: sr.category_name, value, unit: sr.unit });
   }
 
   // Map to DTO
@@ -235,7 +263,15 @@ export default async function EmbedComparePage({
     }),
   }));
 
+  const specFields = layout === "compact" ? SPEC_FIELDS_COMPACT : SPEC_FIELDS_FULL;
+
   return (
-    <EmbedCompareClient yachts={yachts} specFields={SPEC_FIELDS} siteUrl={siteUrl} />
+    <EmbedCompareClient
+      yachts={yachts}
+      specFields={specFields}
+      siteUrl={siteUrl}
+      layout={layout}
+      theme={theme}
+    />
   );
 }

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import EmbedConfiguratorClient from "./EmbedConfiguratorClient";
+
+export const metadata: Metadata = {
+  title: "Embed Yacht Comparison Widget | Sailing Yacht Info",
+  description:
+    "Create an embeddable yacht comparison widget for your website or blog. Choose yachts, customize layout, and get the embed code.",
+  robots: { index: true, follow: true },
+};
+
+export default function EmbedPage() {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://info.sailboats.fr";
+  return <EmbedConfiguratorClient siteUrl={siteUrl} />;
+}

--- a/tests/embed-widget.test.ts
+++ b/tests/embed-widget.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Embed URL Builder Tests ──────────────────────────────────────────
+
+describe("Embed Widget URL Builder", () => {
+  const siteUrl = "https://info.sailboats.fr";
+
+  it("builds basic embed URL with yacht IDs", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27`;
+    const params = new URL(url).searchParams;
+    expect(params.get("ids")).toBe("26,27");
+  });
+
+  it("builds compact layout embed URL", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27&layout=compact`;
+    const params = new URL(url).searchParams;
+    expect(params.get("ids")).toBe("26,27");
+    expect(params.get("layout")).toBe("compact");
+  });
+
+  it("builds full layout embed URL", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27&layout=full`;
+    const params = new URL(url).searchParams;
+    expect(params.get("layout")).toBe("full");
+  });
+
+  it("builds dark theme embed URL", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27&theme=dark`;
+    const params = new URL(url).searchParams;
+    expect(params.get("theme")).toBe("dark");
+  });
+
+  it("builds auto theme embed URL", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27&theme=auto`;
+    const params = new URL(url).searchParams;
+    expect(params.get("theme")).toBe("auto");
+  });
+
+  it("builds full URL with all options", () => {
+    const url = `${siteUrl}/embed/compare?ids=1,2,3,4&layout=compact&theme=dark`;
+    const params = new URL(url).searchParams;
+    expect(params.get("ids")).toBe("1,2,3,4");
+    expect(params.get("layout")).toBe("compact");
+    expect(params.get("theme")).toBe("dark");
+  });
+
+  it("defaults to full layout when layout param is missing", () => {
+    const url = `${siteUrl}/embed/compare?ids=26,27`;
+    const params = new URL(url).searchParams;
+    const layout = params.get("layout");
+    // Default should be "full" when not specified
+    expect(layout).toBeNull();
+  });
+});
+
+// ─── Iframe Embed Code Generation Tests ───────────────────────────────
+
+describe("Iframe Embed Code Generation", () => {
+  const siteUrl = "https://info.sailboats.fr";
+
+  it("generates valid iframe embed code with correct src", () => {
+    const ids = "26,27";
+    const layout = "compact";
+    const theme = "light";
+    const src = `${siteUrl}/embed/compare?ids=${ids}&layout=${layout}&theme=${theme}`;
+    const code = `<iframe src="${src}" width="100%" height="400" frameBorder="0"></iframe>`;
+
+    expect(code).toContain(`src="${src}"`);
+    expect(code).toContain('width="100%"');
+    expect(code).toContain('height="400"');
+    expect(code).toContain("<iframe");
+    expect(code).toContain("</iframe>");
+  });
+
+  it("uses 600px height for full layout", () => {
+    const code = `<iframe src="..." height="600"></iframe>`;
+    expect(code).toContain('height="600"');
+  });
+
+  it("uses 400px height for compact layout", () => {
+    const code = `<iframe src="..." height="400"></iframe>`;
+    expect(code).toContain('height="400"');
+  });
+});
+
+// ─── JS Embed Code Generation Tests ───────────────────────────────────
+
+describe("JS Embed Code Generation", () => {
+  it("includes auto-resize listener", () => {
+    const code = `window.addEventListener('message', function(e) {
+      if (e.data && e.data.type === 'sailing-yachts-embed' && e.data.height) {
+        iframe.height = e.data.height + 'px';
+      }
+    });`;
+
+    expect(code).toContain("sailing-yachts-embed");
+    expect(code).toContain("e.data.height");
+  });
+
+  it("creates iframe dynamically", () => {
+    const code = `var iframe = document.createElement('iframe');`;
+    expect(code).toContain("createElement('iframe')");
+  });
+
+  it("appends to target container", () => {
+    const code = `document.getElementById('sailing-yachts-widget').appendChild(iframe);`;
+    expect(code).toContain("sailing-yachts-widget");
+    expect(code).toContain("appendChild");
+  });
+});
+
+// ─── Embed Configurator Logic Tests ───────────────────────────────────
+
+describe("Embed Configurator Logic", () => {
+  it("limits yacht selection to 4", () => {
+    const MAX_YACHTS = 4;
+    const selected = [1, 2, 3, 4];
+    const canAdd = selected.length < MAX_YACHTS;
+    expect(canAdd).toBe(false);
+  });
+
+  it("allows adding when under limit", () => {
+    const MAX_YACHTS = 4;
+    const selected = [1, 2];
+    const canAdd = selected.length < MAX_YACHTS;
+    expect(canAdd).toBe(true);
+  });
+
+  it("requires minimum 2 yachts", () => {
+    const selected = [1];
+    const canGenerate = selected.length >= 2;
+    expect(canGenerate).toBe(false);
+  });
+
+  it("generates embed URL with 2 yachts", () => {
+    const selected = [
+      { id: 26, modelName: "Oceanis 40.1", manufacturer: "Beneteau" },
+      { id: 27, modelName: "C42", manufacturer: "Bavaria" },
+    ];
+    const ids = selected.map((y) => y.id).join(",");
+    expect(ids).toBe("26,27");
+  });
+
+  it("parses valid IDs from query string", () => {
+    const idsParam = "26,27,30";
+    const ids = idsParam
+      .split(",")
+      .map((id) => parseInt(id.trim(), 10))
+      .filter((id) => !isNaN(id));
+    expect(ids).toEqual([26, 27, 30]);
+  });
+
+  it("rejects invalid IDs", () => {
+    const idsParam = "26,abc,27";
+    const ids = idsParam
+      .split(",")
+      .map((id) => parseInt(id.trim(), 10))
+      .filter((id) => !isNaN(id));
+    expect(ids).toEqual([26, 27]);
+  });
+
+  it("validates yacht count between 2 and 4", () => {
+    const valid = (n: number) => n >= 2 && n <= 4;
+    expect(valid(0)).toBe(false);
+    expect(valid(1)).toBe(false);
+    expect(valid(2)).toBe(true);
+    expect(valid(3)).toBe(true);
+    expect(valid(4)).toBe(true);
+    expect(valid(5)).toBe(false);
+  });
+});
+
+// ─── PostMessage Auto-Resize Tests ────────────────────────────────────
+
+describe("PostMessage Auto-Resize Protocol", () => {
+  it("sails-yachts-embed message includes height", () => {
+    const message = { type: "sailing-yachts-embed", height: 450 };
+    expect(message.type).toBe("sailing-yachts-embed");
+    expect(message.height).toBe(450);
+    expect(typeof message.height).toBe("number");
+  });
+
+  it("handler ignores unrelated messages", () => {
+    const validMessage = { type: "sailing-yachts-embed", height: 300 };
+    const invalidMessage = { type: "other-widget", height: 300 };
+    const noTypeMessage = { height: 300 };
+
+    const isValid = (data: any) =>
+      data && data.type === "sailing-yachts-embed" && typeof data.height === "number";
+
+    expect(isValid(validMessage)).toBe(true);
+    expect(isValid(invalidMessage)).toBe(false);
+    expect(isValid(noTypeMessage)).toBe(false);
+  });
+});
+
+// ─── Theme Detection Tests ────────────────────────────────────────────
+
+describe("Theme Color Scheme", () => {
+  type ThemeMode = "light" | "dark" | "auto";
+
+  function resolveTheme(theme: ThemeMode, prefersDark: boolean): boolean {
+    if (theme === "dark") return true;
+    if (theme === "light") return false;
+    // auto
+    return prefersDark;
+  }
+
+  it("light theme always uses light colors", () => {
+    expect(resolveTheme("light", true)).toBe(false);
+    expect(resolveTheme("light", false)).toBe(false);
+  });
+
+  it("dark theme always uses dark colors", () => {
+    expect(resolveTheme("dark", true)).toBe(true);
+    expect(resolveTheme("dark", false)).toBe(true);
+  });
+
+  it("auto theme follows system preference", () => {
+    expect(resolveTheme("auto", true)).toBe(true);
+    expect(resolveTheme("auto", false)).toBe(false);
+  });
+});
+
+// ─── Layout Mode Tests ────────────────────────────────────────────────
+
+describe("Layout Mode Spec Fields", () => {
+  interface SpecField { key: string; label: string; unit?: string }
+  interface SpecGroup { group: string; fields: SpecField[] }
+
+  const COMPACT_FIELDS: SpecGroup[] = [
+    {
+      group: "Key Specs",
+      fields: [
+        { key: "lengthOverall", label: "LOA", unit: "m" },
+        { key: "beam", label: "Beam", unit: "m" },
+        { key: "draft", label: "Draft", unit: "m" },
+        { key: "displacement", label: "Displacement", unit: "kg" },
+        { key: "cabins", label: "Cabins" },
+        { key: "berths", label: "Berths" },
+      ],
+    },
+  ];
+
+  const FULL_FIELDS: SpecGroup[] = [
+    { group: "Dimensions", fields: [
+      { key: "lengthOverall", label: "LOA", unit: "m" },
+      { key: "beam", label: "Beam", unit: "m" },
+      { key: "draft", label: "Draft", unit: "m" },
+      { key: "displacement", label: "Displacement", unit: "kg" },
+      { key: "ballast", label: "Ballast", unit: "kg" },
+    ]},
+    { group: "Rig & Sails", fields: [
+      { key: "sailAreaMain", label: "Sail Area", unit: "m²" },
+      { key: "rigType", label: "Rig Type" },
+    ]},
+    { group: "Construction", fields: [
+      { key: "keelType", label: "Keel" },
+      { key: "hullMaterial", label: "Hull" },
+    ]},
+    { group: "Accommodation", fields: [
+      { key: "cabins", label: "Cabins" },
+      { key: "berths", label: "Berths" },
+      { key: "heads", label: "Heads" },
+      { key: "maxOccupancy", label: "Max Occupancy" },
+    ]},
+    { group: "Engine & Tankage", fields: [
+      { key: "engineHp", label: "Engine HP" },
+      { key: "engineType", label: "Engine Type" },
+      { key: "fuelCapacity", label: "Fuel", unit: "L" },
+      { key: "waterCapacity", label: "Water", unit: "L" },
+    ]},
+  ];
+
+  it("compact layout has fewer spec groups", () => {
+    expect(COMPACT_FIELDS.length).toBe(1);
+    expect(FULL_FIELDS.length).toBe(5);
+  });
+
+  it("compact layout has 6 fields", () => {
+    const totalFields = COMPACT_FIELDS.reduce((sum, g) => sum + g.fields.length, 0);
+    expect(totalFields).toBe(6);
+  });
+
+  it("full layout has 17 fields", () => {
+    const totalFields = FULL_FIELDS.reduce((sum, g) => sum + g.fields.length, 0);
+    expect(totalFields).toBe(17);
+  });
+
+  it("compact includes only essential specs", () => {
+    const labels = COMPACT_FIELDS.flatMap((g) => g.fields.map((f) => f.label));
+    expect(labels).toContain("LOA");
+    expect(labels).toContain("Beam");
+    expect(labels).toContain("Draft");
+    expect(labels).toContain("Cabins");
+    expect(labels).not.toContain("Engine HP");
+    expect(labels).not.toContain("Keel");
+  });
+});


### PR DESCRIPTION
- Embed configurator page at /embed with yacht search, selection, and live preview
- Compact layout mode (6 key specs, ~400px height) vs full layout (17+ specs)
- Light/dark/auto theme support for embedded widgets
- Copy-paste embed code generation (iframe + JavaScript auto-resize snippet)
- URL parameter configuration: ?ids=X,Y&layout=compact&theme=dark
- PostMessage auto-resize protocol for JS embed
- 29 unit tests for URL building, embed code gen, theme detection, layout modes
