### PR TITLE
fix: force-dynamic for featured API routes

### DIFF
--- a/app/api/admin/featured/route.ts
+++ b/app/api/admin/featured/route.ts
@@ -8,6 +8,8 @@ import {
   markNewsletterSent,
 } from "@/lib/featured-yacht-service";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     await ensureSchema();

--- a/app/api/featured/route.ts
+++ b/app/api/featured/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getActiveFeaturedYacht, getRecentFeaturedYachts } from "@/lib/featured-yacht-service";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     const [active, recent] = await Promise.all([


### PR DESCRIPTION
Prevents static prerendering of /api/featured and /api/admin/featured
which caused 404 on Vercel (no DATABASE_URL at build time).
