### PR TITLE
feat: user behavior analytics dashboard (closes #388)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -78,15 +78,15 @@
 - **P22.4 — Bundle size optimization** *(completed 2026-05-29 — Issue #350, PR #351, 38 tests)* — Lazy-loaded 15+ below-the-fold components, reducing /yachts/[slug] First Load by 11%, /compare by 21%.
 - **P22.5 — Core Web Vitals monitoring** *(completed 2026-05-29 — Issue #352, PR #353, 13 tests)* — Admin dashboard at /admin/vitals with real-time CWV stats, Sentry integration for poor metric alerting, server-side poor metric logging.
 
-### Phase 23 — Social Engagement & Virality (Priority: Medium) — 🔲 ACTIVE
+### Phase 23 — Social Engagement & Virality (Priority: Medium) — ✅ COMPLETE
 
 - **P23.1 — Yacht rating system with star ratings** *(completed 2026-06-04 — Issue #379, PR #380, 13 tests)* — 5-star rating widget with live data fetching, distribution chart, JSON-LD AggregateRating, i18n.
 - **P23.2 — Comparison sharing with persistent URLs** *(completed 2026-06-03 — Issue #377, PR #378, 19 tests)* — Generate shareable comparison URLs (e.g., /compare/beneteau-oceanis-40-1-vs-bavaria-c42). Save comparison configurations server-side. OG images for shared comparisons. Social meta tags for comparison pages.
 - **P23.3 — "Email this yacht" feature** *(completed 2026-06-04 — Issue #381, PR #382, 45 tests)* — Send yacht details via email to a friend. Simple form with recipient email, optional message. Server-side email template with yacht specs and image. Rate-limited to prevent abuse.
 - **P23.4 — Embeddable yacht comparison widget** *(completed 2026-06-05 — Issue #383, PR #384, 29 tests)* — Configurator page at /embed with yacht search/selection. Compact (6 specs) and full (17+ specs) layouts. Light/dark/auto themes. Copy-paste embed code (iframe + JS auto-resize). PostMessage auto-resize protocol. Frame-ancestors CSP allows third-party embedding.
-- **P23.5 — Yacht of the week / featured rotation** — Admin-configurable featured yacht shown on homepage. Weekly rotation with manual override. Newsletter integration to announce featured yacht. Landing page at /yacht-of-the-week.
+- ~~**P23.5 — Yacht of the week / featured rotation**~~ *(completed 2026-06-05 — Issue #385, PR #386, 27 tests)* — Admin-configurable featured yacht shown on homepage. Weekly rotation with manual override. Newsletter integration to announce featured yacht. Landing page at /yacht-of-the-week.
 
-### Phase 24 — Advanced Analytics & Intelligence (Priority: Medium) — 🔲 PLANNED
+### Phase 24 — Advanced Analytics & Intelligence (Priority: Medium) — 🔲 ACTIVE
 
 - **P24.1 — User behavior tracking dashboard** — Admin dashboard showing page views, popular yachts, search trends, comparison patterns. Aggregate anonymized analytics. Charts for daily/weekly/monthly trends.
 - **P24.2 — A/B testing framework** — Implement server-side A/B test assignment (infrastructure exists in ab-testing.ts). Admin dashboard for managing experiments. Statistical significance calculator. Feature flag integration.

--- a/app/[locale]/compare/CompareClient.tsx
+++ b/app/[locale]/compare/CompareClient.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 // Lazy-loaded for bundle optimization (P22.4)
 // Lazy-loaded for bundle optimization (P22.4)
 import dynamic from "next/dynamic";
+import { trackCompare } from "@/lib/analytics-tracker";
 const ComparisonRadarChart = dynamic(
   () => import("@/components/comparison-radar-chart").then(m => ({ default: m.ComparisonRadarChart })),
   { ssr: false, loading: () => null },
@@ -305,7 +306,18 @@ export function CompareClient({ initialIds }: CompareClientProps) {
     setError(null);
     fetch(`/api/compare?ids=${selectedIds.join(',')}`)
       .then(res => res.ok ? res.json() : Promise.reject(new Error('Failed to fetch')))
-      .then(data => { setYachts(data.yachts || []); setLoading(false); })
+      .then(data => {
+        const fetched = data.yachts || [];
+        setYachts(fetched);
+        setLoading(false);
+        // Track comparison for analytics
+        if (fetched.length >= 2) {
+          try { trackCompare({
+            yachtIds: fetched.map((y: any) => y.id),
+            yachtNames: fetched.map((y: any) => y.manufacturer + " " + y.modelName),
+          }); } catch {}
+        }
+      })
       .catch(err => { setError(err.message); setLoading(false); });
   }, [selectedIds]);
 

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { locales, type Locale } from "@/i18n";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { ClientNav } from "./ClientNav";
 import UXPolish from "@/components/UXPolish";
+import AnalyticsPageTracker from "@/components/AnalyticsPageTracker";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -113,6 +114,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
         </div>
       </footer>
       <UXPolish />
+      <AnalyticsPageTracker />
     </NextIntlClientProvider>
   );
 }

--- a/app/[locale]/search/SearchClient.tsx
+++ b/app/[locale]/search/SearchClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { useTranslations, useLocale } from "next-intl";
 import { localePath } from "@/lib/i18n-paths";
+import { trackSearch } from "@/lib/analytics-tracker";
 
 interface SearchResult {
   id: number;
@@ -126,6 +127,8 @@ export function SearchClient() {
         const data = await res.json();
         setResults(data.yachts || []);
         setTotal(data.total || 0);
+        // Track search for analytics
+        try { trackSearch({ query: q, resultCount: data.total || 0 }); } catch {}
       } catch {
         setResults([]);
         setTotal(0);

--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -22,6 +22,7 @@ import TableOfContents from "@/components/TableOfContents";
 import dynamic from "next/dynamic";
 import { localePath } from "@/lib/i18n-paths";
 import { calculateCompletenessScore } from "@/lib/completeness";
+import { trackYachtView } from "@/lib/analytics-tracker";
 
 // Lazy-loaded below-the-fold components for bundle optimization (P22.4)
 const SocialShareButtons = dynamic(() => import("@/components/SocialShareButtons").then(m => ({ default: m.default })), {
@@ -292,7 +293,11 @@ export default function YachtDetailClient() {
         if (!r.ok) throw new Error(t("notFound.heading"));
         return r.json();
       })
-      .then((data) => setYacht(data))
+      .then((data) => {
+        setYacht(data);
+        // Track yacht view for analytics
+        try { trackYachtView({ yachtId: data.id, yachtSlug: slug, yachtName: data.modelName, manufacturerName: data.manufacturer }); } catch {}
+      })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [slug, t]);

--- a/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/app/admin/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,641 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+interface AnalyticsSummary {
+  totalPageViews: number;
+  uniqueSessions: number;
+  totalSearches: number;
+  totalComparisons: number;
+  totalYachtViews: number;
+  avgSessionLength: number;
+  bounceRate: number;
+}
+
+interface TrendDataPoint {
+  date: string;
+  count: number;
+}
+
+interface PopularYacht {
+  yachtModelId: number;
+  modelName: string;
+  manufacturerName: string;
+  viewCount: number;
+}
+
+interface PopularSearch {
+  query: string;
+  count: number;
+  resultCount: number | null;
+  lastSearched: string;
+}
+
+interface ComparisonPattern {
+  yachtIds: number[];
+  yachtNames: string[];
+  count: number;
+}
+
+interface PageViewBreakdown {
+  page: string;
+  views: number;
+  uniqueViews: number;
+}
+
+interface TopReferrer {
+  referrer: string;
+  count: number;
+}
+
+interface EventCount {
+  eventType: string;
+  count: number;
+}
+
+interface AnalyticsData {
+  summary: AnalyticsSummary;
+  trends: {
+    pageViews: TrendDataPoint[];
+    searches: TrendDataPoint[];
+    comparisons: TrendDataPoint[];
+    yachtViews: TrendDataPoint[];
+  };
+  popularYachts: PopularYacht[];
+  popularSearches: PopularSearch[];
+  comparisons: ComparisonPattern[];
+  pageBreakdown: PageViewBreakdown[];
+  topReferrers: TopReferrer[];
+  eventCounts: EventCount[];
+  period: { days: number };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function truncateUrl(url: string, max = 50): string {
+  if (url.length <= max) return url;
+  return url.slice(0, max - 3) + "...";
+}
+
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+// ─── Simple SVG Chart Components ──────────────────────────────────
+
+function MiniSparkline({ data, color = "#3b82f6", height = 40 }: { data: TrendDataPoint[]; color?: string; height?: number }) {
+  if (data.length < 2) return <span className="text-gray-400 text-sm">No data yet</span>;
+
+  const values = data.map((d) => d.count);
+  const max = Math.max(...values, 1);
+  const width = 200;
+  const padding = 2;
+
+  const points = values
+    .map((v, i) => {
+      const x = padding + (i / (values.length - 1)) * (width - padding * 2);
+      const y = height - padding - (v / max) * (height - padding * 2);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  const areaPoints = `${padding},${height - padding} ${points} ${width - padding},${height - padding}`;
+
+  return (
+    <svg width={width} height={height} className="inline-block">
+      <polygon points={areaPoints} fill={color} opacity={0.15} />
+      <polyline points={points} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function BarChart({ data, maxBars = 15, height = 200, color = "#3b82f6" }: {
+  data: { label: string; value: number }[];
+  maxBars?: number;
+  height?: number;
+  color?: string;
+}) {
+  if (data.length === 0)
+    return (
+      <div className="flex items-center justify-center text-gray-400" style={{ height }}>
+        No data yet — tracking starts when users visit the site
+      </div>
+    );
+
+  const bars = data.slice(0, maxBars);
+  const max = Math.max(...bars.map((b) => b.value), 1);
+  const barWidth = Math.max(8, Math.min(40, 600 / bars.length - 4));
+
+  return (
+    <div className="flex items-end gap-1 justify-center" style={{ height }}>
+      {bars.map((bar, i) => {
+        const barHeight = Math.max(2, (bar.value / max) * (height - 40));
+        return (
+          <div key={i} className="flex flex-col items-center gap-1" title={`${bar.label}: ${bar.value}`}>
+            <span className="text-xs text-gray-500">{formatNumber(bar.value)}</span>
+            <div
+              style={{
+                width: barWidth,
+                height: barHeight,
+                backgroundColor: color,
+                borderRadius: 3,
+                minWidth: 8,
+              }}
+            />
+            <span
+              className="text-xs text-gray-400 truncate"
+              style={{ maxWidth: barWidth + 8, writingMode: bars.length > 10 ? "vertical-rl" : undefined }}
+            >
+              {bar.label.length > 6 ? bar.label.slice(0, 5) + "…" : bar.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Period Selector ──────────────────────────────────────────────
+
+function PeriodSelector({ value, onChange }: { value: number; onChange: (d: number) => void }) {
+  const periods = [
+    { days: 7, label: "7 days" },
+    { days: 14, label: "14 days" },
+    { days: 30, label: "30 days" },
+    { days: 90, label: "90 days" },
+  ];
+
+  return (
+    <div className="flex gap-2">
+      {periods.map((p) => (
+        <button
+          key={p.days}
+          onClick={() => onChange(p.days)}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            value === p.days
+              ? "bg-blue-600 text-white"
+              : "bg-white text-gray-600 border border-gray-300 hover:bg-gray-50"
+          }`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Main Dashboard ──────────────────────────────────────────────
+
+export default function AnalyticsDashboard() {
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [period, setPeriod] = useState(30);
+
+  const fetchData = useCallback(async (days: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/analytics?days=${days}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setData(json);
+    } catch (err: any) {
+      setError(err.message || "Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(period);
+  }, [period, fetchData]);
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-red-700">
+        <h3 className="font-semibold mb-2">Error loading analytics</h3>
+        <p>{error}</p>
+        <button
+          onClick={() => fetchData(period)}
+          className="mt-3 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, trends, popularYachts, popularSearches, comparisons, pageBreakdown, topReferrers, eventCounts } = data;
+
+  return (
+    <div className="space-y-8">
+      {/* Period selector */}
+      <div className="flex items-center justify-between">
+        <PeriodSelector value={period} onChange={setPeriod} />
+        <button
+          onClick={() => fetchData(period)}
+          className="px-4 py-1.5 bg-white border border-gray-300 rounded-md text-sm text-gray-600 hover:bg-gray-50"
+        >
+          ↻ Refresh
+        </button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <SummaryCard
+          title="Page Views"
+          value={summary.totalPageViews}
+          sparkline={trends.pageViews}
+          color="#3b82f6"
+        />
+        <SummaryCard
+          title="Unique Sessions"
+          value={summary.uniqueSessions}
+          color="#8b5cf6"
+        />
+        <SummaryCard
+          title="Yacht Views"
+          value={summary.totalYachtViews}
+          sparkline={trends.yachtViews}
+          color="#10b981"
+        />
+        <SummaryCard
+          title="Searches"
+          value={summary.totalSearches}
+          sparkline={trends.searches}
+          color="#f59e0b"
+        />
+        <SummaryCard
+          title="Comparisons"
+          value={summary.totalComparisons}
+          sparkline={trends.comparisons}
+          color="#ef4444"
+        />
+      </div>
+
+      {/* Trend Chart */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">Daily Trends</h2>
+        {trends.pageViews.length > 0 ? (
+          <div className="space-y-4">
+            <TrendMultiChart trends={trends} />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-40 text-gray-400">
+            No trend data yet — tracking starts when users visit the site
+          </div>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Popular Yachts */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Popular Yachts</h2>
+          {popularYachts.length > 0 ? (
+            <div className="space-y-3">
+              {popularYachts.map((yacht, i) => (
+                <div key={yacht.yachtModelId} className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
+                      i < 3 ? "bg-blue-100 text-blue-700" : "bg-gray-100 text-gray-500"
+                    }`}>
+                      {i + 1}
+                    </span>
+                    <div>
+                      <a
+                        href={`/yachts/${yacht.modelName.toLowerCase().replace(/\s+/g, "-")}`}
+                        className="text-sm font-medium text-gray-800 hover:text-blue-600"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {yacht.modelName}
+                      </a>
+                      <p className="text-xs text-gray-400">{yacht.manufacturerName}</p>
+                    </div>
+                  </div>
+                  <span className="text-sm font-semibold text-gray-600">
+                    {formatNumber(yacht.viewCount)} views
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No yacht views recorded yet</p>
+          )}
+        </div>
+
+        {/* Popular Searches */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Popular Searches</h2>
+          {popularSearches.length > 0 ? (
+            <div className="space-y-3">
+              {popularSearches.map((search, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="w-6 h-6 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-xs font-bold">
+                      {i + 1}
+                    </span>
+                    <div>
+                      <span className="text-sm font-medium text-gray-800">&ldquo;{search.query}&rdquo;</span>
+                      {search.resultCount !== null && (
+                        <p className="text-xs text-gray-400">
+                          {search.resultCount} results
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <span className="text-sm font-semibold text-gray-600">
+                    {formatNumber(search.count)}×
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No searches recorded yet</p>
+          )}
+        </div>
+
+        {/* Comparison Patterns */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Top Comparisons</h2>
+          {comparisons.length > 0 ? (
+            <div className="space-y-3">
+              {comparisons.map((comp, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="w-6 h-6 rounded-full bg-red-100 text-red-700 flex items-center justify-center text-xs font-bold">
+                      {i + 1}
+                    </span>
+                    <span className="text-sm text-gray-700">
+                      {comp.yachtNames.length > 0
+                        ? comp.yachtNames.join(" vs ")
+                        : `${comp.yachtIds.length} yachts`}
+                    </span>
+                  </div>
+                  <span className="text-sm font-semibold text-gray-600">
+                    {comp.count}×
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No comparisons recorded yet</p>
+          )}
+        </div>
+
+        {/* Page Breakdown */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Page Views Breakdown</h2>
+          {pageBreakdown.length > 0 ? (
+            <div className="space-y-2">
+              {pageBreakdown.slice(0, 12).map((page, i) => {
+                const maxViews = pageBreakdown[0]?.views || 1;
+                const pct = (page.views / maxViews) * 100;
+                return (
+                  <div key={i} className="flex items-center gap-3">
+                    <span className="text-xs text-gray-500 w-36 truncate" title={page.page}>
+                      {truncateUrl(page.page, 24)}
+                    </span>
+                    <div className="flex-1 bg-gray-100 rounded-full h-4 relative overflow-hidden">
+                      <div
+                        className="h-full bg-blue-500 rounded-full"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-gray-600 font-medium w-12 text-right">
+                      {formatNumber(page.views)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No page views recorded yet</p>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Event Counts */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Event Distribution</h2>
+          {eventCounts.length > 0 ? (
+            <div className="space-y-2">
+              {eventCounts.map((ec, i) => {
+                const maxCount = eventCounts[0]?.count || 1;
+                const pct = (ec.count / maxCount) * 100;
+                const colors: Record<string, string> = {
+                  page_view: "bg-blue-500",
+                  yacht_view: "bg-green-500",
+                  search: "bg-amber-500",
+                  compare: "bg-red-500",
+                  manufacturer_view: "bg-purple-500",
+                  guide_view: "bg-teal-500",
+                  cta_click: "bg-orange-500",
+                  share: "bg-pink-500",
+                  filter_use: "bg-indigo-500",
+                  rating: "bg-yellow-500",
+                };
+                return (
+                  <div key={i} className="flex items-center gap-3">
+                    <span className="text-xs text-gray-500 w-32">
+                      {ec.eventType.replace(/_/g, " ")}
+                    </span>
+                    <div className="flex-1 bg-gray-100 rounded-full h-4 relative overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${colors[ec.eventType] || "bg-gray-400"}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-gray-600 font-medium w-12 text-right">
+                      {formatNumber(ec.count)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No events recorded yet</p>
+          )}
+        </div>
+
+        {/* Top Referrers */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Top Referrers</h2>
+          {topReferrers.length > 0 ? (
+            <div className="space-y-3">
+              {topReferrers.map((ref, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <span className="text-sm text-gray-700 truncate max-w-[70%]" title={ref.referrer}>
+                    {extractDomain(ref.referrer)}
+                  </span>
+                  <span className="text-sm font-semibold text-gray-600">
+                    {formatNumber(ref.count)} visits
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-400 text-sm">No referrer data yet</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-Components ──────────────────────────────────────────────
+
+function SummaryCard({
+  title,
+  value,
+  sparkline,
+  color,
+}: {
+  title: string;
+  value: number;
+  sparkline?: TrendDataPoint[];
+  color: string;
+}) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">{title}</p>
+      <p className="text-2xl font-bold text-gray-800 mt-1">{formatNumber(value)}</p>
+      {sparkline && sparkline.length > 1 && (
+        <div className="mt-2">
+          <MiniSparkline data={sparkline} color={color} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TrendMultiChart({
+  trends,
+}: {
+  trends: AnalyticsData["trends"];
+}) {
+  // Merge all dates and create a unified chart
+  const allDates = new Set<string>();
+  for (const key of ["pageViews", "searches", "comparisons", "yachtViews"] as const) {
+    trends[key].forEach((d) => allDates.add(d.date));
+  }
+
+  const sortedDates = [...allDates].sort();
+  if (sortedDates.length === 0) return null;
+
+  const maxVal = Math.max(
+    ...trends.pageViews.map((d) => d.count),
+    ...trends.searches.map((d) => d.count),
+    ...trends.comparisons.map((d) => d.count),
+    ...trends.yachtViews.map((d) => d.count),
+    1,
+  );
+
+  const height = 200;
+  const width = 700;
+  const padX = 50;
+  const padY = 20;
+  const chartW = width - padX;
+  const chartH = height - padY * 2;
+
+  function toPoints(data: TrendDataPoint[]): string {
+    return sortedDates
+      .map((date, i) => {
+        const point = data.find((d) => d.date === date);
+        const count = point?.count || 0;
+        const x = padX + (i / Math.max(sortedDates.length - 1, 1)) * chartW;
+        const y = padY + chartH - (count / maxVal) * chartH;
+        return `${x},${y}`;
+      })
+      .join(" ");
+  }
+
+  const legend = [
+    { label: "Page Views", color: "#3b82f6", key: "pageViews" as const },
+    { label: "Yacht Views", color: "#10b981", key: "yachtViews" as const },
+    { label: "Searches", color: "#f59e0b", key: "searches" as const },
+    { label: "Comparisons", color: "#ef4444", key: "comparisons" as const },
+  ];
+
+  return (
+    <div>
+      {/* Legend */}
+      <div className="flex gap-4 mb-3">
+        {legend.map((item) => (
+          <div key={item.key} className="flex items-center gap-1.5">
+            <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
+            <span className="text-xs text-gray-500">{item.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* SVG Chart */}
+      <svg width="100%" viewBox={`0 0 ${width} ${height}`} className="overflow-visible">
+        {/* Grid lines */}
+        {[0, 0.25, 0.5, 0.75, 1].map((pct) => {
+          const y = padY + chartH * (1 - pct);
+          const val = Math.round(maxVal * pct);
+          return (
+            <g key={pct}>
+              <line x1={padX} y1={y} x2={width} y2={y} stroke="#f3f4f6" strokeWidth={1} />
+              <text x={padX - 5} y={y + 4} textAnchor="end" className="text-xs fill-gray-400">
+                {formatNumber(val)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Lines */}
+        {legend.map((item) => (
+          <polyline
+            key={item.key}
+            points={toPoints(trends[item.key])}
+            fill="none"
+            stroke={item.color}
+            strokeWidth={2}
+            strokeLinejoin="round"
+          />
+        ))}
+
+        {/* X-axis labels (every Nth date) */}
+        {sortedDates
+          .filter((_, i) => i % Math.max(1, Math.floor(sortedDates.length / 8)) === 0)
+          .map((date, i, arr) => {
+            const idx = sortedDates.indexOf(date);
+            const x = padX + (idx / Math.max(sortedDates.length - 1, 1)) * chartW;
+            return (
+              <text key={date} x={x} y={height - 2} textAnchor="middle" className="text-xs fill-gray-400">
+                {date.slice(5)}
+              </text>
+            );
+          })}
+      </svg>
+    </div>
+  );
+}

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,35 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import AnalyticsDashboard from "./AnalyticsDashboard";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Analytics Dashboard - Admin" };
+
+export default async function AnalyticsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    redirect("/admin");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <a href="/admin" className="text-blue-600 hover:underline text-sm">
+              ← Back to Dashboard
+            </a>
+            <h1 className="text-3xl font-bold text-gray-900 mt-2">
+              User Behavior Analytics
+            </h1>
+            <p className="text-gray-500 mt-1">
+              Page views, popular yachts, search trends &amp; comparison patterns — anonymized aggregate data
+            </p>
+          </div>
+        </div>
+        <AnalyticsDashboard />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -167,6 +167,17 @@ export default async function AdminPage() {
                 Manage Featured
               </a>
             </div>
+
+            <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Analytics</h2>
+              <p className="text-gray-600 mb-4">User behavior tracking: page views, popular yachts, search trends, comparison patterns, and more.</p>
+              <a
+                href="/admin/analytics"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                View Analytics
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminAnalyticsDashboard } from "@/lib/analytics-service";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/analytics — Get full analytics data for the admin dashboard.
+ *
+ * Query params:
+ *   days: number (default 30) — lookback period in days
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const days = parseInt(
+      request.nextUrl.searchParams.get("days") || "30",
+      10,
+    );
+    const clampedDays = Math.max(1, Math.min(365, days));
+
+    const data = await getAdminAnalyticsDashboard(clampedDays);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("[admin/analytics] Error fetching analytics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch analytics" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { insertAnalyticsEvents } from "@/lib/analytics-service";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/analytics — Collect batched analytics events from the client.
+ *
+ * Accepts an array of events and inserts them into the database.
+ * Rate-limited to 50 events per batch. Silently fails to avoid breaking UX.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json();
+    const events = body.events;
+
+    if (!Array.isArray(events) || events.length === 0) {
+      return NextResponse.json(
+        { error: "No events provided" },
+        { status: 400 },
+      );
+    }
+
+    // Limit batch size
+    const batch = events.slice(0, 50);
+
+    const processed = await insertAnalyticsEvents(
+      batch.map((e: any) => ({
+        eventType: e.eventType,
+        page: e.page || "/",
+        entityId: e.entityId,
+        entityType: e.entityType,
+        sessionId: e.sessionId || "unknown",
+        metadata: e.metadata,
+        referrer: e.referrer,
+        userAgent: undefined, // Don't store user agents from client for privacy
+      })),
+    );
+
+    return NextResponse.json({ success: true, processed });
+  } catch (error: any) {
+    // If table doesn't exist yet, log to console instead of failing
+    if (error?.message?.includes("analytics_events")) {
+      console.log("[analytics] Table not found, skipping events");
+      return NextResponse.json({
+        success: true,
+        processed: 0,
+        fallback: true,
+      });
+    }
+
+    console.error("[analytics] Error processing events:", error);
+    return NextResponse.json(
+      { error: "Failed to process events" },
+      { status: 500 },
+    );
+  }
+}

--- a/components/AnalyticsPageTracker.tsx
+++ b/components/AnalyticsPageTracker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { trackPageView } from "@/lib/analytics-tracker";
+
+/**
+ * Automatically tracks page views on route changes.
+ * Include once in the root layout.
+ */
+export default function AnalyticsPageTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Skip admin and API routes
+    if (pathname.startsWith("/admin") || pathname.startsWith("/api")) return;
+
+    // Small delay to ensure page is loaded
+    const timer = setTimeout(() => {
+      try {
+        trackPageView({ page: pathname });
+      } catch {
+        // Silently fail — analytics should never break UX
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [pathname]);
+
+  return null;
+}

--- a/drizzle/migrations/0022_analytics_events.sql
+++ b/drizzle/migrations/0022_analytics_events.sql
@@ -1,0 +1,21 @@
+-- P24.1: Analytics events table for user behavior tracking
+CREATE TABLE IF NOT EXISTS analytics_events (
+  id SERIAL PRIMARY KEY,
+  event_type VARCHAR(50) NOT NULL,
+  page VARCHAR(500) NOT NULL,
+  entity_id INTEGER,
+  entity_type VARCHAR(50),
+  session_id VARCHAR(100) NOT NULL,
+  metadata JSONB,
+  referrer VARCHAR(500),
+  user_agent VARCHAR(500),
+  country VARCHAR(2),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_analytics_events_type ON analytics_events (event_type);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_created ON analytics_events (created_at);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_session ON analytics_events (session_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_page ON analytics_events (page);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_entity ON analytics_events (entity_type, entity_id);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1052,3 +1052,31 @@ export const featuredYachts = pgTable(
 
 export const insertFeaturedYachtSchema = createInsertSchema(featuredYachts);
 export const selectFeaturedYachtSchema = createSelectSchema(featuredYachts);
+
+// P24.1: Analytics events (page views, searches, comparisons, interactions)
+export const analyticsEvents = pgTable(
+  "analytics_events",
+  {
+    id: serial("id").primaryKey(),
+    eventType: varchar("event_type", { length: 50 }).notNull(), // 'page_view', 'search', 'compare', 'yacht_view', 'manufacturer_view', 'guide_view', 'cta_click', 'share', 'filter_use'
+    page: varchar("page", { length: 500 }).notNull(),
+    entityId: integer("entity_id"), // yacht_model_id, manufacturer_id, etc.
+    entityType: varchar("entity_type", { length: 50 }), // 'yacht', 'manufacturer', 'guide', 'comparison'
+    sessionId: varchar("session_id", { length: 100 }).notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    referrer: varchar("referrer", { length: 500 }),
+    userAgent: varchar("user_agent", { length: 500 }),
+    country: varchar("country", { length: 2 }), // ISO country code
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    idxEventType: index("idx_analytics_events_type").on(table.eventType),
+    idxCreatedAt: index("idx_analytics_events_created").on(table.createdAt),
+    idxSessionId: index("idx_analytics_events_session").on(table.sessionId),
+    idxPage: index("idx_analytics_events_page").on(table.page),
+    idxEntity: index("idx_analytics_events_entity").on(table.entityType, table.entityId),
+  }),
+);
+
+export const insertAnalyticsEventSchema = createInsertSchema(analyticsEvents);
+export const selectAnalyticsEventSchema = createSelectSchema(analyticsEvents);

--- a/lib/analytics-service.ts
+++ b/lib/analytics-service.ts
@@ -1,0 +1,461 @@
+/**
+ * P24.1 — Analytics Service
+ *
+ * Server-side analytics service for querying aggregated analytics data.
+ * Tracks page views, popular yachts, search trends, comparison patterns.
+ * All data is aggregated and anonymized — no PII stored.
+ */
+
+import { pool } from "./db";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export type AnalyticsEventType =
+  | "page_view"
+  | "search"
+  | "compare"
+  | "yacht_view"
+  | "manufacturer_view"
+  | "guide_view"
+  | "cta_click"
+  | "share"
+  | "filter_use"
+  | "rating"
+  | "email_yacht"
+  | "featured_view";
+
+export interface AnalyticsEventInput {
+  eventType: AnalyticsEventType;
+  page: string;
+  entityId?: number;
+  entityType?: "yacht" | "manufacturer" | "guide" | "comparison";
+  sessionId: string;
+  metadata?: Record<string, unknown>;
+  referrer?: string;
+  userAgent?: string;
+  country?: string;
+}
+
+export interface AnalyticsSummary {
+  totalPageViews: number;
+  uniqueSessions: number;
+  totalSearches: number;
+  totalComparisons: number;
+  totalYachtViews: number;
+  avgSessionLength: number;
+  bounceRate: number;
+}
+
+export interface TrendDataPoint {
+  date: string;
+  count: number;
+}
+
+export interface PopularYacht {
+  yachtModelId: number;
+  modelName: string;
+  manufacturerName: string;
+  viewCount: number;
+}
+
+export interface PopularSearch {
+  query: string;
+  count: number;
+  resultCount: number | null;
+  lastSearched: string;
+}
+
+export interface ComparisonPattern {
+  yachtIds: number[];
+  yachtNames: string[];
+  count: number;
+}
+
+export interface PageViewBreakdown {
+  page: string;
+  views: number;
+  uniqueViews: number;
+}
+
+// ─── Event Insertion ──────────────────────────────────────────────
+
+/**
+ * Insert a batch of analytics events.
+ */
+export async function insertAnalyticsEvents(
+  events: AnalyticsEventInput[],
+): Promise<number> {
+  if (events.length === 0) return 0;
+
+  const values: unknown[] = [];
+  const placeholders: string[] = [];
+  let paramIdx = 1;
+
+  for (const event of events) {
+    placeholders.push(
+      `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7})`,
+    );
+    values.push(
+      event.eventType,
+      event.page,
+      event.entityId ?? null,
+      event.entityType ?? null,
+      event.sessionId,
+      event.metadata ? JSON.stringify(event.metadata) : null,
+      event.referrer ?? null,
+      event.userAgent ?? null,
+    );
+    paramIdx += 8;
+  }
+
+  const result = await pool.query(
+    `INSERT INTO analytics_events (event_type, page, entity_id, entity_type, session_id, metadata, referrer, user_agent)
+     VALUES ${placeholders.join(", ")}`,
+    values,
+  );
+
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Insert a single analytics event.
+ */
+export async function insertAnalyticsEvent(
+  event: AnalyticsEventInput,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO analytics_events (event_type, page, entity_id, entity_type, session_id, metadata, referrer, user_agent)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    [
+      event.eventType,
+      event.page,
+      event.entityId ?? null,
+      event.entityType ?? null,
+      event.sessionId,
+      event.metadata ? JSON.stringify(event.metadata) : null,
+      event.referrer ?? null,
+      event.userAgent ?? null,
+    ],
+  );
+}
+
+// ─── Query Functions ──────────────────────────────────────────────
+
+/**
+ * Get overall analytics summary for a time period.
+ */
+export async function getAnalyticsSummary(
+  days: number = 30,
+): Promise<AnalyticsSummary> {
+  const interval = `${days} days`;
+
+  const [viewsRes, sessionsRes, searchesRes, comparisonsRes, yachtViewsRes] =
+    await Promise.all([
+      pool.query(
+        `SELECT COUNT(*) as count FROM analytics_events WHERE event_type = 'page_view' AND created_at > NOW() - INTERVAL '${interval}'`,
+      ),
+      pool.query(
+        `SELECT COUNT(DISTINCT session_id) as count FROM analytics_events WHERE created_at > NOW() - INTERVAL '${interval}'`,
+      ),
+      pool.query(
+        `SELECT COUNT(*) as count FROM analytics_events WHERE event_type = 'search' AND created_at > NOW() - INTERVAL '${interval}'`,
+      ),
+      pool.query(
+        `SELECT COUNT(*) as count FROM analytics_events WHERE event_type = 'compare' AND created_at > NOW() - INTERVAL '${interval}'`,
+      ),
+      pool.query(
+        `SELECT COUNT(*) as count FROM analytics_events WHERE event_type = 'yacht_view' AND created_at > NOW() - INTERVAL '${interval}'`,
+      ),
+    ]);
+
+  return {
+    totalPageViews: parseInt(viewsRes.rows[0]?.count || "0", 10),
+    uniqueSessions: parseInt(sessionsRes.rows[0]?.count || "0", 10),
+    totalSearches: parseInt(searchesRes.rows[0]?.count || "0", 10),
+    totalComparisons: parseInt(comparisonsRes.rows[0]?.count || "0", 10),
+    totalYachtViews: parseInt(yachtViewsRes.rows[0]?.count || "0", 10),
+    avgSessionLength: 0,
+    bounceRate: 0,
+  };
+}
+
+/**
+ * Get daily trend data for a given event type.
+ */
+export async function getEventTrend(
+  eventType: AnalyticsEventType | "all",
+  days: number = 30,
+): Promise<TrendDataPoint[]> {
+  const interval = `${days} days`;
+  const typeFilter =
+    eventType === "all" ? "" : `AND event_type = '${eventType}'`;
+
+  const result = await pool.query(
+    `SELECT DATE(created_at) as date, COUNT(*) as count
+     FROM analytics_events
+     WHERE created_at > NOW() - INTERVAL '${interval}' ${typeFilter}
+     GROUP BY DATE(created_at)
+     ORDER BY date ASC`,
+  );
+
+  return result.rows.map((row) => ({
+    date: row.date,
+    count: parseInt(row.count, 10),
+  }));
+}
+
+/**
+ * Get multi-metric trend data (page views, searches, comparisons) in one query.
+ */
+export async function getMultiMetricTrend(
+  days: number = 30,
+): Promise<
+  Record<"pageViews" | "searches" | "comparisons" | "yachtViews", TrendDataPoint[]>
+> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT DATE(created_at) as date, event_type, COUNT(*) as count
+     FROM analytics_events
+     WHERE created_at > NOW() - INTERVAL '${interval}'
+       AND event_type IN ('page_view', 'search', 'compare', 'yacht_view')
+     GROUP BY DATE(created_at), event_type
+     ORDER BY date ASC`,
+  );
+
+  const data: Record<string, TrendDataPoint[]> = {
+    pageViews: [],
+    searches: [],
+    comparisons: [],
+    yachtViews: [],
+  };
+
+  for (const row of result.rows) {
+    const point = { date: row.date, count: parseInt(row.count, 10) };
+    switch (row.event_type) {
+      case "page_view":
+        data.pageViews.push(point);
+        break;
+      case "search":
+        data.searches.push(point);
+        break;
+      case "compare":
+        data.comparisons.push(point);
+        break;
+      case "yacht_view":
+        data.yachtViews.push(point);
+        break;
+    }
+  }
+
+  return data as Record<
+    "pageViews" | "searches" | "comparisons" | "yachtViews",
+    TrendDataPoint[]
+  >;
+}
+
+/**
+ * Get most popular yachts by view count.
+ */
+export async function getPopularYachts(
+  days: number = 30,
+  limit: number = 10,
+): Promise<PopularYacht[]> {
+  const result = await pool.query(
+    `SELECT
+       ae.entity_id as yacht_model_id,
+       ym.model_name,
+       m.name as manufacturer_name,
+       COUNT(*) as view_count
+     FROM analytics_events ae
+     LEFT JOIN yacht_models ym ON ae.entity_id = ym.id
+     LEFT JOIN manufacturers m ON ym.manufacturer_id = m.id
+     WHERE ae.event_type = 'yacht_view'
+       AND ae.created_at > NOW() - INTERVAL '${days} days'
+     GROUP BY ae.entity_id, ym.model_name, m.name
+     ORDER BY view_count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    yachtModelId: row.yacht_model_id,
+    modelName: row.model_name || "Unknown",
+    manufacturerName: row.manufacturer_name || "Unknown",
+    viewCount: parseInt(row.view_count, 10),
+  }));
+}
+
+/**
+ * Get popular search queries.
+ */
+export async function getPopularSearches(
+  days: number = 30,
+  limit: number = 20,
+): Promise<PopularSearch[]> {
+  const result = await pool.query(
+    `SELECT
+       metadata->>'query' as query,
+       COUNT(*) as count,
+       metadata->>'resultCount' as result_count,
+       MAX(created_at) as last_searched
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${days} days'
+       AND metadata->>'query' IS NOT NULL
+     GROUP BY metadata->>'query', metadata->>'resultCount'
+     ORDER BY count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    query: row.query,
+    count: parseInt(row.count, 10),
+    resultCount: row.result_count ? parseInt(row.result_count, 10) : null,
+    lastSearched: row.last_searched,
+  }));
+}
+
+/**
+ * Get comparison patterns (most compared yacht combinations).
+ */
+export async function getComparisonPatterns(
+  days: number = 30,
+  limit: number = 10,
+): Promise<ComparisonPattern[]> {
+  const result = await pool.query(
+    `SELECT
+       ae.entity_id,
+       ae.metadata->>'yachtIds' as yacht_ids,
+       ae.metadata->>'yachtNames' as yacht_names,
+       COUNT(*) as count
+     FROM analytics_events ae
+     WHERE ae.event_type = 'compare'
+       AND ae.created_at > NOW() - INTERVAL '${days} days'
+       AND ae.metadata->>'yachtIds' IS NOT NULL
+     GROUP BY ae.entity_id, ae.metadata->>'yachtIds', ae.metadata->>'yachtNames'
+     ORDER BY count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    yachtIds: row.yacht_ids ? JSON.parse(row.yacht_ids) : [],
+    yachtNames: row.yacht_names ? JSON.parse(row.yacht_names) : [],
+    count: parseInt(row.count, 10),
+  }));
+}
+
+/**
+ * Get page view breakdown by page.
+ */
+export async function getPageViewBreakdown(
+  days: number = 30,
+  limit: number = 20,
+): Promise<PageViewBreakdown[]> {
+  const result = await pool.query(
+    `SELECT
+       page,
+       COUNT(*) as views,
+       COUNT(DISTINCT session_id) as unique_views
+     FROM analytics_events
+     WHERE event_type = 'page_view'
+       AND created_at > NOW() - INTERVAL '${days} days'
+     GROUP BY page
+     ORDER BY views DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    page: row.page,
+    views: parseInt(row.views, 10),
+    uniqueViews: parseInt(row.unique_views, 10),
+  }));
+}
+
+/**
+ * Get top referrers.
+ */
+export async function getTopReferrers(
+  days: number = 30,
+  limit: number = 10,
+): Promise<{ referrer: string; count: number }[]> {
+  const result = await pool.query(
+    `SELECT
+       referrer,
+       COUNT(*) as count
+     FROM analytics_events
+     WHERE event_type = 'page_view'
+       AND created_at > NOW() - INTERVAL '${days} days'
+       AND referrer IS NOT NULL
+       AND referrer != ''
+     GROUP BY referrer
+     ORDER BY count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    referrer: row.referrer,
+    count: parseInt(row.count, 10),
+  }));
+}
+
+/**
+ * Get event counts by type for a period.
+ */
+export async function getEventCountsByType(
+  days: number = 30,
+): Promise<{ eventType: string; count: number }[]> {
+  const result = await pool.query(
+    `SELECT event_type, COUNT(*) as count
+     FROM analytics_events
+     WHERE created_at > NOW() - INTERVAL '${days} days'
+     GROUP BY event_type
+     ORDER BY count DESC`,
+  );
+
+  return result.rows.map((row) => ({
+    eventType: row.event_type,
+    count: parseInt(row.count, 10),
+  }));
+}
+
+/**
+ * Get analytics data for the admin dashboard — all in one call.
+ */
+export async function getAdminAnalyticsDashboard(days: number = 30) {
+  const [
+    summary,
+    trends,
+    popularYachts,
+    popularSearches,
+    comparisons,
+    pageBreakdown,
+    topReferrers,
+    eventCounts,
+  ] = await Promise.all([
+    getAnalyticsSummary(days),
+    getMultiMetricTrend(days),
+    getPopularYachts(days, 10),
+    getPopularSearches(days, 15),
+    getComparisonPatterns(days, 10),
+    getPageViewBreakdown(days, 15),
+    getTopReferrers(days, 10),
+    getEventCountsByType(days),
+  ]);
+
+  return {
+    summary,
+    trends,
+    popularYachts,
+    popularSearches,
+    comparisons,
+    pageBreakdown,
+    topReferrers,
+    eventCounts,
+    period: { days },
+  };
+}

--- a/lib/analytics-tracker.ts
+++ b/lib/analytics-tracker.ts
@@ -1,0 +1,335 @@
+/**
+ * P24.1 — Client-Side Analytics Tracker
+ *
+ * Lightweight client-side module for tracking user behavior events.
+ * Batches events and sends them to /api/analytics for server-side storage.
+ * No PII collected — session IDs are random and anonymous.
+ *
+ * Event types: page_view, yacht_view, search, compare, manufacturer_view,
+ *              guide_view, cta_click, share, filter_use, rating, email_yacht, featured_view
+ */
+
+export type AnalyticsEventType =
+  | "page_view"
+  | "search"
+  | "compare"
+  | "yacht_view"
+  | "manufacturer_view"
+  | "guide_view"
+  | "cta_click"
+  | "share"
+  | "filter_use"
+  | "rating"
+  | "email_yacht"
+  | "featured_view";
+
+interface TrackEvent {
+  eventType: AnalyticsEventType;
+  page: string;
+  entityId?: number;
+  entityType?: "yacht" | "manufacturer" | "guide" | "comparison";
+  metadata?: Record<string, unknown>;
+}
+
+interface QueuedTrackEvent extends TrackEvent {
+  sessionId: string;
+  referrer: string;
+  timestamp: number;
+}
+
+// ─── Session Management ──────────────────────────────────────────
+
+let _sessionId: string | null = null;
+
+function getSessionId(): string {
+  if (_sessionId) return _sessionId;
+  if (typeof window === "undefined") return "server";
+
+  // Reuse session from sessionStorage
+  const stored = sessionStorage.getItem("_analytics_sid");
+  if (stored) {
+    _sessionId = stored;
+    return _sessionId;
+  }
+
+  // Generate new anonymous session ID
+  _sessionId = `a-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  try {
+    sessionStorage.setItem("_analytics_sid", _sessionId);
+  } catch {
+    // sessionStorage unavailable
+  }
+  return _sessionId;
+}
+
+// ─── Event Queue & Batching ──────────────────────────────────────
+
+const queue: QueuedTrackEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function queueEvent(event: TrackEvent): void {
+  if (typeof window === "undefined") return;
+
+  // Respect Do Not Track
+  if (navigator.doNotTrack === "1") return;
+
+  const queued: QueuedTrackEvent = {
+    ...event,
+    sessionId: getSessionId(),
+    referrer: document.referrer || "",
+    page: event.page || window.location.pathname,
+    timestamp: Date.now(),
+  };
+
+  queue.push(queued);
+
+  // Batch send — flush after 3 seconds of inactivity
+  if (flushTimer) clearTimeout(flushTimer);
+  flushTimer = setTimeout(flushQueue, 3000);
+
+  // Flush immediately if queue is large
+  if (queue.length >= 10) {
+    flushQueue();
+  }
+}
+
+async function flushQueue(): Promise<void> {
+  if (queue.length === 0) return;
+
+  const events = queue.splice(0, queue.length);
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+
+  try {
+    const payload = JSON.stringify({ events });
+
+    if (navigator.sendBeacon) {
+      const blob = new Blob([payload], { type: "application/json" });
+      navigator.sendBeacon("/api/analytics", blob);
+    } else {
+      await fetch("/api/analytics", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+        keepalive: true,
+      });
+    }
+  } catch {
+    // Silently fail — analytics should never break UX
+  }
+}
+
+// Flush on page hide/unload
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", () => flushQueue());
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flushQueue();
+  });
+}
+
+// ─── Public API ──────────────────────────────────────────────────
+
+/**
+ * Track a page view. Call this from route-level layouts or pages.
+ */
+export function trackPageView(data?: {
+  page?: string;
+  entityId?: number;
+  entityType?: "yacht" | "manufacturer" | "guide";
+}): void {
+  queueEvent({
+    eventType: "page_view",
+    page: data?.page || (typeof window !== "undefined" ? window.location.pathname : "/"),
+    entityId: data?.entityId,
+    entityType: data?.entityType,
+  });
+}
+
+/**
+ * Track a yacht detail page view.
+ */
+export function trackYachtView(data: {
+  yachtId: number;
+  yachtSlug: string;
+  yachtName: string;
+  manufacturerName?: string;
+}): void {
+  queueEvent({
+    eventType: "yacht_view",
+    page: `/yachts/${data.yachtSlug}`,
+    entityId: data.yachtId,
+    entityType: "yacht",
+    metadata: {
+      yachtName: data.yachtName,
+      manufacturerName: data.manufacturerName,
+    },
+  });
+}
+
+/**
+ * Track a manufacturer page view.
+ */
+export function trackManufacturerView(data: {
+  manufacturerId: number;
+  manufacturerSlug: string;
+  manufacturerName: string;
+}): void {
+  queueEvent({
+    eventType: "manufacturer_view",
+    page: `/manufacturers/${data.manufacturerSlug}`,
+    entityId: data.manufacturerId,
+    entityType: "manufacturer",
+    metadata: { manufacturerName: data.manufacturerName },
+  });
+}
+
+/**
+ * Track a search query.
+ */
+export function trackSearch(data: {
+  query: string;
+  resultCount: number;
+  filters?: Record<string, unknown>;
+}): void {
+  queueEvent({
+    eventType: "search",
+    page: "/search",
+    metadata: {
+      query: data.query,
+      resultCount: data.resultCount,
+      filters: data.filters,
+    },
+  });
+}
+
+/**
+ * Track a comparison action.
+ */
+export function trackCompare(data: {
+  yachtIds: number[];
+  yachtNames?: string[];
+  yachtSlugs?: string[];
+}): void {
+  queueEvent({
+    eventType: "compare",
+    page: "/compare",
+    entityType: "comparison",
+    metadata: {
+      yachtIds: data.yachtIds,
+      yachtNames: data.yachtNames,
+      yachtSlugs: data.yachtSlugs,
+      yachtCount: data.yachtIds.length,
+    },
+  });
+}
+
+/**
+ * Track a CTA (call-to-action) click.
+ */
+export function trackCtaClick(data: {
+  ctaType: string;
+  targetUrl?: string;
+  page?: string;
+}): void {
+  queueEvent({
+    eventType: "cta_click",
+    page: data.page || "",
+    metadata: {
+      ctaType: data.ctaType,
+      targetUrl: data.targetUrl,
+    },
+  });
+}
+
+/**
+ * Track a social share action.
+ */
+export function trackShare(data: {
+  platform: string;
+  contentType: string;
+  contentId?: number;
+  page?: string;
+}): void {
+  queueEvent({
+    eventType: "share",
+    page: data.page || "",
+    entityId: data.contentId,
+    metadata: {
+      platform: data.platform,
+      contentType: data.contentType,
+    },
+  });
+}
+
+/**
+ * Track filter usage.
+ */
+export function trackFilterUse(data: {
+  filters: Record<string, unknown>;
+  resultCount: number;
+  page?: string;
+}): void {
+  queueEvent({
+    eventType: "filter_use",
+    page: data.page || "/yachts",
+    metadata: {
+      filters: data.filters,
+      resultCount: data.resultCount,
+    },
+  });
+}
+
+/**
+ * Track a featured yacht view.
+ */
+export function trackFeaturedView(data: {
+  yachtId: number;
+  yachtName: string;
+}): void {
+  queueEvent({
+    eventType: "featured_view",
+    page: "/yacht-of-the-week",
+    entityId: data.yachtId,
+    entityType: "yacht",
+    metadata: { yachtName: data.yachtName },
+  });
+}
+
+/**
+ * Track email yacht action.
+ */
+export function trackEmailYacht(data: {
+  yachtId: number;
+  yachtName: string;
+}): void {
+  queueEvent({
+    eventType: "email_yacht",
+    page: `/yachts/${data.yachtName}`,
+    entityId: data.yachtId,
+    entityType: "yacht",
+    metadata: { yachtName: data.yachtName },
+  });
+}
+
+/**
+ * Track a guide page view.
+ */
+export function trackGuideView(data: {
+  guideSlug: string;
+  guideTitle?: string;
+}): void {
+  queueEvent({
+    eventType: "guide_view",
+    page: `/guides/${data.guideSlug}`,
+    metadata: { guideTitle: data.guideTitle },
+  });
+}
+
+/**
+ * Get the current analytics session ID (for debugging).
+ */
+export function getAnalyticsSessionId(): string {
+  return getSessionId();
+}

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,411 @@
+/**
+ * P24.1 — Analytics Tests
+ *
+ * Tests for the analytics service, API endpoints, and client tracker.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Analytics Service Tests ──────────────────────────────────────
+
+describe("Analytics Service", () => {
+  // Mock the db module
+  vi.mock("@/lib/db", () => ({
+    pool: {
+      query: vi.fn(),
+    },
+  }));
+
+  let pool: any;
+
+  beforeEach(async () => {
+    const db = await import("@/lib/db");
+    pool = db.pool;
+    vi.clearAllMocks();
+  });
+
+  describe("insertAnalyticsEvents", () => {
+    it("should insert a batch of events", async () => {
+      pool.query.mockResolvedValue({ rowCount: 3 });
+
+      const { insertAnalyticsEvents } = await import(
+        "@/lib/analytics-service"
+      );
+
+      const events = [
+        {
+          eventType: "page_view" as const,
+          page: "/yachts",
+          sessionId: "sess-1",
+        },
+        {
+          eventType: "yacht_view" as const,
+          page: "/yachts/beneteau-oceanis-40-1",
+          entityId: 42,
+          entityType: "yacht" as const,
+          sessionId: "sess-1",
+          metadata: { yachtName: "Oceanis 40.1" },
+        },
+        {
+          eventType: "search" as const,
+          page: "/search",
+          sessionId: "sess-2",
+          metadata: { query: "beneteau", resultCount: 15 },
+        },
+      ];
+
+      const count = await insertAnalyticsEvents(events);
+      expect(count).toBe(3);
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO analytics_events");
+      expect(params).toHaveLength(24); // 8 params per event × 3
+    });
+
+    it("should return 0 for empty batch", async () => {
+      const { insertAnalyticsEvents } = await import(
+        "@/lib/analytics-service"
+      );
+      const count = await insertAnalyticsEvents([]);
+      expect(count).toBe(0);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("insertAnalyticsEvent", () => {
+    it("should insert a single event", async () => {
+      pool.query.mockResolvedValue({ rowCount: 1 });
+
+      const { insertAnalyticsEvent } = await import(
+        "@/lib/analytics-service"
+      );
+
+      await insertAnalyticsEvent({
+        eventType: "compare",
+        page: "/compare",
+        sessionId: "sess-3",
+        metadata: { yachtIds: [1, 2] },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO analytics_events");
+      expect(params[0]).toBe("compare");
+      expect(params[1]).toBe("/compare");
+    });
+  });
+
+  describe("getAnalyticsSummary", () => {
+    it("should return aggregated summary", async () => {
+      pool.query
+        .mockResolvedValueOnce({
+          rows: [{ count: "1250" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "340" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "89" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "45" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "567" }],
+        });
+
+      const { getAnalyticsSummary } = await import(
+        "@/lib/analytics-service"
+      );
+      const summary = await getAnalyticsSummary(30);
+
+      expect(summary.totalPageViews).toBe(1250);
+      expect(summary.uniqueSessions).toBe(340);
+      expect(summary.totalSearches).toBe(89);
+      expect(summary.totalComparisons).toBe(45);
+      expect(summary.totalYachtViews).toBe(567);
+      expect(pool.query).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("getEventTrend", () => {
+    it("should return daily trend data", async () => {
+      pool.query.mockResolvedValue({
+        rows: [
+          { date: "2026-06-03", count: "45" },
+          { date: "2026-06-04", count: "52" },
+          { date: "2026-06-05", count: "38" },
+        ],
+      });
+
+      const { getEventTrend } = await import("@/lib/analytics-service");
+      const trend = await getEventTrend("page_view", 7);
+
+      expect(trend).toHaveLength(3);
+      expect(trend[0]).toEqual({ date: "2026-06-03", count: 45 });
+      expect(trend[2]).toEqual({ date: "2026-06-05", count: 38 });
+    });
+  });
+
+  describe("getPopularYachts", () => {
+    it("should return most viewed yachts with names", async () => {
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            yacht_model_id: 10,
+            model_name: "Oceanis 40.1",
+            manufacturer_name: "Beneteau",
+            view_count: "150",
+          },
+          {
+            yacht_model_id: 20,
+            model_name: "C42",
+            manufacturer_name: "Bavaria",
+            view_count: "98",
+          },
+        ],
+      });
+
+      const { getPopularYachts } = await import("@/lib/analytics-service");
+      const yachts = await getPopularYachts(30, 10);
+
+      expect(yachts).toHaveLength(2);
+      expect(yachts[0].modelName).toBe("Oceanis 40.1");
+      expect(yachts[0].viewCount).toBe(150);
+    });
+  });
+
+  describe("getPopularSearches", () => {
+    it("should return popular search queries", async () => {
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            query: "beneteau",
+            count: "25",
+            result_count: "15",
+            last_searched: "2026-06-05T10:00:00Z",
+          },
+        ],
+      });
+
+      const { getPopularSearches } = await import("@/lib/analytics-service");
+      const searches = await getPopularSearches(30, 10);
+
+      expect(searches).toHaveLength(1);
+      expect(searches[0].query).toBe("beneteau");
+      expect(searches[0].resultCount).toBe(15);
+    });
+  });
+
+  describe("getPageViewBreakdown", () => {
+    it("should return page view breakdown with unique views", async () => {
+      pool.query.mockResolvedValue({
+        rows: [
+          { page: "/yachts", views: "500", unique_views: "350" },
+          { page: "/compare", views: "200", unique_views: "180" },
+        ],
+      });
+
+      const { getPageViewBreakdown } = await import(
+        "@/lib/analytics-service"
+      );
+      const breakdown = await getPageViewBreakdown(30, 15);
+
+      expect(breakdown).toHaveLength(2);
+      expect(breakdown[0].page).toBe("/yachts");
+      expect(breakdown[0].views).toBe(500);
+      expect(breakdown[0].uniqueViews).toBe(350);
+    });
+  });
+
+  describe("getEventCountsByType", () => {
+    it("should return event type distribution", async () => {
+      pool.query.mockResolvedValue({
+        rows: [
+          { event_type: "page_view", count: "1000" },
+          { event_type: "yacht_view", count: "500" },
+          { event_type: "search", count: "200" },
+        ],
+      });
+
+      const { getEventCountsByType } = await import(
+        "@/lib/analytics-service"
+      );
+      const counts = await getEventCountsByType(30);
+
+      expect(counts).toHaveLength(3);
+      expect(counts[0].eventType).toBe("page_view");
+      expect(counts[0].count).toBe(1000);
+    });
+  });
+
+  describe("getAdminAnalyticsDashboard", () => {
+    it("should call all sub-functions and return combined data", async () => {
+      // Mock all 8 queries in sequence
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ count: "100" }] }) // page views
+        .mockResolvedValueOnce({ rows: [{ count: "50" }] }) // sessions
+        .mockResolvedValueOnce({ rows: [{ count: "10" }] }) // searches
+        .mockResolvedValueOnce({ rows: [{ count: "5" }] }) // comparisons
+        .mockResolvedValueOnce({ rows: [{ count: "30" }] }) // yacht views
+        .mockResolvedValueOnce({ rows: [] }) // multi-metric trend
+        .mockResolvedValueOnce({ rows: [] }) // popular yachts
+        .mockResolvedValueOnce({ rows: [] }) // popular searches
+        .mockResolvedValueOnce({ rows: [] }) // comparison patterns
+        .mockResolvedValueOnce({ rows: [] }) // page breakdown
+        .mockResolvedValueOnce({ rows: [] }) // top referrers
+        .mockResolvedValueOnce({ rows: [] }); // event counts
+
+      const { getAdminAnalyticsDashboard } = await import(
+        "@/lib/analytics-service"
+      );
+      const dashboard = await getAdminAnalyticsDashboard(7);
+
+      expect(dashboard.summary.totalPageViews).toBe(100);
+      expect(dashboard.period.days).toBe(7);
+    });
+  });
+});
+
+// ─── Analytics Tracker (Client) Tests ──────────────────────────────
+
+describe("Analytics Tracker (Client)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window/navigator for client code
+    Object.defineProperty(global, "navigator", {
+      value: { doNotTrack: "0", sendBeacon: vi.fn(() => true) },
+      writable: true,
+    });
+    Object.defineProperty(global, "window", {
+      value: {
+        location: { pathname: "/yachts" },
+        addEventListener: vi.fn(),
+        document: {
+          referrer: "",
+          addEventListener: vi.fn(),
+          visibilityState: "visible",
+        },
+        sessionStorage: {
+          getItem: vi.fn(),
+          setItem: vi.fn(),
+        },
+      },
+      writable: true,
+    });
+    Object.defineProperty(global, "document", {
+      value: {
+        referrer: "",
+        addEventListener: vi.fn(),
+        visibilityState: "visible",
+      },
+      writable: true,
+    });
+  });
+
+  it("should export all tracking functions", async () => {
+    const tracker = await import("@/lib/analytics-tracker");
+    expect(typeof tracker.trackPageView).toBe("function");
+    expect(typeof tracker.trackYachtView).toBe("function");
+    expect(typeof tracker.trackSearch).toBe("function");
+    expect(typeof tracker.trackCompare).toBe("function");
+    expect(typeof tracker.trackManufacturerView).toBe("function");
+    expect(typeof tracker.trackGuideView).toBe("function");
+    expect(typeof tracker.trackCtaClick).toBe("function");
+    expect(typeof tracker.trackShare).toBe("function");
+    expect(typeof tracker.trackFilterUse).toBe("function");
+    expect(typeof tracker.trackFeaturedView).toBe("function");
+    expect(typeof tracker.trackEmailYacht).toBe("function");
+  });
+
+  it("should return a session ID", async () => {
+    // Mock sessionStorage properly
+    const store: Record<string, string> = {};
+    global.sessionStorage = {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, val: string) => { store[key] = val; },
+      removeItem: (key: string) => { delete store[key]; },
+      clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+      get length() { return Object.keys(store).length; },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    } as Storage;
+
+    // Re-import to get fresh module
+    vi.resetModules();
+    const { getAnalyticsSessionId } = await import("@/lib/analytics-tracker");
+    const sid = getAnalyticsSessionId();
+    expect(typeof sid).toBe("string");
+    expect(sid.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── API Endpoint Tests ──────────────────────────────────────────
+
+describe("Analytics API POST", () => {
+  it("should validate event payload structure", () => {
+    // Validate the expected input structure
+    const validEvent = {
+      eventType: "page_view",
+      page: "/yachts",
+      sessionId: "sess-123",
+    };
+
+    expect(validEvent.eventType).toBe("page_view");
+    expect(validEvent.page).toBe("/yachts");
+    expect(validEvent.sessionId).toBe("sess-123");
+  });
+
+  it("should accept all valid event types", () => {
+    const validTypes = [
+      "page_view",
+      "search",
+      "compare",
+      "yacht_view",
+      "manufacturer_view",
+      "guide_view",
+      "cta_click",
+      "share",
+      "filter_use",
+      "rating",
+      "email_yacht",
+      "featured_view",
+    ];
+
+    for (const type of validTypes) {
+      expect(type).toMatch(/^[a-z_]+$/);
+    }
+  });
+
+  it("should accept optional metadata", () => {
+    const eventWithMetadata = {
+      eventType: "search",
+      page: "/search",
+      sessionId: "sess-456",
+      metadata: {
+        query: "beneteau",
+        resultCount: 15,
+        filters: { lengthMin: 30, lengthMax: 50 },
+      },
+    };
+
+    expect(eventWithMetadata.metadata).toBeDefined();
+    expect((eventWithMetadata.metadata as any).query).toBe("beneteau");
+  });
+});
+
+// ─── Analytics Page Tracker Component Tests ──────────────────────
+
+describe("AnalyticsPageTracker", () => {
+  it("should skip admin routes", () => {
+    const adminPath = "/admin/analytics";
+    const apiPath = "/api/yachts";
+    const normalPath = "/yachts";
+
+    const shouldSkip = (p: string) =>
+      p.startsWith("/admin") || p.startsWith("/api");
+
+    expect(shouldSkip(adminPath)).toBe(true);
+    expect(shouldSkip(apiPath)).toBe(true);
+    expect(shouldSkip(normalPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
P24.1 — Analytics Dashboard

- DB schema: analytics_events table (event_type, page, entity_id, session_id, metadata, referrer)
- Migration: 0022_analytics_events applied to Neon DB
- Server service: lib/analytics-service.ts — full CRUD + aggregated queries (summary, trends, popular yachts, searches, comparisons, page breakdown, referrers)
- Client tracker: lib/analytics-tracker.ts — batched event sender (sendBeacon/fetch), session management, Do Not Track support
- Public API: POST /api/analytics — collects batched events from client
- Admin API: GET /api/admin/analytics — returns full dashboard data
- Admin UI: /admin/analytics — summary cards with sparklines, multi-line trend chart, popular yachts/searches/comparisons, page breakdown, event distribution, referrers
- Client integration: trackYachtView (yacht detail), trackCompare (compare page), trackSearch (search page), trackPageView (global via AnalyticsPageTracker component in layout)
- Admin dashboard: new Analytics card added to admin home
- Tests: 16 tests in tests/analytics.test.ts
