### PR TITLE
feat: search intent analysis dashboard (closes #395)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -200,6 +200,17 @@ export default async function AdminPage() {
                 View Funnel
               </a>
             </div>
+
+            <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Search Analytics</h2>
+              <p className="text-gray-600 mb-4">Analyze search queries, zero-result searches, popular filters, and surface content gaps.</p>
+              <a
+                href="/admin/search-analytics"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                View Search Analytics
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/admin/search-analytics/SearchAnalyticsClient.tsx
+++ b/app/admin/search-analytics/SearchAnalyticsClient.tsx
@@ -1,0 +1,934 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+interface SearchAnalyticsSummary {
+  totalSearches: number;
+  uniqueQueries: number;
+  zeroResultSearches: number;
+  zeroResultRate: number;
+  avgResultCount: number;
+  topSearchHour: number;
+  searchesWithFilters: number;
+}
+
+interface TopQuery {
+  query: string;
+  count: number;
+  avgResultCount: number;
+  zeroResultCount: number;
+  lastSearchedAt: string;
+  hasIntentPage: boolean;
+  intentPageSlug: string | null;
+}
+
+interface ZeroResultQuery {
+  query: string;
+  count: number;
+  lastSearchedAt: string;
+  similarQueries: string[];
+  suggestedIntentPage: string | null;
+}
+
+interface FilterUsageItem {
+  filterKey: string;
+  filterLabel: string;
+  count: number;
+  percentage: number;
+  topValues: { value: string; count: number }[];
+}
+
+interface FilterCombination {
+  filters: string[];
+  count: number;
+  avgResultCount: number;
+}
+
+interface DailySearchTrend {
+  date: string;
+  totalSearches: number;
+  uniqueQueries: number;
+  zeroResultRate: number;
+}
+
+interface ContentGap {
+  query: string;
+  searchCount: number;
+  avgResultCount: number;
+  existingIntentSlug: string | null;
+  suggestedAction: "create_intent" | "improve_matching" | "monitor";
+  priority: "high" | "medium" | "low";
+}
+
+interface SearchAnalyticsData {
+  summary: SearchAnalyticsSummary;
+  topQueries: TopQuery[];
+  zeroResultQueries: ZeroResultQuery[];
+  filterUsage: FilterUsageItem[];
+  filterCombinations: FilterCombination[];
+  dailyTrend: DailySearchTrend[];
+  contentGaps: ContentGap[];
+  period: { days: number };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function formatDate(d: string): string {
+  try {
+    return new Date(d).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return d;
+  }
+}
+
+const PERIOD_OPTIONS = [
+  { value: 7, label: "7 Days" },
+  { value: 30, label: "30 Days" },
+  { value: 90, label: "90 Days" },
+  { value: 365, label: "1 Year" },
+];
+
+const PRIORITY_BADGE: Record<string, string> = {
+  high: "bg-red-100 text-red-800",
+  medium: "bg-yellow-100 text-yellow-800",
+  low: "bg-green-100 text-green-800",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  create_intent: "Create Intent Page",
+  improve_matching: "Improve Matching",
+  monitor: "Monitor",
+};
+
+// ─── Chart Components ────────────────────────────────────────────
+
+function SimpleBarChart({
+  data,
+  maxValue,
+  color = "#3b82f6",
+}: {
+  data: { label: string; value: number; extra?: string }[];
+  maxValue: number;
+  color?: string;
+}) {
+  const maxBarWidth = 100;
+  return (
+    <div className="space-y-2">
+      {data.map((item, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <div
+            className="w-32 text-sm text-gray-700 truncate flex-shrink-0"
+            title={item.label}
+          >
+            {item.label}
+          </div>
+          <div className="flex-1 bg-gray-100 rounded-full h-6 relative overflow-hidden">
+            <div
+              className="h-full rounded-full transition-all duration-500 flex items-center justify-end pr-2"
+              style={{
+                width: `${Math.max((item.value / maxValue) * maxBarWidth, 2)}%`,
+                backgroundColor: color,
+              }}
+            >
+              {item.value > 0 && (
+                <span className="text-xs text-white font-medium">
+                  {formatNumber(item.value)}
+                </span>
+              )}
+            </div>
+          </div>
+          {item.extra && (
+            <span className="text-xs text-gray-500 w-20 text-right">
+              {item.extra}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MiniLineChart({ data, dataKey, color = "#3b82f6" }: { data: DailySearchTrend[]; dataKey: keyof DailySearchTrend; color?: string }) {
+  if (data.length === 0) return <div className="text-gray-400 text-sm">No data</div>;
+
+  const values = data.map((d) => Number(d[dataKey]));
+  const maxVal = Math.max(...values, 1);
+  const width = 600;
+  const height = 120;
+  const padding = { top: 10, right: 10, bottom: 20, left: 40 };
+  const chartW = width - padding.left - padding.right;
+  const chartH = height - padding.top - padding.bottom;
+
+  const points = values
+    .map((v, i) => {
+      const x = padding.left + (i / Math.max(values.length - 1, 1)) * chartW;
+      const y = padding.top + chartH - (v / maxVal) * chartH;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  const areaPoints = [
+    `${padding.left},${padding.top + chartH}`,
+    ...values.map((v, i) => {
+      const x = padding.left + (i / Math.max(values.length - 1, 1)) * chartW;
+      const y = padding.top + chartH - (v / maxVal) * chartH;
+      return `${x},${y}`;
+    }),
+    `${padding.left + chartW},${padding.top + chartH}`,
+  ].join(" ");
+
+  // Show every Nth date label
+  const step = Math.max(Math.floor(data.length / 8), 1);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" style={{ maxWidth: width }}>
+      <polygon points={areaPoints} fill={color} opacity={0.1} />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinejoin="round"
+      />
+      {/* Y-axis labels */}
+      <text x={padding.left - 5} y={padding.top + 4} textAnchor="end" className="text-[9px] fill-gray-400">
+        {formatNumber(maxVal)}
+      </text>
+      <text x={padding.left - 5} y={padding.top + chartH} textAnchor="end" className="text-[9px] fill-gray-400">
+        0
+      </text>
+      {/* X-axis labels */}
+      {data.map(
+        (d, i) =>
+          i % step === 0 && (
+            <text
+              key={i}
+              x={padding.left + (i / Math.max(data.length - 1, 1)) * chartW}
+              y={height - 2}
+              textAnchor="middle"
+              className="text-[9px] fill-gray-400"
+            >
+              {formatDate(d.date)}
+            </text>
+          ),
+      )}
+    </svg>
+  );
+}
+
+// ─── Tabs ────────────────────────────────────────────────────────
+
+type TabId = "overview" | "queries" | "zero-results" | "filters" | "gaps";
+
+const TABS: { id: TabId; label: string; icon: string }[] = [
+  { id: "overview", label: "Overview", icon: "📊" },
+  { id: "queries", label: "Top Queries", icon: "🔍" },
+  { id: "zero-results", label: "Zero Results", icon: "🚫" },
+  { id: "filters", label: "Filters", icon: "🎛️" },
+  { id: "gaps", label: "Content Gaps", icon: "💡" },
+];
+
+// ─── Main Component ──────────────────────────────────────────────
+
+export default function SearchAnalyticsClient() {
+  const [data, setData] = useState<SearchAnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [period, setPeriod] = useState(30);
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
+
+  const fetchData = useCallback(async (days: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/search-analytics?days=${days}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setData(json);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(period);
+  }, [period, fetchData]);
+
+  const handlePeriodChange = (days: number) => {
+    setPeriod(days);
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-gray-500">
+          <div className="animate-spin inline-block w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full mb-4" />
+          <p>Loading search analytics...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+        <h3 className="text-red-800 font-semibold">Error Loading Data</h3>
+        <p className="text-red-600 text-sm mt-1">{error}</p>
+        <button
+          onClick={() => fetchData(period)}
+          className="mt-3 px-4 py-2 bg-red-600 text-white rounded-md text-sm hover:bg-red-700"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div>
+      {/* Period Selector */}
+      <div className="flex items-center gap-2 mb-6">
+        <span className="text-sm text-gray-600">Period:</span>
+        {PERIOD_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => handlePeriodChange(opt.value)}
+            className={`px-3 py-1.5 text-sm rounded-md transition ${
+              period === opt.value
+                ? "bg-blue-600 text-white"
+                : "bg-white text-gray-600 border border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-gray-200 mb-6">
+        <nav className="flex gap-1">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition ${
+                activeTab === tab.id
+                  ? "border-blue-600 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              }`}
+            >
+              {tab.icon} {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === "overview" && (
+        <OverviewTab data={data} />
+      )}
+      {activeTab === "queries" && (
+        <QueriesTab queries={data.topQueries} />
+      )}
+      {activeTab === "zero-results" && (
+        <ZeroResultsTab queries={data.zeroResultQueries} />
+      )}
+      {activeTab === "filters" && (
+        <FiltersTab
+          filterUsage={data.filterUsage}
+          combinations={data.filterCombinations}
+        />
+      )}
+      {activeTab === "gaps" && (
+        <ContentGapsTab gaps={data.contentGaps} />
+      )}
+
+      {/* Refresh */}
+      <div className="mt-8 flex justify-end">
+        <button
+          onClick={() => fetchData(period)}
+          disabled={loading}
+          className="px-4 py-2 text-sm bg-gray-100 text-gray-600 rounded-md hover:bg-gray-200 transition disabled:opacity-50"
+        >
+          {loading ? "Refreshing..." : "↻ Refresh"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Overview Tab ────────────────────────────────────────────────
+
+function OverviewTab({ data }: { data: SearchAnalyticsData }) {
+  const { summary, dailyTrend, topQueries, contentGaps } = data;
+
+  return (
+    <div className="space-y-8">
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          label="Total Searches"
+          value={formatNumber(summary.totalSearches)}
+          icon="🔍"
+          color="blue"
+        />
+        <StatCard
+          label="Unique Queries"
+          value={formatNumber(summary.uniqueQueries)}
+          icon="📝"
+          color="green"
+        />
+        <StatCard
+          label="Zero-Result Rate"
+          value={`${summary.zeroResultRate}%`}
+          icon="🚫"
+          color="orange"
+        />
+        <StatCard
+          label="Avg Results"
+          value={formatNumber(summary.avgResultCount)}
+          icon="📊"
+          color="purple"
+        />
+      </div>
+
+      {/* Secondary Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <div className="text-sm text-gray-500">Peak Search Hour</div>
+          <div className="text-2xl font-bold text-gray-900 mt-1">
+            {summary.topSearchHour}:00
+          </div>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <div className="text-sm text-gray-500">Zero-Result Searches</div>
+          <div className="text-2xl font-bold text-gray-900 mt-1">
+            {formatNumber(summary.zeroResultSearches)}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <div className="text-sm text-gray-500">Searches with Filters</div>
+          <div className="text-2xl font-bold text-gray-900 mt-1">
+            {formatNumber(summary.searchesWithFilters)}
+          </div>
+        </div>
+      </div>
+
+      {/* Daily Trend Chart */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          📈 Daily Search Volume
+        </h3>
+        <MiniLineChart data={dailyTrend} dataKey="totalSearches" color="#3b82f6" />
+      </div>
+
+      {/* Zero-Result Rate Trend */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          📉 Zero-Result Rate Over Time
+        </h3>
+        <MiniLineChart data={dailyTrend} dataKey="zeroResultRate" color="#ef4444" />
+      </div>
+
+      {/* Quick: Top 5 Queries */}
+      {topQueries.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            🔝 Top 5 Search Queries
+          </h3>
+          <SimpleBarChart
+            data={topQueries.slice(0, 5).map((q) => ({
+              label: q.query,
+              value: q.count,
+              extra: `${q.avgResultCount} avg results`,
+            }))}
+            maxValue={topQueries[0]?.count || 1}
+            color="#3b82f6"
+          />
+        </div>
+      )}
+
+      {/* Quick: Content Gaps */}
+      {contentGaps.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            💡 Top Content Gaps
+          </h3>
+          <div className="space-y-3">
+            {contentGaps.slice(0, 5).map((gap, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between py-2 px-3 bg-gray-50 rounded-md"
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_BADGE[gap.priority]}`}
+                  >
+                    {gap.priority}
+                  </span>
+                  <span className="text-sm font-medium text-gray-900">
+                    &ldquo;{gap.query}&rdquo;
+                  </span>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs text-gray-500">
+                    {gap.searchCount} searches · {gap.avgResultCount} avg results
+                  </div>
+                  <div className="text-xs text-blue-600">
+                    {ACTION_LABELS[gap.suggestedAction]}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Queries Tab ─────────────────────────────────────────────────
+
+function QueriesTab({ queries }: { queries: TopQuery[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const displayed = showAll ? queries : queries.slice(0, 15);
+
+  if (queries.length === 0) {
+    return <EmptyState message="No search queries recorded yet." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Query
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Count
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Avg Results
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Zero Results
+              </th>
+              <th className="text-center px-4 py-3 font-medium text-gray-600">
+                Intent Page
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Last Searched
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {displayed.map((q, i) => (
+              <tr key={i} className="border-t border-gray-100 hover:bg-gray-50">
+                <td className="px-4 py-3 font-medium text-gray-900 max-w-xs truncate">
+                  {q.query}
+                </td>
+                <td className="px-4 py-3 text-right text-gray-700">
+                  {formatNumber(q.count)}
+                </td>
+                <td className="px-4 py-3 text-right text-gray-700">
+                  {q.avgResultCount}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {q.zeroResultCount > 0 ? (
+                    <span className="text-red-600 font-medium">
+                      {q.zeroResultCount}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400">0</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-center">
+                  {q.hasIntentPage ? (
+                    <a
+                      href={`/search-intent/${q.intentPageSlug}`}
+                      className="text-blue-600 hover:underline text-xs"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      View ↗
+                    </a>
+                  ) : (
+                    <span className="text-gray-400 text-xs">None</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right text-gray-500 text-xs">
+                  {formatDate(q.lastSearchedAt)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {queries.length > 15 && (
+        <div className="text-center">
+          <button
+            onClick={() => setShowAll(!showAll)}
+            className="px-4 py-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            {showAll
+              ? "Show less"
+              : `Show all ${queries.length} queries`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Zero Results Tab ────────────────────────────────────────────
+
+function ZeroResultsTab({ queries }: { queries: ZeroResultQuery[] }) {
+  if (queries.length === 0) {
+    return (
+      <EmptyState message="No zero-result searches recorded. Great job!" />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <p className="text-blue-800 text-sm">
+          💡 <strong>Tip:</strong> These searches returned no results. Consider creating search intent pages for popular queries to capture this traffic.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {queries.map((q, i) => (
+          <div
+            key={i}
+            className="bg-white rounded-lg border border-gray-200 p-5"
+          >
+            <div className="flex items-start justify-between">
+              <div>
+                <h4 className="text-lg font-semibold text-gray-900">
+                  &ldquo;{q.query}&rdquo;
+                </h4>
+                <div className="flex items-center gap-4 mt-1">
+                  <span className="text-sm text-red-600 font-medium">
+                    {q.count} zero-result searches
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    Last: {formatDate(q.lastSearchedAt)}
+                  </span>
+                </div>
+              </div>
+              {q.suggestedIntentPage ? (
+                <a
+                  href={`/search-intent/${q.suggestedIntentPage}`}
+                  className="px-3 py-1.5 bg-green-100 text-green-800 text-sm rounded-md hover:bg-green-200"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View Intent Page ↗
+                </a>
+              ) : (
+                <span className="px-3 py-1.5 bg-orange-100 text-orange-800 text-sm rounded-md">
+                  No Intent Page
+                </span>
+              )}
+            </div>
+
+            {q.similarQueries.length > 0 && (
+              <div className="mt-3">
+                <span className="text-xs text-gray-500">Similar queries:</span>
+                <div className="flex flex-wrap gap-2 mt-1">
+                  {q.similarQueries.map((sq, j) => (
+                    <span
+                      key={j}
+                      className="px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded"
+                    >
+                      {sq}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Filters Tab ─────────────────────────────────────────────────
+
+function FiltersTab({
+  filterUsage,
+  combinations,
+}: {
+  filterUsage: FilterUsageItem[];
+  combinations: FilterCombination[];
+}) {
+  return (
+    <div className="space-y-8">
+      {/* Filter Usage */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          🎛️ Filter Usage
+        </h3>
+        {filterUsage.length === 0 ? (
+          <p className="text-gray-500 text-sm">
+            No filter usage data recorded yet.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {filterUsage.map((f, i) => (
+              <div key={i}>
+                <div className="flex items-center justify-between mb-2">
+                  <div>
+                    <span className="font-medium text-gray-900">
+                      {f.filterLabel}
+                    </span>
+                    <span className="text-gray-500 text-sm ml-2">
+                      ({f.count} uses · {f.percentage}%)
+                    </span>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {f.topValues.map((v, j) => (
+                    <span
+                      key={j}
+                      className="inline-flex items-center gap-1 px-2.5 py-1 bg-blue-50 text-blue-800 text-xs rounded-full"
+                    >
+                      {v.value}
+                      <span className="text-blue-500">({v.count})</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Filter Combinations */}
+      {combinations.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            🔗 Popular Filter Combinations
+          </h3>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">
+                    Filters
+                  </th>
+                  <th className="text-right px-4 py-3 font-medium text-gray-600">
+                    Uses
+                  </th>
+                  <th className="text-right px-4 py-3 font-medium text-gray-600">
+                    Avg Results
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {combinations.map((c, i) => (
+                  <tr key={i} className="border-t border-gray-100 hover:bg-gray-50">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {c.filters.map((f, j) => (
+                          <span
+                            key={j}
+                            className="px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded"
+                          >
+                            {f}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {c.count}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {c.avgResultCount}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Content Gaps Tab ─────────────────────────────────────────────
+
+function ContentGapsTab({ gaps }: { gaps: ContentGap[] }) {
+  if (gaps.length === 0) {
+    return (
+      <EmptyState message="No content gaps detected. All searches are well-served!" />
+    );
+  }
+
+  const highGaps = gaps.filter((g) => g.priority === "high");
+  const medGaps = gaps.filter((g) => g.priority === "medium");
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+        <p className="text-yellow-800 text-sm">
+          💡 <strong>Content gaps</strong> are frequent searches that yield few or no results. Creating intent pages for these queries can significantly improve SEO and user satisfaction.
+        </p>
+      </div>
+
+      {/* Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <div className="text-sm text-gray-500">Total Gaps</div>
+          <div className="text-2xl font-bold text-gray-900">{gaps.length}</div>
+        </div>
+        <div className="bg-white rounded-lg border border-red-200 p-4">
+          <div className="text-sm text-red-600">High Priority</div>
+          <div className="text-2xl font-bold text-red-700">
+            {highGaps.length}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg border border-yellow-200 p-4">
+          <div className="text-sm text-yellow-600">Medium Priority</div>
+          <div className="text-2xl font-bold text-yellow-700">
+            {medGaps.length}
+          </div>
+        </div>
+      </div>
+
+      {/* Gaps Table */}
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Priority
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Query
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Searches
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Avg Results
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Action
+              </th>
+              <th className="text-center px-4 py-3 font-medium text-gray-600">
+                Intent Page
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {gaps.map((gap, i) => (
+              <tr key={i} className="border-t border-gray-100 hover:bg-gray-50">
+                <td className="px-4 py-3">
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_BADGE[gap.priority]}`}
+                  >
+                    {gap.priority}
+                  </span>
+                </td>
+                <td className="px-4 py-3 font-medium text-gray-900">
+                  &ldquo;{gap.query}&rdquo;
+                </td>
+                <td className="px-4 py-3 text-right text-gray-700">
+                  {gap.searchCount}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {gap.avgResultCount === 0 ? (
+                    <span className="text-red-600 font-medium">0</span>
+                  ) : (
+                    <span className="text-gray-700">{gap.avgResultCount}</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-gray-600 text-xs">
+                  {ACTION_LABELS[gap.suggestedAction]}
+                </td>
+                <td className="px-4 py-3 text-center">
+                  {gap.existingIntentSlug ? (
+                    <a
+                      href={`/search-intent/${gap.existingIntentSlug}`}
+                      className="text-blue-600 hover:underline text-xs"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      View ↗
+                    </a>
+                  ) : (
+                    <span className="text-gray-400 text-xs">—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Shared Components ───────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string;
+  value: string;
+  icon: string;
+  color: string;
+}) {
+  const colorMap: Record<string, string> = {
+    blue: "border-blue-200 bg-blue-50",
+    green: "border-green-200 bg-green-50",
+    orange: "border-orange-200 bg-orange-50",
+    purple: "border-purple-200 bg-purple-50",
+  };
+
+  return (
+    <div className={`rounded-lg border p-4 ${colorMap[color] || "border-gray-200 bg-white"}`}>
+      <div className="flex items-center justify-between">
+        <span className="text-2xl">{icon}</span>
+      </div>
+      <div className="mt-2">
+        <div className="text-2xl font-bold text-gray-900">{value}</div>
+        <div className="text-sm text-gray-600 mt-0.5">{label}</div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="text-center py-16">
+      <div className="text-4xl mb-3">📭</div>
+      <p className="text-gray-500">{message}</p>
+    </div>
+  );
+}

--- a/app/admin/search-analytics/page.tsx
+++ b/app/admin/search-analytics/page.tsx
@@ -1,0 +1,35 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import SearchAnalyticsClient from "./SearchAnalyticsClient";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Search Analytics - Admin" };
+
+export default async function SearchAnalyticsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    redirect("/admin");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <a href="/admin" className="text-blue-600 hover:underline text-sm">
+              ← Back to Dashboard
+            </a>
+            <h1 className="text-3xl font-bold text-gray-900 mt-2">
+              Search Analytics
+            </h1>
+            <p className="text-gray-500 mt-1">
+              Analyze search queries, zero-result searches, popular filters, and surface content gaps.
+            </p>
+          </div>
+        </div>
+        <SearchAnalyticsClient />
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/search-analytics/route.ts
+++ b/app/api/admin/search-analytics/route.ts
@@ -1,0 +1,72 @@
+/**
+ * P24.4 — Search Intent Analysis API
+ *
+ * GET /api/admin/search-analytics?days=30&section=summary|queries|zero-results|filters|trends|gaps
+ * Returns search analytics data for the admin dashboard.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getSearchAnalyticsDashboard,
+  getSearchAnalyticsSummary,
+  getTopQueries,
+  getZeroResultQueries,
+  getFilterUsage,
+  getSearchDailyTrend,
+  getContentGaps,
+} from "@/lib/search-analytics-service";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  // Auth check
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const daysParam = request.nextUrl.searchParams.get("days");
+  const days = Math.min(
+    Math.max(parseInt(daysParam || "30", 10) || 30, 1),
+    365,
+  );
+  const section = request.nextUrl.searchParams.get("section");
+
+  try {
+    let data;
+
+    switch (section) {
+      case "summary":
+        data = await getSearchAnalyticsSummary(days);
+        break;
+      case "queries":
+        data = await getTopQueries(days);
+        break;
+      case "zero-results":
+        data = await getZeroResultQueries(days);
+        break;
+      case "filters":
+        data = await getFilterUsage(days);
+        break;
+      case "trends":
+        data = await getSearchDailyTrend(days);
+        break;
+      case "gaps":
+        data = await getContentGaps(days);
+        break;
+      default:
+        data = await getSearchAnalyticsDashboard(days);
+        break;
+    }
+
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error("[Search Analytics API] Error:", error.message);
+    return NextResponse.json(
+      { error: "Failed to load search analytics", details: error.message },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/search-analytics-service.ts
+++ b/lib/search-analytics-service.ts
@@ -1,0 +1,552 @@
+/**
+ * P24.4 — Search Intent Analysis Service
+ *
+ * Analyzes search queries, zero-result searches, popular filters,
+ * and surfaces content gaps. Built on analytics_events data.
+ *
+ * Sections:
+ *   - Top search queries with frequency & result counts
+ *   - Zero-result search analysis & content gap detection
+ *   - Popular filter usage & combinations
+ *   - Daily/weekly trends for search volume
+ */
+
+import { pool } from "./db";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface TopQuery {
+  query: string;
+  count: number;
+  avgResultCount: number;
+  zeroResultCount: number;
+  lastSearchedAt: string;
+  hasIntentPage: boolean;
+  intentPageSlug: string | null;
+}
+
+export interface ZeroResultQuery {
+  query: string;
+  count: number;
+  lastSearchedAt: string;
+  similarQueries: string[];
+  suggestedIntentPage: string | null;
+}
+
+export interface FilterUsage {
+  filterKey: string;
+  filterLabel: string;
+  count: number;
+  percentage: number;
+  topValues: { value: string; count: number }[];
+}
+
+export interface FilterCombination {
+  filters: string[];
+  count: number;
+  avgResultCount: number;
+}
+
+export interface DailySearchTrend {
+  date: string;
+  totalSearches: number;
+  uniqueQueries: number;
+  zeroResultRate: number;
+}
+
+export interface SearchAnalyticsSummary {
+  totalSearches: number;
+  uniqueQueries: number;
+  zeroResultSearches: number;
+  zeroResultRate: number;
+  avgResultCount: number;
+  topSearchHour: number;
+  searchesWithFilters: number;
+}
+
+export interface ContentGap {
+  query: string;
+  searchCount: number;
+  avgResultCount: number;
+  existingIntentSlug: string | null;
+  suggestedAction: "create_intent" | "improve_matching" | "monitor";
+  priority: "high" | "medium" | "low";
+}
+
+export interface SearchAnalyticsData {
+  summary: SearchAnalyticsSummary;
+  topQueries: TopQuery[];
+  zeroResultQueries: ZeroResultQuery[];
+  filterUsage: FilterUsage[];
+  filterCombinations: FilterCombination[];
+  dailyTrend: DailySearchTrend[];
+  contentGaps: ContentGap[];
+  period: { days: number };
+}
+
+// ─── Filter Labels ──────────────────────────────────────────────
+
+const FILTER_LABELS: Record<string, string> = {
+  query: "Search Query",
+  lengthMin: "Min Length",
+  lengthMax: "Max Length",
+  cabinsMin: "Min Cabins",
+  cabinsMax: "Max Cabins",
+  keelType: "Keel Type",
+  rigType: "Rig Type",
+  hullMaterial: "Hull Material",
+  displacementMin: "Min Displacement",
+  displacementMax: "Max Displacement",
+  yearMin: "Min Year",
+  yearMax: "Max Year",
+  manufacturerId: "Manufacturer",
+  useCase: "Use Case",
+  sortBy: "Sort By",
+  sortDir: "Sort Direction",
+};
+
+// ─── Summary ──────────────────────────────────────────────────────
+
+export async function getSearchAnalyticsSummary(
+  days: number = 30,
+): Promise<SearchAnalyticsSummary> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT
+       COUNT(*) as total_searches,
+       COUNT(DISTINCT metadata->>'query') as unique_queries,
+       COUNT(*) FILTER (WHERE (metadata->>'resultCount')::int = 0 OR metadata->>'resultCount' IS NULL) as zero_result_searches,
+       ROUND(AVG((metadata->>'resultCount')::int)) as avg_result_count,
+       COUNT(*) FILTER (WHERE metadata->>'filters' IS NOT NULL AND metadata->>'filters' != '{}' AND metadata->>'filters' != 'undefined') as searches_with_filters
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'`,
+  );
+
+  // Get peak search hour
+  const hourResult = await pool.query(
+    `SELECT EXTRACT(HOUR FROM created_at) as hour, COUNT(*) as count
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+     GROUP BY hour
+     ORDER BY count DESC
+     LIMIT 1`,
+  );
+
+  const row = result.rows[0];
+  const totalSearches = parseInt(row?.total_searches || "0", 10);
+  const zeroResultSearches = parseInt(row?.zero_result_searches || "0", 10);
+
+  return {
+    totalSearches,
+    uniqueQueries: parseInt(row?.unique_queries || "0", 10),
+    zeroResultSearches,
+    zeroResultRate:
+      totalSearches > 0
+        ? Math.round((zeroResultSearches / totalSearches) * 10000) / 100
+        : 0,
+    avgResultCount: Math.round(parseFloat(row?.avg_result_count || "0")),
+    topSearchHour: parseInt(hourResult.rows[0]?.hour || "12", 10),
+    searchesWithFilters: parseInt(row?.searches_with_filters || "0", 10),
+  };
+}
+
+// ─── Top Queries ──────────────────────────────────────────────────
+
+export async function getTopQueries(
+  days: number = 30,
+  limit: number = 25,
+): Promise<TopQuery[]> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT
+       metadata->>'query' as query,
+       COUNT(*) as count,
+       ROUND(AVG((metadata->>'resultCount')::int)) as avg_result_count,
+       COUNT(*) FILTER (WHERE (metadata->>'resultCount')::int = 0) as zero_result_count,
+       MAX(created_at) as last_searched_at
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+       AND metadata->>'query' IS NOT NULL
+       AND metadata->>'query' != ''
+     GROUP BY metadata->>'query'
+     ORDER BY count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  // Check which queries have existing intent pages
+  const queries = result.rows.map((row) => ({
+    query: row.query,
+    count: parseInt(row.count, 10),
+    avgResultCount: Math.round(parseFloat(row.avg_result_count || "0")),
+    zeroResultCount: parseInt(row.zero_result_count, 10),
+    lastSearchedAt: row.last_searched_at,
+    hasIntentPage: false,
+    intentPageSlug: null as string | null,
+  }));
+
+  // Cross-reference with search_intents
+  if (queries.length > 0) {
+    const queryTerms = queries.map((q) => q.query.toLowerCase().trim());
+    const intentResult = await pool.query(
+      `SELECT slug, search_query FROM search_intents WHERE search_query IS NOT NULL`,
+    );
+
+    const intentMap = new Map<string, string>();
+    for (const row of intentResult.rows) {
+      if (row.search_query) {
+        intentMap.set(row.search_query.toLowerCase().trim(), row.slug);
+      }
+    }
+
+    for (const q of queries) {
+      const slug = intentMap.get(q.query.toLowerCase());
+      if (slug) {
+        q.hasIntentPage = true;
+        q.intentPageSlug = slug;
+      }
+    }
+  }
+
+  return queries;
+}
+
+// ─── Zero-Result Queries ─────────────────────────────────────────
+
+export async function getZeroResultQueries(
+  days: number = 30,
+  limit: number = 20,
+): Promise<ZeroResultQuery[]> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT
+       metadata->>'query' as query,
+       COUNT(*) as count,
+       MAX(created_at) as last_searched_at
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+       AND metadata->>'query' IS NOT NULL
+       AND metadata->>'query' != ''
+       AND ((metadata->>'resultCount')::int = 0 OR metadata->>'resultCount' IS NULL)
+     GROUP BY metadata->>'query'
+     ORDER BY count DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  // Find similar queries and check for existing intent pages
+  const zeroQueries: ZeroResultQuery[] = [];
+
+  for (const row of result.rows) {
+    const query = row.query;
+    const words = query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w: string) => w.length > 2);
+
+    // Find similar queries
+    let similarQueries: string[] = [];
+    if (words.length > 0) {
+      const params = words.map((w: string) => `%${w}%`);
+
+      const similarResult = await pool.query(
+        `SELECT DISTINCT metadata->>'query' as q
+         FROM analytics_events
+         WHERE event_type = 'search'
+           AND metadata->>'query' ILIKE ANY($1)
+           AND metadata->>'query' != $2
+         LIMIT 5`,
+        [params, query],
+      );
+      similarQueries = similarResult.rows.map((r) => r.q);
+    }
+
+    // Check for suggested intent page
+    const slug = query
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "")
+      .substring(0, 100);
+
+    const intentResult = await pool.query(
+      `SELECT slug FROM search_intents WHERE slug = $1 OR search_query = $2`,
+      [slug, query],
+    );
+
+    zeroQueries.push({
+      query,
+      count: parseInt(row.count, 10),
+      lastSearchedAt: row.last_searched_at,
+      similarQueries,
+      suggestedIntentPage:
+        intentResult.rows.length > 0 ? intentResult.rows[0].slug : null,
+    });
+  }
+
+  return zeroQueries;
+}
+
+// ─── Filter Usage ─────────────────────────────────────────────────
+
+export async function getFilterUsage(
+  days: number = 30,
+): Promise<FilterUsage[]> {
+  const interval = `${days} days`;
+
+  // Get all filter events
+  const result = await pool.query(
+    `SELECT metadata->>'filters' as filters
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+       AND metadata->>'filters' IS NOT NULL
+       AND metadata->>'filters' != '{}'
+       AND metadata->>'filters' != 'undefined'`,
+  );
+
+  const filterCounts: Record<
+    string,
+    { count: number; values: Record<string, number> }
+  > = {};
+
+  for (const row of result.rows) {
+    try {
+      const filters =
+        typeof row.filters === "string"
+          ? JSON.parse(row.filters)
+          : row.filters;
+      if (!filters || typeof filters !== "object") continue;
+
+      for (const [key, value] of Object.entries(filters)) {
+        if (!filterCounts[key]) {
+          filterCounts[key] = { count: 0, values: {} };
+        }
+        filterCounts[key].count++;
+        const valStr = String(value);
+        filterCounts[key].values[valStr] =
+          (filterCounts[key].values[valStr] || 0) + 1;
+      }
+    } catch {
+      // Invalid JSON — skip
+    }
+  }
+
+  const totalWithFilters = result.rows.length;
+  const filterUsage: FilterUsage[] = Object.entries(filterCounts)
+    .sort((a, b) => b[1].count - a[1].count)
+    .map(([key, data]) => ({
+      filterKey: key,
+      filterLabel: FILTER_LABELS[key] || key,
+      count: data.count,
+      percentage:
+        totalWithFilters > 0
+          ? Math.round((data.count / totalWithFilters) * 10000) / 100
+          : 0,
+      topValues: Object.entries(data.values)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([value, count]) => ({ value, count })),
+    }));
+
+  return filterUsage;
+}
+
+// ─── Filter Combinations ─────────────────────────────────────────
+
+export async function getFilterCombinations(
+  days: number = 30,
+  limit: number = 10,
+): Promise<FilterCombination[]> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT metadata->>'filters' as filters, metadata->>'resultCount' as result_count
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+       AND metadata->>'filters' IS NOT NULL
+       AND metadata->>'filters' != '{}'
+       AND metadata->>'filters' != 'undefined'`,
+  );
+
+  const comboMap: Record<string, { count: number; totalResults: number }> = {};
+
+  for (const row of result.rows) {
+    try {
+      const filters =
+        typeof row.filters === "string"
+          ? JSON.parse(row.filters)
+          : row.filters;
+      if (!filters || typeof filters !== "object") continue;
+
+      const keys = Object.keys(filters).sort();
+      if (keys.length < 2) continue; // Only combinations of 2+ filters
+
+      const comboKey = keys.join(" + ");
+      if (!comboMap[comboKey]) {
+        comboMap[comboKey] = { count: 0, totalResults: 0 };
+      }
+      comboMap[comboKey].count++;
+      comboMap[comboKey].totalResults += parseInt(
+        row.result_count || "0",
+        10,
+      );
+    } catch {
+      // Invalid JSON — skip
+    }
+  }
+
+  return Object.entries(comboMap)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, limit)
+    .map(([combo, data]) => ({
+      filters: combo.split(" + "),
+      count: data.count,
+      avgResultCount:
+        data.count > 0
+          ? Math.round(data.totalResults / data.count)
+          : 0,
+    }));
+}
+
+// ─── Daily Trend ──────────────────────────────────────────────────
+
+export async function getSearchDailyTrend(
+  days: number = 30,
+): Promise<DailySearchTrend[]> {
+  const interval = `${days} days`;
+
+  const result = await pool.query(
+    `SELECT
+       DATE(created_at) as date,
+       COUNT(*) as total_searches,
+       COUNT(DISTINCT metadata->>'query') as unique_queries,
+       ROUND(
+         COUNT(*) FILTER (WHERE (metadata->>'resultCount')::int = 0 OR metadata->>'resultCount' IS NULL)::numeric
+         / NULLIF(COUNT(*), 0) * 100, 2
+       ) as zero_result_rate
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+     GROUP BY DATE(created_at)
+     ORDER BY date ASC`,
+  );
+
+  return result.rows.map((row) => ({
+    date: row.date,
+    totalSearches: parseInt(row.total_searches, 10),
+    uniqueQueries: parseInt(row.unique_queries, 10),
+    zeroResultRate: parseFloat(row.zero_result_rate || "0"),
+  }));
+}
+
+// ─── Content Gaps ─────────────────────────────────────────────────
+
+export async function getContentGaps(
+  days: number = 30,
+  limit: number = 15,
+): Promise<ContentGap[]> {
+  const interval = `${days} days`;
+
+  // Find queries that have low result counts and high search frequency
+  const result = await pool.query(
+    `SELECT
+       metadata->>'query' as query,
+       COUNT(*) as search_count,
+       ROUND(AVG((metadata->>'resultCount')::int)) as avg_result_count
+     FROM analytics_events
+     WHERE event_type = 'search'
+       AND created_at > NOW() - INTERVAL '${interval}'
+       AND metadata->>'query' IS NOT NULL
+       AND metadata->>'query' != ''
+       AND length(metadata->>'query') > 2
+     GROUP BY metadata->>'query'
+     HAVING COUNT(*) >= 2
+     ORDER BY search_count DESC, avg_result_count ASC
+     LIMIT $1`,
+    [limit * 3], // Over-fetch to filter by intent pages
+  );
+
+  // Cross-reference with search_intents
+  const intentResult = await pool.query(
+    `SELECT slug, search_query FROM search_intents`,
+  );
+  const intentMap = new Map<string, string>();
+  for (const row of intentResult.rows) {
+    if (row.search_query) {
+      intentMap.set(row.search_query.toLowerCase().trim(), row.slug);
+    }
+  }
+
+  const gaps: ContentGap[] = result.rows
+    .map((row) => {
+      const query = row.query;
+      const searchCount = parseInt(row.search_count, 10);
+      const avgResultCount = Math.round(
+        parseFloat(row.avg_result_count || "0"),
+      );
+      const existingSlug = intentMap.get(query.toLowerCase()) || null;
+
+      let suggestedAction: ContentGap["suggestedAction"] = "monitor";
+      let priority: ContentGap["priority"] = "low";
+
+      if (avgResultCount === 0 && searchCount >= 3) {
+        suggestedAction = "create_intent";
+        priority = "high";
+      } else if (avgResultCount > 0 && avgResultCount <= 3 && searchCount >= 5) {
+        suggestedAction = "improve_matching";
+        priority = "medium";
+      } else if (avgResultCount === 0 && searchCount >= 2) {
+        suggestedAction = "create_intent";
+        priority = "medium";
+      }
+
+      return {
+        query,
+        searchCount,
+        avgResultCount,
+        existingIntentSlug: existingSlug,
+        suggestedAction,
+        priority,
+      };
+    })
+    .filter((g) => g.suggestedAction !== "monitor")
+    .slice(0, limit);
+
+  return gaps;
+}
+
+// ─── Full Dashboard Data ─────────────────────────────────────────
+
+export async function getSearchAnalyticsDashboard(
+  days: number = 30,
+): Promise<SearchAnalyticsData> {
+  const [summary, topQueries, zeroResultQueries, filterUsage, filterCombinations, dailyTrend, contentGaps] =
+    await Promise.all([
+      getSearchAnalyticsSummary(days),
+      getTopQueries(days),
+      getZeroResultQueries(days),
+      getFilterUsage(days),
+      getFilterCombinations(days),
+      getSearchDailyTrend(days),
+      getContentGaps(days),
+    ]);
+
+  return {
+    summary,
+    topQueries,
+    zeroResultQueries,
+    filterUsage,
+    filterCombinations,
+    dailyTrend,
+    contentGaps,
+    period: { days },
+  };
+}

--- a/tests/search-analytics-service.test.ts
+++ b/tests/search-analytics-service.test.ts
@@ -1,0 +1,403 @@
+/**
+ * P24.4 — Search Analytics Service Tests
+ *
+ * Tests for search query analytics, zero-result analysis,
+ * filter usage, content gap detection, and trend data.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  pool: {
+    query: vi.fn(),
+  },
+}));
+
+import { pool } from "@/lib/db";
+import {
+  getSearchAnalyticsSummary,
+  getTopQueries,
+  getZeroResultQueries,
+  getFilterUsage,
+  getFilterCombinations,
+  getSearchDailyTrend,
+  getContentGaps,
+  getSearchAnalyticsDashboard,
+} from "@/lib/search-analytics-service";
+
+const mockQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+// ─── Summary Tests ────────────────────────────────────────────
+
+describe("getSearchAnalyticsSummary", () => {
+  it("returns summary with correct calculations", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_searches: "1000",
+            unique_queries: "350",
+            zero_result_searches: "150",
+            avg_result_count: "12.5",
+            searches_with_filters: "400",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ hour: "14", count: "120" }],
+      });
+
+    const summary = await getSearchAnalyticsSummary(30);
+
+    expect(summary.totalSearches).toBe(1000);
+    expect(summary.uniqueQueries).toBe(350);
+    expect(summary.zeroResultSearches).toBe(150);
+    expect(summary.zeroResultRate).toBe(15);
+    expect(summary.avgResultCount).toBe(13);
+    expect(summary.topSearchHour).toBe(14);
+    expect(summary.searchesWithFilters).toBe(400);
+  });
+
+  it("handles empty data gracefully", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_searches: "0",
+            unique_queries: "0",
+            zero_result_searches: "0",
+            avg_result_count: null,
+            searches_with_filters: "0",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [],
+      });
+
+    const summary = await getSearchAnalyticsSummary(30);
+
+    expect(summary.totalSearches).toBe(0);
+    expect(summary.zeroResultRate).toBe(0);
+    expect(summary.avgResultCount).toBe(0);
+    expect(summary.topSearchHour).toBe(12);
+  });
+});
+
+// ─── Top Queries Tests ──────────────────────────────────────────
+
+describe("getTopQueries", () => {
+  it("returns top queries with intent page cross-reference", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            query: "beneteau oceanis",
+            count: "50",
+            avg_result_count: "15",
+            zero_result_count: "2",
+            last_searched_at: "2026-06-07T10:00:00Z",
+          },
+          {
+            query: "bluewater cruiser",
+            count: "30",
+            avg_result_count: "0",
+            zero_result_count: "30",
+            last_searched_at: "2026-06-07T09:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { slug: "beneteau-oceanis", search_query: "beneteau oceanis" },
+        ],
+      });
+
+    const queries = await getTopQueries(30);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0].query).toBe("beneteau oceanis");
+    expect(queries[0].count).toBe(50);
+    expect(queries[0].avgResultCount).toBe(15);
+    expect(queries[0].hasIntentPage).toBe(true);
+    expect(queries[0].intentPageSlug).toBe("beneteau-oceanis");
+    expect(queries[1].hasIntentPage).toBe(false);
+  });
+
+  it("returns empty array when no queries exist", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const queries = await getTopQueries(30);
+    expect(queries).toHaveLength(0);
+  });
+});
+
+// ─── Zero Result Queries Tests ──────────────────────────────────
+
+describe("getZeroResultQueries", () => {
+  it("returns zero-result queries with similar queries", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            query: "luxury catamaran",
+            count: "15",
+            last_searched_at: "2026-06-07T08:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ q: "catamaran luxury" }, { q: "luxury sailing catamaran" }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const queries = await getZeroResultQueries(30);
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0].query).toBe("luxury catamaran");
+    expect(queries[0].count).toBe(15);
+    expect(queries[0].similarQueries).toHaveLength(2);
+    expect(queries[0].suggestedIntentPage).toBeNull();
+  });
+
+  it("finds existing intent page for zero-result query", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            query: "fast racer",
+            count: "5",
+            last_searched_at: "2026-06-07T08:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ q: "fast racing" }] })
+      .mockResolvedValueOnce({
+        rows: [{ slug: "fast-racer" }],
+      });
+
+    const queries = await getZeroResultQueries(30);
+    expect(queries[0].suggestedIntentPage).toBe("fast-racer");
+  });
+});
+
+// ─── Filter Usage Tests ──────────────────────────────────────────
+
+describe("getFilterUsage", () => {
+  it("parses filter usage from metadata", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { filters: '{"lengthMin": "30", "lengthMax": "45"}' },
+        { filters: '{"lengthMin": "35", "keelType": "fin"}' },
+        { filters: '{"lengthMin": "30", "cabinsMin": "3"}' },
+      ],
+    });
+
+    const usage = await getFilterUsage(30);
+
+    expect(usage.length).toBeGreaterThanOrEqual(3);
+    expect(usage[0].filterKey).toBe("lengthMin");
+    expect(usage[0].count).toBe(3);
+    expect(usage[0].percentage).toBe(100);
+
+    const lengthMin = usage.find((f: any) => f.filterKey === "lengthMin");
+    expect(lengthMin).toBeDefined();
+    expect(lengthMin!.topValues.length).toBeGreaterThan(0);
+  });
+
+  it("handles empty filter data", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const usage = await getFilterUsage(30);
+    expect(usage).toHaveLength(0);
+  });
+
+  it("handles invalid JSON in filters", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { filters: "not json" },
+        { filters: '{"lengthMin": "30"}' },
+      ],
+    });
+
+    const usage = await getFilterUsage(30);
+    expect(usage).toHaveLength(1);
+    expect(usage[0].filterKey).toBe("lengthMin");
+  });
+});
+
+// ─── Filter Combinations Tests ──────────────────────────────────
+
+describe("getFilterCombinations", () => {
+  it("finds common filter combinations", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          filters:
+            '{"lengthMin": "30", "lengthMax": "45", "cabinsMin": "3"}',
+          result_count: "12",
+        },
+        {
+          filters:
+            '{"lengthMin": "30", "lengthMax": "45", "keelType": "fin"}',
+          result_count: "8",
+        },
+        {
+          filters: '{"lengthMin": "30"}',
+          result_count: "50",
+        },
+      ],
+    });
+
+    const combos = await getFilterCombinations(30);
+
+    expect(combos.length).toBeGreaterThanOrEqual(1);
+    expect(combos[0].filters.length).toBeGreaterThanOrEqual(2);
+    expect(combos[0].count).toBeGreaterThan(0);
+  });
+
+  it("returns empty when no combos exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const combos = await getFilterCombinations(30);
+    expect(combos).toHaveLength(0);
+  });
+});
+
+// ─── Daily Trend Tests ──────────────────────────────────────────
+
+describe("getSearchDailyTrend", () => {
+  it("returns daily trend data", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          date: "2026-06-05",
+          total_searches: "45",
+          unique_queries: "20",
+          zero_result_rate: "11.11",
+        },
+        {
+          date: "2026-06-06",
+          total_searches: "62",
+          unique_queries: "35",
+          zero_result_rate: "16.13",
+        },
+        {
+          date: "2026-06-07",
+          total_searches: "38",
+          unique_queries: "18",
+          zero_result_rate: "13.16",
+        },
+      ],
+    });
+
+    const trend = await getSearchDailyTrend(30);
+
+    expect(trend).toHaveLength(3);
+    expect(trend[0].totalSearches).toBe(45);
+    expect(trend[1].uniqueQueries).toBe(35);
+    expect(trend[2].zeroResultRate).toBe(13.16);
+  });
+});
+
+// ─── Content Gaps Tests ──────────────────────────────────────────
+
+describe("getContentGaps", () => {
+  it("identifies high-priority content gaps", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            query: "luxury catamaran 50ft",
+            search_count: "8",
+            avg_result_count: "0",
+          },
+          {
+            query: "beneteau first",
+            search_count: "15",
+            avg_result_count: "3",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ slug: "beneteau-first", search_query: "beneteau first" }],
+      });
+
+    const gaps = await getContentGaps(30);
+
+    const catGap = gaps.find((g: any) => g.query === "luxury catamaran 50ft");
+    expect(catGap).toBeDefined();
+    expect(catGap!.priority).toBe("high");
+    expect(catGap!.suggestedAction).toBe("create_intent");
+
+    const beneGap = gaps.find((g: any) => g.query === "beneteau first");
+    expect(beneGap).toBeDefined();
+    expect(beneGap!.existingIntentSlug).toBe("beneteau-first");
+    expect(beneGap!.suggestedAction).toBe("improve_matching");
+  });
+
+  it("filters out low-priority monitor items", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            query: "oceanis 40",
+            search_count: "2",
+            avg_result_count: "25",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const gaps = await getContentGaps(30);
+    expect(gaps).toHaveLength(0);
+  });
+});
+
+// ─── Dashboard Integration Test ──────────────────────────────────
+
+describe("getSearchAnalyticsDashboard", () => {
+  it("assembles full dashboard data from all sections", async () => {
+    // Promise.all runs queries in parallel, so mock order is non-deterministic.
+    // Use a default return value for all calls, with specific overrides for summary.
+    let summaryCallCount = 0;
+    mockQuery.mockImplementation((sql: string) => {
+      const s = typeof sql === "string" ? sql : "";
+      // Summary main query (has searches_with_filters)
+      if (s.includes("searches_with_filters")) {
+        return Promise.resolve({
+          rows: [{
+            total_searches: "200",
+            unique_queries: "80",
+            zero_result_searches: "30",
+            avg_result_count: "10",
+            searches_with_filters: "100",
+          }],
+        });
+      }
+      // Peak hour query
+      if (s.includes("EXTRACT(HOUR")) {
+        return Promise.resolve({ rows: [{ hour: "15", count: "50" }] });
+      }
+      // Default: empty rows
+      return Promise.resolve({ rows: [] });
+    });
+
+    const dashboard = await getSearchAnalyticsDashboard(30);
+
+    expect(dashboard.summary.totalSearches).toBe(200);
+    expect(dashboard.topQueries).toEqual([]);
+    expect(dashboard.zeroResultQueries).toEqual([]);
+    expect(dashboard.filterUsage).toEqual([]);
+    expect(dashboard.filterCombinations).toEqual([]);
+    expect(dashboard.dailyTrend).toEqual([]);
+    expect(dashboard.contentGaps).toEqual([]);
+    expect(dashboard.period).toEqual({ days: 30 });
+  });
+});


### PR DESCRIPTION
- Service: lib/search-analytics-service.ts with 7 query functions
  - getSearchAnalyticsSummary: total searches, unique queries, zero-result rate, peak hour
  - getTopQueries: top search queries with intent page cross-reference
  - getZeroResultQueries: zero-result analysis with similar query discovery
  - getFilterUsage: filter popularity and top values per filter
  - getFilterCombinations: popular 2+ filter combos with avg results
  - getSearchDailyTrend: daily search volume and zero-result rate trends
  - getContentGaps: content gap detection with priority scoring

- API: GET /api/admin/search-analytics with period and section filtering
  - Auth-protected (admin only)
  - Supports individual sections via ?section=summary|queries|zero-results|filters|trends|gaps

- Admin UI: /admin/search-analytics with tabbed dashboard
  - Overview tab: summary cards, daily trend charts, top queries, content gaps
  - Top Queries tab: sortable table with intent page links
  - Zero Results tab: expandable cards with similar queries and intent page status
  - Filters tab: filter usage breakdown with top values, popular combinations
  - Content Gaps tab: priority-scored gaps with suggested actions

- Admin home: Added Search Analytics card

- Tests: 15 tests covering all service functions, edge cases, and dashboard assembly
