### PR TITLE
feat: competitive positioning matrix dashboard (closes #397)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -90,8 +90,8 @@
 
 - **P24.1 — User behavior tracking dashboard** *(completed 2026-06-06 — Issue #388, PR #389, 16 tests)* — Admin dashboard showing page views, popular yachts, search trends, comparison patterns. Aggregate anonymized analytics. Charts for daily/weekly/monthly trends.
 - **P24.2 — A/B testing framework** *(completed 2026-06-06 — Issue #390, PR #391, 17 tests)* — Admin dashboard at /admin/ab-testing with experiment management, variant breakdown, statistical significance calculator (Z-test), confidence intervals, traffic distribution charts, conversion rate comparison. Event tracking API at POST /api/ab/event and GET /api/admin/ab-testing.
-- **P24.3 — Conversion funnel tracking** — Track user journey from landing → search → detail → compare → lead. Identify drop-off points. Admin funnel visualization.
-- **P24.4 — Search intent analysis dashboard** — Analyze search queries, zero-result searches, popular filters. Surface content gaps. Admin dashboard with search analytics.
+- **P24.3 — Conversion funnel tracking** *(completed 2026-06-08)* — Track user journey from landing → search → detail → compare → lead. Identify drop-off points. Admin funnel visualization.
+- **P24.4 — Search intent analysis dashboard** *(completed 2026-06-08)* — Analyze search queries, zero-result searches, popular filters. Surface content gaps. Admin dashboard with search analytics.
 - **P24.5 — Competitive positioning matrix** — Auto-generate competitive positioning analysis for each manufacturer. Market segment coverage visualization. Price positioning charts.
 
 ### Phase 25 — Content Expansion (Priority: Medium) — 🔲 PLANNED

--- a/app/admin/competitive-positioning/CompetitivePositioningClient.tsx
+++ b/app/admin/competitive-positioning/CompetitivePositioningClient.tsx
@@ -1,0 +1,628 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+type SizeSegment = "under-30ft" | "30-35ft" | "35-40ft" | "40-45ft" | "45-50ft" | "over-50ft";
+type PriceTier = "budget" | "mid-range" | "premium" | "luxury" | "unknown";
+
+interface ManufacturerPosition {
+  manufacturerId: number;
+  manufacturerName: string;
+  country: string | null;
+  logoUrl: string | null;
+  fleetSize: number;
+  avgLength: number;
+  minLength: number;
+  maxLength: number;
+  sizeSegments: Record<SizeSegment, number>;
+  priceTier: PriceTier;
+  avgPrice: number | null;
+  minPrice: number | null;
+  maxPrice: number | null;
+  avgCompleteness: number;
+  featureDensity: number;
+  positioningScore: number;
+  breadthScore: number;
+  depthScore: number;
+}
+
+interface SegmentCoverage {
+  segment: SizeSegment;
+  label: string;
+  rangeLabel: string;
+  manufacturerCount: number;
+  yachtCount: number;
+  manufacturers: { name: string; count: number }[];
+}
+
+interface PricePositioning {
+  tier: PriceTier;
+  label: string;
+  rangeLabel: string;
+  manufacturerCount: number;
+  avgFleetSize: number;
+}
+
+interface PositioningQuadrant {
+  manufacturerId: number;
+  manufacturerName: string;
+  breadthScore: number;
+  depthScore: number;
+  quadrant: "specialist" | "generalist" | "niche" | "dominant";
+}
+
+interface CompetitiveMatrix {
+  manufacturers: ManufacturerPosition[];
+  segmentCoverage: SegmentCoverage[];
+  pricePositioning: PricePositioning[];
+  quadrants: PositioningQuadrant[];
+  totalManufacturers: number;
+  totalYachts: number;
+  mostDiverse: string | null;
+  largestFleet: string | null;
+  premiumLeader: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function formatPrice(n: number | null): string {
+  if (n === null) return "—";
+  if (n >= 1_000_000) return `€${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `€${(n / 1_000).toFixed(0)}K`;
+  return `€${n.toLocaleString()}`;
+}
+
+const TIER_COLORS: Record<PriceTier, string> = {
+  budget: "#22c55e",
+  "mid-range": "#3b82f6",
+  premium: "#f59e0b",
+  luxury: "#ef4444",
+  unknown: "#9ca3af",
+};
+
+const SEGMENT_COLORS: Record<SizeSegment, string> = {
+  "under-30ft": "#6ee7b7",
+  "30-35ft": "#3b82f6",
+  "35-40ft": "#8b5cf6",
+  "40-45ft": "#f59e0b",
+  "45-50ft": "#ef4444",
+  "over-50ft": "#ec4899",
+};
+
+const QUADRANT_STYLES: Record<string, { bg: string; text: string; icon: string }> = {
+  dominant: { bg: "bg-green-100", text: "text-green-800", icon: "👑" },
+  generalist: { bg: "bg-blue-100", text: "text-blue-800", icon: "🌐" },
+  specialist: { bg: "bg-purple-100", text: "text-purple-800", icon: "🎯" },
+  niche: { bg: "bg-gray-100", text: "text-gray-800", icon: "🔬" },
+};
+
+// ─── Segment Coverage Heatmap ──────────────────────────────────────
+
+function SegmentHeatmap({ manufacturers }: { manufacturers: ManufacturerPosition[] }) {
+  const segments: SizeSegment[] = ["under-30ft", "30-35ft", "35-40ft", "40-45ft", "45-50ft", "over-50ft"];
+  const segmentLabels: Record<SizeSegment, string> = {
+    "under-30ft": "<30ft", "30-35ft": "30-35", "35-40ft": "35-40",
+    "40-45ft": "40-45", "45-50ft": "45-50", "over-50ft": "50+",
+  };
+
+  const maxCount = Math.max(
+    ...manufacturers.flatMap((m) => segments.map((s) => m.sizeSegments[s])),
+    1
+  );
+
+  function getOpacity(count: number): number {
+    if (count === 0) return 0.05;
+    return 0.2 + (count / maxCount) * 0.8;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left py-2 px-2 text-gray-500 font-medium sticky left-0 bg-white min-w-[140px]">
+              Manufacturer
+            </th>
+            {segments.map((s) => (
+              <th key={s} className="text-center py-2 px-1 text-gray-500 font-medium whitespace-nowrap">
+                {segmentLabels[s]}
+              </th>
+            ))}
+            <th className="text-center py-2 px-2 text-gray-500 font-medium">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {manufacturers.map((m) => (
+            <tr key={m.manufacturerId} className="border-b border-gray-50 hover:bg-gray-50/50">
+              <td className="py-1.5 px-2 font-medium text-gray-800 sticky left-0 bg-white">
+                {m.manufacturerName}
+              </td>
+              {segments.map((s) => {
+                const count = m.sizeSegments[s];
+                return (
+                  <td key={s} className="text-center py-1.5 px-1">
+                    <div
+                      className="mx-auto rounded text-xs font-medium flex items-center justify-center h-8 min-w-[32px]"
+                      style={{
+                        backgroundColor: `rgba(59, 130, 246, ${getOpacity(count)})`,
+                        color: count > 0 ? "white" : "#d1d5db",
+                      }}
+                    >
+                      {count > 0 ? count : "·"}
+                    </div>
+                  </td>
+                );
+              })}
+              <td className="text-center py-1.5 px-2 font-semibold text-gray-700">
+                {m.fleetSize}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Positioning Scatter Plot ──────────────────────────────────────
+
+function PositioningScatter({ quadrants }: { quadrants: PositioningQuadrant[] }) {
+  if (quadrants.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-gray-400">
+        No positioning data available
+      </div>
+    );
+  }
+
+  const width = 600;
+  const height = 400;
+  const padX = 50;
+  const padY = 40;
+  const chartW = width - padX - 20;
+  const chartH = height - padY * 2;
+
+  const QUADRANT_COLORS: Record<string, string> = {
+    dominant: "#22c55e",
+    generalist: "#3b82f6",
+    specialist: "#8b5cf6",
+    niche: "#9ca3af",
+  };
+
+  return (
+    <div>
+      <div className="flex gap-4 mb-3">
+        {Object.entries(QUADRANT_STYLES).map(([key, style]) => (
+          <div key={key} className="flex items-center gap-1.5">
+            <div className="w-3 h-3 rounded-full" style={{ backgroundColor: QUADRANT_COLORS[key] }} />
+            <span className="text-xs text-gray-500 capitalize">{key}</span>
+          </div>
+        ))}
+      </div>
+
+      <svg width="100%" viewBox={`0 0 ${width} ${height}`} className="overflow-visible">
+        {/* Quadrant backgrounds */}
+        <rect x={padX} y={padY} width={chartW / 2} height={chartH / 2} fill="#f0fdf4" opacity={0.5} />
+        <rect x={padX + chartW / 2} y={padY} width={chartW / 2} height={chartH / 2} fill="#eff6ff" opacity={0.5} />
+        <rect x={padX} y={padY + chartH / 2} width={chartW / 2} height={chartH / 2} fill="#f3f4f6" opacity={0.5} />
+        <rect x={padX + chartW / 2} y={padY + chartH / 2} width={chartW / 2} height={chartH / 2} fill="#faf5ff" opacity={0.5} />
+
+        {/* Quadrant labels */}
+        <text x={padX + chartW * 0.25} y={padY + 16} textAnchor="middle" className="text-xs fill-green-400 font-medium">
+          Niche
+        </text>
+        <text x={padX + chartW * 0.75} y={padY + 16} textAnchor="middle" className="text-xs fill-blue-400 font-medium">
+          Generalist
+        </text>
+        <text x={padX + chartW * 0.25} y={padY + chartH - 4} textAnchor="middle" className="text-xs fill-purple-400 font-medium">
+          Specialist
+        </text>
+        <text x={padX + chartW * 0.75} y={padY + chartH - 4} textAnchor="middle" className="text-xs fill-green-500 font-medium">
+          Dominant
+        </text>
+
+        {/* Grid lines */}
+        {[0, 25, 50, 75, 100].map((v) => {
+          const x = padX + (v / 100) * chartW;
+          const y = padY + chartH - (v / 100) * chartH;
+          return (
+            <g key={v}>
+              <line x1={x} y1={padY} x2={x} y2={padY + chartH} stroke="#e5e7eb" strokeWidth={0.5} />
+              <line x1={padX} y1={y} x2={padX + chartW} y2={y} stroke="#e5e7eb" strokeWidth={0.5} />
+              <text x={padX - 5} y={y + 4} textAnchor="end" className="text-xs fill-gray-400">{v}</text>
+              <text x={x} y={height - 5} textAnchor="middle" className="text-xs fill-gray-400">{v}</text>
+            </g>
+          );
+        })}
+
+        {/* Center lines */}
+        <line x1={padX + chartW / 2} y1={padY} x2={padX + chartW / 2} y2={padY + chartH} stroke="#9ca3af" strokeWidth={1} strokeDasharray="4,4" />
+        <line x1={padX} y1={padY + chartH / 2} x2={padX + chartW} y2={padY + chartH / 2} stroke="#9ca3af" strokeWidth={1} strokeDasharray="4,4" />
+
+        {/* Data points */}
+        {quadrants.map((q) => {
+          const x = padX + (q.breadthScore / 100) * chartW;
+          const y = padY + chartH - (q.depthScore / 100) * chartH;
+          const color = QUADRANT_COLORS[q.quadrant] || "#6b7280";
+          return (
+            <g key={q.manufacturerId}>
+              <circle cx={x} cy={y} r={6} fill={color} opacity={0.8} />
+              <text x={x + 8} y={y + 4} className="text-xs fill-gray-700">{q.manufacturerName}</text>
+            </g>
+          );
+        })}
+
+        {/* Axis labels */}
+        <text x={padX + chartW / 2} y={height + 5} textAnchor="middle" className="text-xs fill-gray-500 font-medium">
+          Breadth Score (segment coverage) →
+        </text>
+        <text x={8} y={padY + chartH / 2} textAnchor="middle" className="text-xs fill-gray-500 font-medium"
+          transform={`rotate(-90, 8, ${padY + chartH / 2})`}>
+          Depth Score (models per segment) →
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+// ─── Price Tier Distribution ──────────────────────────────────────
+
+function PriceTierChart({ data }: { data: PricePositioning[] }) {
+  const total = data.reduce((sum, d) => sum + d.manufacturerCount, 0);
+  if (total === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 text-gray-400">
+        No price data available
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((tier) => {
+        const pct = total > 0 ? (tier.manufacturerCount / total) * 100 : 0;
+        return (
+          <div key={tier.tier} className="flex items-center gap-3">
+            <div className="w-24 text-sm font-medium text-gray-700">{tier.label}</div>
+            <div className="flex-1 h-8 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full flex items-center px-3 text-white text-xs font-medium transition-all duration-500"
+                style={{
+                  width: `${Math.max(pct, 2)}%`,
+                  backgroundColor: TIER_COLORS[tier.tier],
+                }}
+              >
+                {pct >= 8 ? `${tier.manufacturerCount} manufacturers` : ""}
+              </div>
+            </div>
+            <div className="w-20 text-right text-xs text-gray-500">
+              {tier.rangeLabel}
+            </div>
+            <div className="w-16 text-right text-xs text-gray-400">
+              {pct.toFixed(0)}%
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Segment Coverage Bars ──────────────────────────────────────
+
+function SegmentCoverageBars({ data }: { data: SegmentCoverage[] }) {
+  const maxYachts = Math.max(...data.map((d) => d.yachtCount), 1);
+
+  return (
+    <div className="space-y-3">
+      {data.map((seg) => {
+        const pct = (seg.yachtCount / maxYachts) * 100;
+        return (
+          <div key={seg.segment} className="flex items-center gap-3">
+            <div className="w-24 text-sm font-medium text-gray-700">{seg.label}</div>
+            <div className="flex-1">
+              <div className="h-7 bg-gray-100 rounded overflow-hidden">
+                <div
+                  className="h-full rounded flex items-center px-3 text-white text-xs font-medium transition-all duration-500"
+                  style={{
+                    width: `${Math.max(pct, 3)}%`,
+                    backgroundColor: SEGMENT_COLORS[seg.segment],
+                  }}
+                >
+                  {seg.yachtCount} yachts ({seg.manufacturerCount} mfrs)
+                </div>
+              </div>
+            </div>
+            <div className="w-16 text-right text-xs text-gray-500">{seg.rangeLabel}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Manufacturer Table ──────────────────────────────────────────
+
+function ManufacturerTable({ manufacturers }: { manufacturers: ManufacturerPosition[] }) {
+  const [sortKey, setSortKey] = useState<keyof ManufacturerPosition>("fleetSize");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const sorted = [...manufacturers].sort((a, b) => {
+    const aVal = a[sortKey];
+    const bVal = b[sortKey];
+    if (typeof aVal === "number" && typeof bVal === "number") {
+      return sortAsc ? aVal - bVal : bVal - aVal;
+    }
+    return sortAsc
+      ? String(aVal ?? "").localeCompare(String(bVal ?? ""))
+      : String(bVal ?? "").localeCompare(String(aVal ?? ""));
+  });
+
+  const handleSort = (key: keyof ManufacturerPosition) => {
+    if (sortKey === key) setSortAsc(!sortAsc);
+    else { setSortKey(key); setSortAsc(false); }
+  };
+
+  const SortIcon = ({ col }: { col: keyof ManufacturerPosition }) => (
+    <span className={`ml-1 text-xs ${sortKey === col ? "text-blue-600" : "text-gray-300"}`}>
+      {sortKey === col ? (sortAsc ? "↑" : "↓") : "↕"}
+    </span>
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200">
+            <th className="text-left py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("manufacturerName")}>
+              Manufacturer <SortIcon col="manufacturerName" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("fleetSize")}>
+              Fleet <SortIcon col="fleetSize" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("avgLength")}>
+              Avg Length <SortIcon col="avgLength" />
+            </th>
+            <th className="text-center py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("priceTier")}>
+              Price Tier <SortIcon col="priceTier" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("avgPrice")}>
+              Avg Price <SortIcon col="avgPrice" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("breadthScore")}>
+              Breadth <SortIcon col="breadthScore" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("depthScore")}>
+              Depth <SortIcon col="depthScore" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("featureDensity")}>
+              Features <SortIcon col="featureDensity" />
+            </th>
+            <th className="text-right py-2 px-2 text-gray-500 font-medium cursor-pointer" onClick={() => handleSort("positioningScore")}>
+              Score <SortIcon col="positioningScore" />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((m) => (
+            <tr key={m.manufacturerId} className="border-b border-gray-50 hover:bg-gray-50">
+              <td className="py-2 px-2 font-medium text-gray-800">{m.manufacturerName}</td>
+              <td className="text-right py-2 px-2 text-gray-700">{m.fleetSize}</td>
+              <td className="text-right py-2 px-2 text-gray-600">{m.avgLength}&apos;</td>
+              <td className="text-center py-2 px-2">
+                <span
+                  className="px-2 py-0.5 rounded-full text-xs font-medium text-white"
+                  style={{ backgroundColor: TIER_COLORS[m.priceTier] }}
+                >
+                  {m.priceTier}
+                </span>
+              </td>
+              <td className="text-right py-2 px-2 text-gray-600">{formatPrice(m.avgPrice)}</td>
+              <td className="text-right py-2 px-2">
+                <span className={`font-medium ${m.breadthScore >= 60 ? "text-green-600" : m.breadthScore >= 30 ? "text-amber-600" : "text-gray-500"}`}>
+                  {m.breadthScore}
+                </span>
+              </td>
+              <td className="text-right py-2 px-2">
+                <span className={`font-medium ${m.depthScore >= 60 ? "text-green-600" : m.depthScore >= 30 ? "text-amber-600" : "text-gray-500"}`}>
+                  {m.depthScore}
+                </span>
+              </td>
+              <td className="text-right py-2 px-2 text-gray-600">{m.featureDensity}/16</td>
+              <td className="text-right py-2 px-2">
+                <span className="font-bold text-blue-600">{m.positioningScore}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Main Dashboard ──────────────────────────────────────────────
+
+export default function CompetitivePositioningClient() {
+  const [data, setData] = useState<CompetitiveMatrix | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/competitive-positioning");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setData(json);
+    } catch (err: any) {
+      setError(err.message || "Failed to load competitive data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-red-700">
+        <h3 className="font-semibold mb-2">Error loading competitive data</h3>
+        <p>{error}</p>
+        <button
+          onClick={fetchData}
+          className="mt-3 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { manufacturers, segmentCoverage, pricePositioning, quadrants } = data;
+
+  // Quadrant summary
+  const quadrantCounts = quadrants.reduce<Record<string, number>>((acc, q) => {
+    acc[q.quadrant] = (acc[q.quadrant] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-8">
+      {/* Refresh */}
+      <div className="flex justify-end">
+        <button
+          onClick={fetchData}
+          className="px-4 py-1.5 bg-white border border-gray-300 rounded-md text-sm text-gray-600 hover:bg-gray-50"
+        >
+          ↻ Refresh
+        </button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Manufacturers</p>
+          <p className="text-2xl font-bold text-gray-800 mt-1">{data.totalManufacturers}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Total Yachts</p>
+          <p className="text-2xl font-bold text-blue-600 mt-1">{formatNumber(data.totalYachts)}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Largest Fleet</p>
+          <p className="text-sm font-bold text-green-600 mt-1">{data.largestFleet || "—"}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Most Diverse</p>
+          <p className="text-sm font-bold text-purple-600 mt-1">{data.mostDiverse || "—"}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Premium Leader</p>
+          <p className="text-sm font-bold text-amber-600 mt-1">{data.premiumLeader || "—"}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Quadrants</p>
+          <div className="flex gap-2 mt-1 flex-wrap">
+            {Object.entries(quadrantCounts).map(([q, count]) => (
+              <span key={q} className={`px-1.5 py-0.5 rounded text-xs font-medium ${QUADRANT_STYLES[q]?.bg} ${QUADRANT_STYLES[q]?.text}`}>
+                {QUADRANT_STYLES[q]?.icon} {count}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Two-column: Scatter + Price */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Positioning Scatter */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">📊 Positioning Matrix</h2>
+          <p className="text-xs text-gray-500 mb-4">Breadth (segment coverage) vs Depth (models per segment)</p>
+          <PositioningScatter quadrants={quadrants} />
+        </div>
+
+        {/* Price Positioning */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">💰 Price Positioning</h2>
+          <p className="text-xs text-gray-500 mb-4">Manufacturer distribution across price tiers</p>
+          <PriceTierChart data={pricePositioning} />
+        </div>
+      </div>
+
+      {/* Segment Coverage */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">📏 Size Segment Coverage</h2>
+        <p className="text-xs text-gray-500 mb-4">Yacht distribution across size categories</p>
+        <SegmentCoverageBars data={segmentCoverage} />
+      </div>
+
+      {/* Heatmap */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">🗺️ Manufacturer × Segment Heatmap</h2>
+        <p className="text-xs text-gray-500 mb-4">Number of models per manufacturer per size segment</p>
+        <SegmentHeatmap manufacturers={manufacturers} />
+      </div>
+
+      {/* Full Manufacturer Table */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">🏢 Manufacturer Rankings</h2>
+        <p className="text-xs text-gray-500 mb-4">Click column headers to sort</p>
+        <ManufacturerTable manufacturers={manufacturers} />
+      </div>
+
+      {/* Methodology */}
+      <div className="bg-blue-50 rounded-lg border border-blue-200 p-6">
+        <h2 className="text-lg font-semibold text-blue-800 mb-3">📐 Scoring Methodology</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div>
+            <p className="font-medium text-blue-700">Breadth Score (0–100)</p>
+            <p className="text-blue-600/70 text-xs">Percentage of size segments with at least 1 model. 6 segments total.</p>
+          </div>
+          <div>
+            <p className="font-medium text-blue-700">Depth Score (0–100)</p>
+            <p className="text-blue-600/70 text-xs">Average models per covered segment, normalized (5+ models = 100).</p>
+          </div>
+          <div>
+            <p className="font-medium text-blue-700">Positioning Score (0–100)</p>
+            <p className="text-blue-600/70 text-xs">Weighted: 30% breadth + 30% depth + 20% fleet size + 10% completeness + 10% features.</p>
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+          {Object.entries(QUADRANT_STYLES).map(([key, style]) => (
+            <div key={key} className={`px-3 py-2 rounded ${style.bg}`}>
+              <span className="text-lg">{style.icon}</span>
+              <span className={`font-medium ml-1 ${style.text} capitalize`}>{key}</span>
+              <p className="text-xs text-gray-600 mt-0.5">
+                {key === "dominant" && "High breadth + high depth"}
+                {key === "generalist" && "High breadth + low depth"}
+                {key === "specialist" && "Low breadth + high depth"}
+                {key === "niche" && "Low breadth + low depth"}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/competitive-positioning/page.tsx
+++ b/app/admin/competitive-positioning/page.tsx
@@ -1,0 +1,35 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import CompetitivePositioningClient from "./CompetitivePositioningClient";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Competitive Positioning - Admin" };
+
+export default async function CompetitivePositioningPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    redirect("/admin");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <a href="/admin" className="text-blue-600 hover:underline text-sm">
+              ← Back to Dashboard
+            </a>
+            <h1 className="text-3xl font-bold text-gray-900 mt-2">
+              Competitive Positioning
+            </h1>
+            <p className="text-gray-500 mt-1">
+              Manufacturer positioning matrix — fleet breadth, depth, price tier, and market segment coverage.
+            </p>
+          </div>
+        </div>
+        <CompetitivePositioningClient />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -211,6 +211,16 @@ export default async function AdminPage() {
                 View Search Analytics
               </a>
             </div>
+            <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Competitive Positioning</h2>
+              <p className="text-gray-600 mb-4">Manufacturer positioning matrix, segment coverage, and price tier analysis.</p>
+              <a
+                href="/admin/competitive-positioning"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                View Positioning
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/api/admin/competitive-positioning/route.ts
+++ b/app/api/admin/competitive-positioning/route.ts
@@ -1,0 +1,31 @@
+/**
+ * P24.5 — Competitive Positioning Matrix API
+ *
+ * GET /api/admin/competitive-positioning
+ * Returns competitive positioning data for all manufacturers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getCompetitiveMatrix } from "@/lib/competitive-positioning-service";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const data = await getCompetitiveMatrix();
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error("[Competitive Positioning API] Error:", error.message);
+    return NextResponse.json(
+      { error: "Failed to load competitive data", details: error.message },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/competitive-positioning-service.ts
+++ b/lib/competitive-positioning-service.ts
@@ -1,0 +1,413 @@
+/**
+ * P24.5 — Competitive Positioning Matrix Service
+ *
+ * Auto-generates competitive positioning analysis for each manufacturer.
+ * Market segment coverage visualization. Price positioning charts.
+ *
+ * Analyzes:
+ *   - Fleet size and model range breadth
+ *   - Size segment coverage (under-30ft, 30-35ft, ..., over-50ft)
+ *   - Price positioning (budget, mid-range, premium, luxury)
+ *   - Feature density (average spec completeness per manufacturer)
+ *   - Market positioning quadrant (breadth vs. depth)
+ */
+
+import { pool } from "./db";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export type SizeSegment =
+  | "under-30ft"
+  | "30-35ft"
+  | "35-40ft"
+  | "40-45ft"
+  | "45-50ft"
+  | "over-50ft";
+
+export type PriceTier = "budget" | "mid-range" | "premium" | "luxury" | "unknown";
+
+export interface ManufacturerPosition {
+  manufacturerId: number;
+  manufacturerName: string;
+  country: string | null;
+  logoUrl: string | null;
+  fleetSize: number;
+  avgLength: number;
+  minLength: number;
+  maxLength: number;
+  sizeSegments: Record<SizeSegment, number>;
+  priceTier: PriceTier;
+  avgPrice: number | null;
+  minPrice: number | null;
+  maxPrice: number | null;
+  avgCompleteness: number;
+  featureDensity: number; // average specs per model
+  positioningScore: number; // 0-100 composite score
+  breadthScore: number; // how many size segments covered (0-100)
+  depthScore: number; // how many models per segment (0-100)
+}
+
+export interface SegmentCoverage {
+  segment: SizeSegment;
+  label: string;
+  rangeLabel: string;
+  manufacturerCount: number;
+  yachtCount: number;
+  manufacturers: { name: string; count: number }[];
+}
+
+export interface PricePositioning {
+  tier: PriceTier;
+  label: string;
+  rangeLabel: string;
+  manufacturerCount: number;
+  avgFleetSize: number;
+}
+
+export interface PositioningQuadrant {
+  manufacturerId: number;
+  manufacturerName: string;
+  breadthScore: number;
+  depthScore: number;
+  quadrant: "specialist" | "generalist" | "niche" | "dominant";
+}
+
+export interface CompetitiveMatrix {
+  manufacturers: ManufacturerPosition[];
+  segmentCoverage: SegmentCoverage[];
+  pricePositioning: PricePositioning[];
+  quadrants: PositioningQuadrant[];
+  totalManufacturers: number;
+  totalYachts: number;
+  mostDiverse: string | null;
+  largestFleet: string | null;
+  premiumLeader: string | null;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+const SIZE_SEGMENTS: { key: SizeSegment; label: string; range: string; min: number; max: number }[] = [
+  { key: "under-30ft", label: "Under 30ft", range: "< 9.14m", min: 0, max: 30 },
+  { key: "30-35ft", label: "30–35ft", range: "9.14–10.67m", min: 30, max: 35 },
+  { key: "35-40ft", label: "35–40ft", range: "10.67–12.19m", min: 35, max: 40 },
+  { key: "40-45ft", label: "40–45ft", range: "12.19–13.72m", min: 40, max: 45 },
+  { key: "45-50ft", label: "45–50ft", range: "13.72–15.24m", min: 45, max: 50 },
+  { key: "over-50ft", label: "Over 50ft", range: "> 15.24m", min: 50, max: 999 },
+];
+
+const PRICE_TIERS: { key: PriceTier; label: string; range: string; min: number; max: number }[] = [
+  { key: "budget", label: "Budget", range: "< €80k", min: 0, max: 80000 },
+  { key: "mid-range", label: "Mid-Range", range: "€80k–€200k", min: 80000, max: 200000 },
+  { key: "premium", label: "Premium", range: "€200k–€500k", min: 200000, max: 500000 },
+  { key: "luxury", label: "Luxury", range: "> €500k", min: 500000, max: Infinity },
+];
+
+// ─── Helper Functions ──────────────────────────────────────────────
+
+export function classifySizeSegment(lengthFt: number): SizeSegment {
+  for (const seg of SIZE_SEGMENTS) {
+    if (lengthFt >= seg.min && lengthFt < seg.max) return seg.key;
+  }
+  return "over-50ft";
+}
+
+export function classifyPriceTier(avgPrice: number | null): PriceTier {
+  if (avgPrice === null) return "unknown";
+  for (const tier of PRICE_TIERS) {
+    if (avgPrice >= tier.min && avgPrice < tier.max) return tier.key;
+  }
+  return "unknown";
+}
+
+export function computeBreadthScore(segments: Record<SizeSegment, number>): number {
+  const covered = Object.values(segments).filter((c) => c > 0).length;
+  return Math.round((covered / SIZE_SEGMENTS.length) * 100);
+}
+
+export function computeDepthScore(segments: Record<SizeSegment, number>, fleetSize: number): number {
+  if (fleetSize === 0) return 0;
+  const maxPerSegment = Math.max(...Object.values(segments));
+  // Score based on average depth across covered segments
+  const covered = Object.values(segments).filter((c) => c > 0);
+  const avgDepth = covered.length > 0 ? covered.reduce((a, b) => a + b, 0) / covered.length : 0;
+  // Normalize: 5+ models per segment = 100
+  return Math.min(Math.round((avgDepth / 5) * 100), 100);
+}
+
+export function classifyQuadrant(breadthScore: number, depthScore: number): PositioningQuadrant["quadrant"] {
+  const breadthMedian = 50;
+  const depthMedian = 40;
+  if (breadthScore >= breadthMedian && depthScore >= depthMedian) return "dominant";
+  if (breadthScore >= breadthMedian && depthScore < depthMedian) return "generalist";
+  if (breadthScore < breadthMedian && depthScore >= depthMedian) return "specialist";
+  return "niche";
+}
+
+// ─── Query Functions ──────────────────────────────────────────────
+
+/**
+ * Get manufacturer positioning data with fleet analysis.
+ */
+export async function getManufacturerPositions(): Promise<ManufacturerPosition[]> {
+  const result = await pool.query(`
+    SELECT
+      m.id as manufacturer_id,
+      m.name as manufacturer_name,
+      m.country,
+      m.logo_url,
+      COUNT(ym.id) as fleet_size,
+      COALESCE(AVG(COALESCE(CAST(ym.length_overall AS numeric), 0)), 0) as avg_length,
+      COALESCE(MIN(CAST(ym.length_overall AS numeric)), 0) as min_length,
+      COALESCE(MAX(CAST(ym.length_overall AS numeric)), 0) as max_length,
+      COALESCE(AVG(CAST(ym.completeness_score AS numeric)), 0) as avg_completeness
+    FROM manufacturers m
+    LEFT JOIN yacht_models ym ON ym.manufacturer_id = m.id
+    GROUP BY m.id, m.name, m.country, m.logo_url
+    HAVING COUNT(ym.id) > 0
+    ORDER BY fleet_size DESC
+  `);
+
+  // Get price data per manufacturer
+  const priceResult = await pool.query(`
+    SELECT
+      ym.manufacturer_id,
+      AVG((CAST(p.price_min AS numeric) + CAST(p.price_max AS numeric)) / 2) as avg_price,
+      MIN(CAST(p.price_min AS numeric)) as min_price,
+      MAX(CAST(p.price_max AS numeric)) as max_price
+    FROM yacht_models ym
+    JOIN yacht_prices p ON p.yacht_model_id = ym.id
+    GROUP BY ym.manufacturer_id
+  `);
+
+  const priceMap = new Map<number, { avg: number; min: number; max: number }>();
+  for (const row of priceResult.rows) {
+    priceMap.set(row.manufacturer_id, {
+      avg: parseFloat(row.avg_price),
+      min: parseFloat(row.min_price),
+      max: parseFloat(row.max_price),
+    });
+  }
+
+  // Get size segment distribution per manufacturer
+  const segmentResult = await pool.query(`
+    SELECT
+      ym.manufacturer_id,
+      CASE
+        WHEN CAST(ym.length_overall AS numeric) < 30 THEN 'under-30ft'
+        WHEN CAST(ym.length_overall AS numeric) >= 30 AND CAST(ym.length_overall AS numeric) < 35 THEN '30-35ft'
+        WHEN CAST(ym.length_overall AS numeric) >= 35 AND CAST(ym.length_overall AS numeric) < 40 THEN '35-40ft'
+        WHEN CAST(ym.length_overall AS numeric) >= 40 AND CAST(ym.length_overall AS numeric) < 45 THEN '40-45ft'
+        WHEN CAST(ym.length_overall AS numeric) >= 45 AND CAST(ym.length_overall AS numeric) < 50 THEN '45-50ft'
+        ELSE 'over-50ft'
+      END as segment,
+      COUNT(*) as count
+    FROM yacht_models ym
+    WHERE ym.length_overall IS NOT NULL
+    GROUP BY ym.manufacturer_id, segment
+  `);
+
+  const segmentMap = new Map<number, Record<SizeSegment, number>>();
+  for (const row of segmentResult.rows) {
+    if (!segmentMap.has(row.manufacturer_id)) {
+      segmentMap.set(row.manufacturer_id, {
+        "under-30ft": 0, "30-35ft": 0, "35-40ft": 0,
+        "40-45ft": 0, "45-50ft": 0, "over-50ft": 0,
+      });
+    }
+    segmentMap.get(row.manufacturer_id)![row.segment as SizeSegment] = parseInt(row.count, 10);
+  }
+
+  // Get feature density (average non-null specs per model)
+  const featureResult = await pool.query(`
+    SELECT
+      ym.manufacturer_id,
+      AVG(
+        (CASE WHEN ym.length_overall IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.beam IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.draft IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.displacement IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.ballast IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.sail_area_main IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.rig_type IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.keel_type IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.hull_material IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.cabins IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.berths IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.heads IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.engine_hp IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.engine_type IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.fuel_capacity IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN ym.water_capacity IS NOT NULL THEN 1 ELSE 0 END)
+      ) as feature_density
+    FROM yacht_models ym
+    GROUP BY ym.manufacturer_id
+  `);
+
+  const featureMap = new Map<number, number>();
+  for (const row of featureResult.rows) {
+    featureMap.set(row.manufacturer_id, parseFloat(row.feature_density || "0"));
+  }
+
+  return result.rows.map((row) => {
+    const fleetSize = parseInt(row.fleet_size, 10);
+    const segments = segmentMap.get(row.manufacturer_id) || {
+      "under-30ft": 0, "30-35ft": 0, "35-40ft": 0,
+      "40-45ft": 0, "45-50ft": 0, "over-50ft": 0,
+    };
+    const priceData = priceMap.get(row.manufacturer_id);
+    const avgPrice = priceData?.avg ?? null;
+    const avgCompleteness = parseFloat(row.avg_completeness) || 0;
+    const featureDensity = featureMap.get(row.manufacturer_id) || 0;
+    const breadthScore = computeBreadthScore(segments);
+    const depthScore = computeDepthScore(segments, fleetSize);
+
+    // Composite positioning score: weighted average
+    const positioningScore = Math.round(
+      breadthScore * 0.3 +
+      depthScore * 0.3 +
+      Math.min(fleetSize, 50) / 50 * 100 * 0.2 +
+      avgCompleteness * 0.1 +
+      Math.min(featureDensity / 16, 1) * 100 * 0.1
+    );
+
+    return {
+      manufacturerId: row.manufacturer_id,
+      manufacturerName: row.manufacturer_name,
+      country: row.country,
+      logoUrl: row.logo_url,
+      fleetSize,
+      avgLength: Math.round(parseFloat(row.avg_length) * 10) / 10,
+      minLength: Math.round(parseFloat(row.min_length) * 10) / 10,
+      maxLength: Math.round(parseFloat(row.max_length) * 10) / 10,
+      sizeSegments: segments,
+      priceTier: classifyPriceTier(avgPrice),
+      avgPrice: avgPrice !== null ? Math.round(avgPrice) : null,
+      minPrice: priceData?.min ? Math.round(priceData.min) : null,
+      maxPrice: priceData?.max ? Math.round(priceData.max) : null,
+      avgCompleteness: Math.round(avgCompleteness),
+      featureDensity: Math.round(featureDensity * 10) / 10,
+      positioningScore,
+      breadthScore,
+      depthScore,
+    };
+  });
+}
+
+/**
+ * Get segment coverage across all manufacturers.
+ */
+export async function getSegmentCoverage(): Promise<SegmentCoverage[]> {
+  const positions = await getManufacturerPositions();
+
+  return SIZE_SEGMENTS.map((seg) => {
+    const manufacturerData: { name: string; count: number }[] = [];
+    let yachtCount = 0;
+
+    for (const pos of positions) {
+      const count = pos.sizeSegments[seg.key];
+      if (count > 0) {
+        manufacturerData.push({ name: pos.manufacturerName, count });
+        yachtCount += count;
+      }
+    }
+
+    // Sort by count descending
+    manufacturerData.sort((a, b) => b.count - a.count);
+
+    return {
+      segment: seg.key,
+      label: seg.label,
+      rangeLabel: seg.range,
+      manufacturerCount: manufacturerData.length,
+      yachtCount,
+      manufacturers: manufacturerData,
+    };
+  });
+}
+
+/**
+ * Get price positioning analysis.
+ */
+export async function getPricePositioning(): Promise<PricePositioning[]> {
+  const positions = await getManufacturerPositions();
+
+  return PRICE_TIERS.map((tier) => {
+    const inTier = positions.filter((p) => p.priceTier === tier.key);
+    return {
+      tier: tier.key,
+      label: tier.label,
+      rangeLabel: tier.range,
+      manufacturerCount: inTier.length,
+      avgFleetSize: inTier.length > 0
+        ? Math.round(inTier.reduce((sum, p) => sum + p.fleetSize, 0) / inTier.length)
+        : 0,
+    };
+  }).concat([
+    {
+      tier: "unknown" as PriceTier,
+      label: "No Price Data",
+      rangeLabel: "—",
+      manufacturerCount: positions.filter((p) => p.priceTier === "unknown").length,
+      avgFleetSize: positions.filter((p) => p.priceTier === "unknown").length > 0
+        ? Math.round(
+            positions
+              .filter((p) => p.priceTier === "unknown")
+              .reduce((sum, p) => sum + p.fleetSize, 0) /
+            positions.filter((p) => p.priceTier === "unknown").length
+          )
+        : 0,
+    },
+  ]);
+}
+
+/**
+ * Get positioning quadrant analysis.
+ */
+export async function getPositioningQuadrants(): Promise<PositioningQuadrant[]> {
+  const positions = await getManufacturerPositions();
+
+  return positions.map((pos) => ({
+    manufacturerId: pos.manufacturerId,
+    manufacturerName: pos.manufacturerName,
+    breadthScore: pos.breadthScore,
+    depthScore: pos.depthScore,
+    quadrant: classifyQuadrant(pos.breadthScore, pos.depthScore),
+  }));
+}
+
+/**
+ * Get full competitive matrix for admin dashboard.
+ */
+export async function getCompetitiveMatrix(): Promise<CompetitiveMatrix> {
+  const [manufacturers, segmentCoverage, pricePositioning, quadrants] = await Promise.all([
+    getManufacturerPositions(),
+    getSegmentCoverage(),
+    getPricePositioning(),
+    getPositioningQuadrants(),
+  ]);
+
+  const totalYachts = manufacturers.reduce((sum, m) => sum + m.fleetSize, 0);
+
+  // Find highlights
+  const mostDiverse = manufacturers.length > 0
+    ? [...manufacturers].sort((a, b) => b.breadthScore - a.breadthScore)[0]?.manufacturerName || null
+    : null;
+  const largestFleet = manufacturers.length > 0
+    ? [...manufacturers].sort((a, b) => b.fleetSize - a.fleetSize)[0]?.manufacturerName || null
+    : null;
+  const premiumLeader = manufacturers.filter((m) => m.avgPrice !== null).length > 0
+    ? [...manufacturers].filter((m) => m.avgPrice !== null).sort((a, b) => (b.avgPrice || 0) - (a.avgPrice || 0))[0]?.manufacturerName || null
+    : null;
+
+  return {
+    manufacturers,
+    segmentCoverage,
+    pricePositioning,
+    quadrants,
+    totalManufacturers: manufacturers.length,
+    totalYachts,
+    mostDiverse,
+    largestFleet,
+    premiumLeader,
+  };
+}

--- a/tests/competitive-positioning.test.ts
+++ b/tests/competitive-positioning.test.ts
@@ -1,0 +1,553 @@
+/**
+ * P24.5 — Competitive Positioning Matrix Tests
+ *
+ * Tests for the competitive positioning service, data transformations,
+ * scoring functions, and API contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Service Tests ──────────────────────────────────────────────
+
+describe("Competitive Positioning Service", () => {
+  vi.mock("@/lib/db", () => ({
+    pool: {
+      query: vi.fn(),
+    },
+  }));
+
+  let pool: any;
+
+  beforeEach(async () => {
+    const db = await import("@/lib/db");
+    pool = db.pool;
+    vi.clearAllMocks();
+  });
+
+  describe("getManufacturerPositions", () => {
+    it("should return manufacturer positioning data", async () => {
+      // Main query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1,
+            manufacturer_name: "Beneteau",
+            country: "France",
+            logo_url: "/logos/beneteau.svg",
+            fleet_size: "45",
+            avg_length: "38.5",
+            min_length: "25",
+            max_length: "55",
+            avg_completeness: "72",
+          },
+          {
+            manufacturer_id: 2,
+            manufacturer_name: "Bavaria",
+            country: "Germany",
+            logo_url: null,
+            fleet_size: "20",
+            avg_length: "36.2",
+            min_length: "30",
+            max_length: "46",
+            avg_completeness: "65",
+          },
+        ],
+      });
+
+      // Price query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1,
+            avg_price: "250000",
+            min_price: "120000",
+            max_price: "500000",
+          },
+        ],
+      });
+
+      // Segment query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "15" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "12" },
+          { manufacturer_id: 1, segment: "30-35ft", count: "8" },
+          { manufacturer_id: 1, segment: "45-50ft", count: "6" },
+          { manufacturer_id: 1, segment: "over-50ft", count: "2" },
+          { manufacturer_id: 1, segment: "under-30ft", count: "2" },
+          { manufacturer_id: 2, segment: "35-40ft", count: "10" },
+          { manufacturer_id: 2, segment: "30-35ft", count: "8" },
+          { manufacturer_id: 2, segment: "40-45ft", count: "2" },
+        ],
+      });
+
+      // Feature density query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, feature_density: "12.5" },
+          { manufacturer_id: 2, feature_density: "10.2" },
+        ],
+      });
+
+      const { getManufacturerPositions } = await import("@/lib/competitive-positioning-service");
+      const positions = await getManufacturerPositions();
+
+      expect(positions).toHaveLength(2);
+
+      // Beneteau — full segment coverage
+      expect(positions[0].manufacturerName).toBe("Beneteau");
+      expect(positions[0].fleetSize).toBe(45);
+      expect(positions[0].breadthScore).toBe(100); // all 6 segments covered
+      expect(positions[0].priceTier).toBe("premium"); // avg 250k
+
+      // Bavaria — partial coverage
+      expect(positions[1].manufacturerName).toBe("Bavaria");
+      expect(positions[1].fleetSize).toBe(20);
+      expect(positions[1].breadthScore).toBe(50); // 3 out of 6 segments
+      expect(positions[1].priceTier).toBe("unknown"); // no price data
+    });
+
+    it("should handle empty results", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const { getManufacturerPositions } = await import("@/lib/competitive-positioning-service");
+      const positions = await getManufacturerPositions();
+
+      expect(positions).toHaveLength(0);
+    });
+  });
+
+  describe("getSegmentCoverage", () => {
+    it("should return coverage for all 6 size segments", async () => {
+      // getSegmentCoverage calls getManufacturerPositions internally
+      // So we need to mock all 4 queries that getManufacturerPositions makes
+
+      // Main query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "Beneteau", country: "France",
+            logo_url: null, fleet_size: "10", avg_length: "38", min_length: "30",
+            max_length: "45", avg_completeness: "70",
+          },
+        ],
+      });
+      // Price query
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      // Segment query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "6" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "4" },
+        ],
+      });
+      // Feature density query
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, feature_density: "10" }],
+      });
+
+      const { getSegmentCoverage } = await import("@/lib/competitive-positioning-service");
+      const coverage = await getSegmentCoverage();
+
+      expect(coverage).toHaveLength(6);
+      expect(coverage[0].segment).toBe("under-30ft");
+      expect(coverage[0].yachtCount).toBe(0);
+      expect(coverage[0].manufacturerCount).toBe(0);
+
+      // 35-40ft segment has Beneteau with 6 models
+      const seg3540 = coverage.find((s) => s.segment === "35-40ft")!;
+      expect(seg3540.yachtCount).toBe(6);
+      expect(seg3540.manufacturerCount).toBe(1);
+      expect(seg3540.manufacturers[0].name).toBe("Beneteau");
+      expect(seg3540.manufacturers[0].count).toBe(6);
+    });
+  });
+
+  describe("getPricePositioning", () => {
+    it("should return price tier distribution", async () => {
+      // getManufacturerPositions mock
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "BudgetCo", country: null,
+            logo_url: null, fleet_size: "5", avg_length: "30", min_length: "25",
+            max_length: "35", avg_completeness: "50",
+          },
+          {
+            manufacturer_id: 2, manufacturer_name: "LuxCo", country: null,
+            logo_url: null, fleet_size: "8", avg_length: "48", min_length: "42",
+            max_length: "55", avg_completeness: "80",
+          },
+        ],
+      });
+      // Price query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, avg_price: "50000", min_price: "40000", max_price: "60000" },
+          { manufacturer_id: 2, avg_price: "750000", min_price: "500000", max_price: "1000000" },
+        ],
+      });
+      // Segment query
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      // Feature density query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, feature_density: "8" },
+          { manufacturer_id: 2, feature_density: "14" },
+        ],
+      });
+
+      const { getPricePositioning } = await import("@/lib/competitive-positioning-service");
+      const tiers = await getPricePositioning();
+
+      expect(tiers).toHaveLength(5); // 4 tiers + unknown
+      expect(tiers.find((t) => t.tier === "budget")!.manufacturerCount).toBe(1);
+      expect(tiers.find((t) => t.tier === "luxury")!.manufacturerCount).toBe(1);
+      expect(tiers.find((t) => t.tier === "unknown")!.manufacturerCount).toBe(0);
+    });
+  });
+
+  describe("getPositioningQuadrants", () => {
+    it("should classify manufacturers into quadrants", async () => {
+      // getManufacturerPositions mock
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "BigCo", country: null,
+            logo_url: null, fleet_size: "50", avg_length: "38", min_length: "25",
+            max_length: "55", avg_completeness: "80",
+          },
+          {
+            manufacturer_id: 2, manufacturer_name: "SmallCo", country: null,
+            logo_url: null, fleet_size: "3", avg_length: "35", min_length: "34",
+            max_length: "36", avg_completeness: "40",
+          },
+        ],
+      });
+      // Price query
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      // Segment query — BigCo covers all segments, SmallCo only 1
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "under-30ft", count: "5" },
+          { manufacturer_id: 1, segment: "30-35ft", count: "8" },
+          { manufacturer_id: 1, segment: "35-40ft", count: "12" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "10" },
+          { manufacturer_id: 1, segment: "45-50ft", count: "8" },
+          { manufacturer_id: 1, segment: "over-50ft", count: "7" },
+          { manufacturer_id: 2, segment: "35-40ft", count: "3" },
+        ],
+      });
+      // Feature density query
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, feature_density: "14" },
+          { manufacturer_id: 2, feature_density: "6" },
+        ],
+      });
+
+      const { getPositioningQuadrants } = await import("@/lib/competitive-positioning-service");
+      const quadrants = await getPositioningQuadrants();
+
+      expect(quadrants).toHaveLength(2);
+
+      // BigCo: breadth=100 (all segments), depth=high → dominant
+      const bigCo = quadrants.find((q) => q.manufacturerName === "BigCo")!;
+      expect(bigCo.breadthScore).toBe(100);
+      expect(bigCo.quadrant).toBe("dominant");
+
+      // SmallCo: breadth=~17 (1/6), depth depends on avg → likely niche
+      const smallCo = quadrants.find((q) => q.manufacturerName === "SmallCo")!;
+      expect(smallCo.breadthScore).toBe(17); // Math.round(1/6 * 100)
+      expect(["niche", "specialist"]).toContain(smallCo.quadrant);
+    });
+  });
+
+  describe("getCompetitiveMatrix", () => {
+    it("should assemble full competitive matrix", async () => {
+      // Mock getManufacturerPositions (4 queries)
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "TestCo", country: "France",
+            logo_url: null, fleet_size: "10", avg_length: "38", min_length: "30",
+            max_length: "45", avg_completeness: "70",
+          },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, avg_price: "150000", min_price: "100000", max_price: "200000" }],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "6" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "4" },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, feature_density: "11" }],
+      });
+
+      // getSegmentCoverage internally calls getManufacturerPositions again (4 queries)
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "TestCo", country: "France",
+            logo_url: null, fleet_size: "10", avg_length: "38", min_length: "30",
+            max_length: "45", avg_completeness: "70",
+          },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, avg_price: "150000", min_price: "100000", max_price: "200000" }],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "6" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "4" },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, feature_density: "11" }],
+      });
+
+      // getPricePositioning internally calls getManufacturerPositions again (4 queries)
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "TestCo", country: "France",
+            logo_url: null, fleet_size: "10", avg_length: "38", min_length: "30",
+            max_length: "45", avg_completeness: "70",
+          },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, avg_price: "150000", min_price: "100000", max_price: "200000" }],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "6" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "4" },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, feature_density: "11" }],
+      });
+
+      // getPositioningQuadrants internally calls getManufacturerPositions again (4 queries)
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            manufacturer_id: 1, manufacturer_name: "TestCo", country: "France",
+            logo_url: null, fleet_size: "10", avg_length: "38", min_length: "30",
+            max_length: "45", avg_completeness: "70",
+          },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, avg_price: "150000", min_price: "100000", max_price: "200000" }],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { manufacturer_id: 1, segment: "35-40ft", count: "6" },
+          { manufacturer_id: 1, segment: "40-45ft", count: "4" },
+        ],
+      });
+      pool.query.mockResolvedValueOnce({
+        rows: [{ manufacturer_id: 1, feature_density: "11" }],
+      });
+
+      const { getCompetitiveMatrix } = await import("@/lib/competitive-positioning-service");
+      const matrix = await getCompetitiveMatrix();
+
+      expect(matrix.manufacturers).toHaveLength(1);
+      expect(matrix.segmentCoverage).toHaveLength(6);
+      expect(matrix.pricePositioning).toHaveLength(5);
+      expect(matrix.quadrants).toHaveLength(1);
+      expect(matrix.totalManufacturers).toBe(1);
+      expect(matrix.totalYachts).toBe(10);
+      expect(matrix.largestFleet).toBe("TestCo");
+      expect(matrix.mostDiverse).toBe("TestCo");
+      expect(matrix.premiumLeader).toBe("TestCo");
+    });
+  });
+});
+
+// ─── Scoring Logic Tests ──────────────────────────────────────────
+
+describe("Positioning Score Calculations", () => {
+  it("should classify size segments correctly", async () => {
+    const { classifySizeSegment } = await import("@/lib/competitive-positioning-service");
+
+    expect(classifySizeSegment(25)).toBe("under-30ft");
+    expect(classifySizeSegment(32)).toBe("30-35ft");
+    expect(classifySizeSegment(38)).toBe("35-40ft");
+    expect(classifySizeSegment(42)).toBe("40-45ft");
+    expect(classifySizeSegment(48)).toBe("45-50ft");
+    expect(classifySizeSegment(55)).toBe("over-50ft");
+  });
+
+  it("should classify price tiers correctly", async () => {
+    const { classifyPriceTier } = await import("@/lib/competitive-positioning-service");
+
+    expect(classifyPriceTier(50000)).toBe("budget");
+    expect(classifyPriceTier(120000)).toBe("mid-range");
+    expect(classifyPriceTier(350000)).toBe("premium");
+    expect(classifyPriceTier(750000)).toBe("luxury");
+    expect(classifyPriceTier(null)).toBe("unknown");
+  });
+
+  it("should compute breadth score from segment coverage", async () => {
+    const { computeBreadthScore } = await import("@/lib/competitive-positioning-service");
+
+    // All 6 segments covered
+    expect(computeBreadthScore({
+      "under-30ft": 1, "30-35ft": 1, "35-40ft": 1,
+      "40-45ft": 1, "45-50ft": 1, "over-50ft": 1,
+    })).toBe(100);
+
+    // 3 segments covered
+    expect(computeBreadthScore({
+      "under-30ft": 0, "30-35ft": 5, "35-40ft": 3,
+      "40-45ft": 0, "45-50ft": 2, "over-50ft": 0,
+    })).toBe(50);
+
+    // No segments
+    expect(computeBreadthScore({
+      "under-30ft": 0, "30-35ft": 0, "35-40ft": 0,
+      "40-45ft": 0, "45-50ft": 0, "over-50ft": 0,
+    })).toBe(0);
+  });
+
+  it("should compute depth score from segment distribution", async () => {
+    const { computeDepthScore } = await import("@/lib/competitive-positioning-service");
+
+    // 10 models across 2 segments = avg 5 per segment = score 100
+    expect(computeDepthScore({
+      "under-30ft": 0, "30-35ft": 5, "35-40ft": 5,
+      "40-45ft": 0, "45-50ft": 0, "over-50ft": 0,
+    }, 10)).toBe(100);
+
+    // 2 models across 2 segments = avg 1 per segment = score 20
+    expect(computeDepthScore({
+      "under-30ft": 0, "30-35ft": 1, "35-40ft": 1,
+      "40-45ft": 0, "45-50ft": 0, "over-50ft": 0,
+    }, 2)).toBe(20);
+  });
+
+  it("should classify quadrants correctly", async () => {
+    const { classifyQuadrant } = await import("@/lib/competitive-positioning-service");
+
+    expect(classifyQuadrant(80, 80)).toBe("dominant");
+    expect(classifyQuadrant(80, 20)).toBe("generalist");
+    expect(classifyQuadrant(20, 80)).toBe("specialist");
+    expect(classifyQuadrant(20, 20)).toBe("niche");
+  });
+});
+
+// ─── API Contract Tests ──────────────────────────────────────────
+
+describe("Competitive Positioning API Contract", () => {
+  it("should validate competitive matrix data structure", () => {
+    const validMatrix = {
+      manufacturers: [
+        {
+          manufacturerId: 1,
+          manufacturerName: "TestCo",
+          country: "France",
+          logoUrl: null,
+          fleetSize: 10,
+          avgLength: 38,
+          minLength: 30,
+          maxLength: 45,
+          sizeSegments: {
+            "under-30ft": 0, "30-35ft": 2, "35-40ft": 5,
+            "40-45ft": 3, "45-50ft": 0, "over-50ft": 0,
+          },
+          priceTier: "mid-range",
+          avgPrice: 150000,
+          minPrice: 100000,
+          maxPrice: 200000,
+          avgCompleteness: 70,
+          featureDensity: 12.5,
+          positioningScore: 65,
+          breadthScore: 50,
+          depthScore: 40,
+        },
+      ],
+      segmentCoverage: [
+        {
+          segment: "35-40ft",
+          label: "35–40ft",
+          rangeLabel: "10.67–12.19m",
+          manufacturerCount: 1,
+          yachtCount: 5,
+          manufacturers: [{ name: "TestCo", count: 5 }],
+        },
+      ],
+      pricePositioning: [
+        { tier: "mid-range", label: "Mid-Range", rangeLabel: "€80k–€200k", manufacturerCount: 1, avgFleetSize: 10 },
+      ],
+      quadrants: [
+        { manufacturerId: 1, manufacturerName: "TestCo", breadthScore: 50, depthScore: 40, quadrant: "niche" },
+      ],
+      totalManufacturers: 1,
+      totalYachts: 10,
+      mostDiverse: "TestCo",
+      largestFleet: "TestCo",
+      premiumLeader: "TestCo",
+    };
+
+    expect(validMatrix.manufacturers).toHaveLength(1);
+    expect(validMatrix.manufacturers[0].sizeSegments).toHaveProperty("35-40ft");
+    expect(validMatrix.quadrants[0].quadrant).toBe("niche");
+    expect(validMatrix.pricePositioning[0].tier).toBe("mid-range");
+  });
+});
+
+// ─── Data Transformation Tests ──────────────────────────────────────
+
+describe("Competitive Data Transformations", () => {
+  it("should calculate positioning score as weighted composite", () => {
+    const breadth = 80;
+    const depth = 60;
+    const fleetSize = 30;
+    const completeness = 70;
+    const featureDensity = 12;
+
+    const score = Math.round(
+      breadth * 0.3 +
+      depth * 0.3 +
+      Math.min(fleetSize, 50) / 50 * 100 * 0.2 +
+      completeness * 0.1 +
+      Math.min(featureDensity / 16, 1) * 100 * 0.1
+    );
+
+    // 80*0.3 + 60*0.3 + 60*0.2 + 70*0.1 + 75*0.1 = 24 + 18 + 12 + 7 + 7.5 = 68.5 → 69
+    expect(score).toBe(69);
+  });
+
+  it("should format prices correctly", () => {
+    function formatPrice(n: number | null): string {
+      if (n === null) return "—";
+      if (n >= 1_000_000) return `€${(n / 1_000_000).toFixed(1)}M`;
+      if (n >= 1_000) return `€${(n / 1_000).toFixed(0)}K`;
+      return `€${n.toLocaleString()}`;
+    }
+
+    expect(formatPrice(null)).toBe("—");
+    expect(formatPrice(500)).toBe("€500");
+    expect(formatPrice(50000)).toBe("€50K");
+    expect(formatPrice(150000)).toBe("€150K");
+    expect(formatPrice(1500000)).toBe("€1.5M");
+  });
+
+  it("should count covered segments correctly", () => {
+    const segments = {
+      "under-30ft": 0, "30-35ft": 5, "35-40ft": 3,
+      "40-45ft": 0, "45-50ft": 2, "over-50ft": 0,
+    };
+    const covered = Object.values(segments).filter((c) => c > 0).length;
+    expect(covered).toBe(3);
+  });
+});


### PR DESCRIPTION
## P24.5 — Competitive Positioning Matrix

Closes #397

### What's New
- **Service** (`lib/competitive-positioning-service.ts`): Full manufacturer positioning analysis
  - Fleet size, size segment coverage, price tier classification
  - Breadth score (segment coverage 0-100), depth score (models per segment 0-100)
  - Composite positioning score (weighted: 30% breadth + 30% depth + 20% fleet + 10% completeness + 10% features)
  - Quadrant classification: dominant, generalist, specialist, niche
- **API** (`GET /api/admin/competitive-positioning`): Admin-only endpoint
- **Admin UI** (`/admin/competitive-positioning`): Rich dashboard with:
  - Positioning scatter plot (breadth vs depth)
  - Manufacturer × segment heatmap
  - Price tier distribution chart
  - Size segment coverage bars
  - Sortable manufacturer rankings table
  - Scoring methodology explanation
- **Admin home**: Added Competitive Positioning card
- **Tests**: 15 tests covering scoring, classification, API contract
- **Roadmap**: Marked P24.3 and P24.4 as complete

### Build
- ✅ TypeScript: no errors
- ✅ Build: passes (exit 0)
- ✅ Tests: 15/15 pass