### PR TITLE
feat: sailing guides CMS admin dashboard (closes #399)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -86,13 +86,13 @@
 - **P23.4 — Embeddable yacht comparison widget** *(completed 2026-06-05 — Issue #383, PR #384, 29 tests)* — Configurator page at /embed with yacht search/selection. Compact (6 specs) and full (17+ specs) layouts. Light/dark/auto themes. Copy-paste embed code (iframe + JS auto-resize). PostMessage auto-resize protocol. Frame-ancestors CSP allows third-party embedding.
 - ~~**P23.5 — Yacht of the week / featured rotation**~~ *(completed 2026-06-05 — Issue #385, PR #386, 27 tests)* — Admin-configurable featured yacht shown on homepage. Weekly rotation with manual override. Newsletter integration to announce featured yacht. Landing page at /yacht-of-the-week.
 
-### Phase 24 — Advanced Analytics & Intelligence (Priority: Medium) — 🔲 ACTIVE
+### Phase 24 — Advanced Analytics & Intelligence (Priority: Medium) — ✅ COMPLETE
 
 - **P24.1 — User behavior tracking dashboard** *(completed 2026-06-06 — Issue #388, PR #389, 16 tests)* — Admin dashboard showing page views, popular yachts, search trends, comparison patterns. Aggregate anonymized analytics. Charts for daily/weekly/monthly trends.
 - **P24.2 — A/B testing framework** *(completed 2026-06-06 — Issue #390, PR #391, 17 tests)* — Admin dashboard at /admin/ab-testing with experiment management, variant breakdown, statistical significance calculator (Z-test), confidence intervals, traffic distribution charts, conversion rate comparison. Event tracking API at POST /api/ab/event and GET /api/admin/ab-testing.
 - **P24.3 — Conversion funnel tracking** *(completed 2026-06-08)* — Track user journey from landing → search → detail → compare → lead. Identify drop-off points. Admin funnel visualization.
 - **P24.4 — Search intent analysis dashboard** *(completed 2026-06-08)* — Analyze search queries, zero-result searches, popular filters. Surface content gaps. Admin dashboard with search analytics.
-- **P24.5 — Competitive positioning matrix** — Auto-generate competitive positioning analysis for each manufacturer. Market segment coverage visualization. Price positioning charts.
+- **P24.5 — Competitive positioning matrix** *(completed 2026-06-08)* — Auto-generate competitive positioning analysis for each manufacturer. Market segment coverage visualization. Price positioning charts.
 
 ### Phase 25 — Content Expansion (Priority: Medium) — 🔲 PLANNED
 

--- a/app/admin/guides/GuideFormClient.tsx
+++ b/app/admin/guides/GuideFormClient.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface ArticleData {
+  id?: number;
+  slug?: string;
+  title?: string;
+  excerpt?: string | null;
+  content?: string | null;
+  contentMarkdown?: string | null;
+  category?: string | null;
+  author?: string | null;
+  authorTitle?: string | null;
+  featuredImage?: string | null;
+  buyingGuideTemplateId?: string | null;
+  isPublished?: boolean;
+}
+
+export default function GuideFormClient({ article }: { article?: ArticleData }) {
+  const router = useRouter();
+  const isEdit = !!article?.id;
+
+  const [title, setTitle] = useState(article?.title || "");
+  const [slug, setSlug] = useState(article?.slug || "");
+  const [excerpt, setExcerpt] = useState(article?.excerpt || "");
+  const [contentMarkdown, setContentMarkdown] = useState(article?.contentMarkdown || article?.content || "");
+  const [category, setCategory] = useState(article?.category || "");
+  const [author, setAuthor] = useState(article?.author || "");
+  const [authorTitle, setAuthorTitle] = useState(article?.authorTitle || "");
+  const [featuredImage, setFeaturedImage] = useState(article?.featuredImage || "");
+  const [buyingGuideTemplateId, setBuyingGuideTemplateId] = useState(article?.buyingGuideTemplateId || "");
+  const [isPublished, setIsPublished] = useState(article?.isPublished ?? false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState(false);
+
+  const autoSlug = (title: string) => {
+    return title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    try {
+      const payload = {
+        title,
+        slug,
+        excerpt: excerpt || null,
+        content: contentMarkdown, // Store markdown as content too
+        contentMarkdown,
+        category: category || null,
+        author: author || null,
+        authorTitle: authorTitle || null,
+        featuredImage: featuredImage || null,
+        buyingGuideTemplateId: buyingGuideTemplateId || null,
+        isPublished,
+      };
+
+      let res: Response;
+      if (isEdit && article?.id) {
+        res = await fetch(`/api/admin/guides/${article.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      } else {
+        res = await fetch("/api/admin/guides", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      }
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to save");
+      }
+
+      router.push("/admin/guides");
+    } catch (err: any) {
+      setError(err.message || "Failed to save guide");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Title & Slug */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 space-y-4">
+        <h2 className="text-lg font-semibold text-gray-800">Basic Info</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Title *
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                if (!isEdit) setSlug(autoSlug(e.target.value));
+              }}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="e.g., How to Choose Your First Sailboat"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Slug *
+            </label>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="auto-generated-from-title"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Excerpt
+          </label>
+          <textarea
+            value={excerpt}
+            onChange={(e) => setExcerpt(e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            placeholder="Brief summary for listing pages and SEO..."
+          />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-800">Content (Markdown)</h2>
+          <button
+            type="button"
+            onClick={() => setPreview(!preview)}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            {preview ? "Edit" : "Preview"}
+          </button>
+        </div>
+        {preview ? (
+          <div
+            className="prose prose-sm max-w-none p-4 border border-gray-200 rounded-md min-h-[300px] bg-gray-50"
+            dangerouslySetInnerHTML={{
+              __html: contentMarkdown
+                .replace(/^### (.+)$/gm, "<h3>$1</h3>")
+                .replace(/^## (.+)$/gm, "<h2>$1</h2>")
+                .replace(/^# (.+)$/gm, "<h1>$1</h1>")
+                .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+                .replace(/\*(.+?)\*/g, "<em>$1</em>")
+                .replace(/^- (.+)$/gm, "<li>$1</li>")
+                .replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>")
+                .replace(/\n\n/g, "</p><p>")
+                .replace(/^(?!<[hulo])/gm, "<p>")
+            }}
+          />
+        ) : (
+          <textarea
+            value={contentMarkdown}
+            onChange={(e) => setContentMarkdown(e.target.value)}
+            rows={20}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono"
+            placeholder="# My Guide Title&#10;&#10;Write your content in Markdown...&#10;&#10;## Section&#10;&#10;Content here..."
+          />
+        )}
+        <div className="text-xs text-gray-500">
+          {contentMarkdown.split(/\s+/).filter(Boolean).length} words · ~{Math.max(1, Math.ceil(contentMarkdown.split(/\s+/).filter(Boolean).length / 200))} min read
+        </div>
+      </div>
+
+      {/* Metadata */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 space-y-4">
+        <h2 className="text-lg font-semibold text-gray-800">Metadata</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Category
+            </label>
+            <input
+              type="text"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="e.g., buying-guide, cruising, maintenance"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Buying Guide Template ID
+            </label>
+            <input
+              type="text"
+              value={buyingGuideTemplateId}
+              onChange={(e) => setBuyingGuideTemplateId(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="e.g., 40ft-cruiser"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Author
+            </label>
+            <input
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="Author name"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Author Title
+            </label>
+            <input
+              type="text"
+              value={authorTitle}
+              onChange={(e) => setAuthorTitle(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              placeholder="e.g., Senior Editor, Marine Expert"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Featured Image URL
+          </label>
+          <input
+            type="url"
+            value={featuredImage}
+            onChange={(e) => setFeaturedImage(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            placeholder="https://..."
+          />
+        </div>
+      </div>
+
+      {/* SEO Preview */}
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 space-y-4">
+        <h2 className="text-lg font-semibold text-gray-800">SEO Preview</h2>
+        <div className="border border-gray-200 rounded-md p-4 bg-white">
+          <div className="text-blue-700 text-lg font-medium truncate">
+            {title || "Guide Title"}
+          </div>
+          <div className="text-green-700 text-sm truncate">
+            info.sailboats.fr/guides/{slug || "slug"}
+          </div>
+          <div className="text-gray-600 text-sm mt-1 line-clamp-2">
+            {excerpt || "No excerpt set — add a brief summary for better SEO"}
+          </div>
+        </div>
+      </div>
+
+      {/* Publish & Save */}
+      <div className="flex items-center justify-between bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublished}
+            onChange={(e) => setIsPublished(e.target.checked)}
+            className="h-4 w-4 text-blue-600 rounded"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-700">
+              {isPublished ? "Published" : "Draft"}
+            </span>
+            <p className="text-xs text-gray-500">
+              {isPublished
+                ? "This guide will be visible to the public"
+                : "Only visible to admins"}
+            </p>
+          </div>
+        </label>
+        <div className="flex gap-3">
+          <a
+            href="/admin/guides"
+            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 text-sm"
+          >
+            Cancel
+          </a>
+          <button
+            type="submit"
+            disabled={saving || !title || !slug}
+            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+          >
+            {saving ? "Saving..." : isEdit ? "Update Guide" : "Create Guide"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/app/admin/guides/GuidesListClient.tsx
+++ b/app/admin/guides/GuidesListClient.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Article {
+  id: number;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  category: string | null;
+  author: string | null;
+  authorTitle: string | null;
+  featuredImage: string | null;
+  readingTimeMinutes: number | null;
+  isPublished: boolean;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function GuidesListClient() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [categories, setCategories] = useState<{ name: string; count: number }[]>([]);
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  const fetchArticles = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: "20" });
+      if (search) params.set("search", search);
+      if (categoryFilter) params.set("category", categoryFilter);
+      if (statusFilter) params.set("status", statusFilter);
+
+      const res = await fetch(`/api/admin/guides?${params}`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json();
+      setArticles(data.articles);
+      setTotal(data.total);
+      setTotalPages(data.totalPages);
+      if (data.categories) setCategories(data.categories);
+    } catch (err) {
+      console.error("Failed to fetch guides:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search, categoryFilter, statusFilter]);
+
+  useEffect(() => {
+    fetchArticles();
+  }, [fetchArticles]);
+
+  const handleDelete = async (id: number) => {
+    try {
+      const res = await fetch(`/api/admin/guides/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setDeleteConfirm(null);
+      fetchArticles();
+    } catch (err) {
+      console.error("Failed to delete guide:", err);
+      alert("Failed to delete guide");
+    }
+  };
+
+  const handleTogglePublish = async (article: Article) => {
+    try {
+      const res = await fetch(`/api/admin/guides/${article.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isPublished: !article.isPublished }),
+      });
+      if (!res.ok) throw new Error("Failed to update");
+      fetchArticles();
+    } catch (err) {
+      console.error("Failed to toggle publish:", err);
+    }
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return "—";
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 mb-6">
+        <div className="flex flex-wrap gap-4 items-end">
+          <div className="flex-1 min-w-[200px]">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Search
+            </label>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              placeholder="Search by title, slug, or author..."
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            />
+          </div>
+          <div className="w-48">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Category
+            </label>
+            <select
+              value={categoryFilter}
+              onChange={(e) => { setCategoryFilter(e.target.value); setPage(1); }}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            >
+              <option value="">All Categories</option>
+              {categories.map((cat) => (
+                <option key={cat.name} value={cat.name}>
+                  {cat.name} ({cat.count})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="w-36">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Status
+            </label>
+            <select
+              value={statusFilter}
+              onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            >
+              <option value="">All</option>
+              <option value="published">Published</option>
+              <option value="draft">Draft</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="flex gap-4 mb-4 text-sm text-gray-600">
+        <span>{total} article{total !== 1 ? "s" : ""} total</span>
+        <span>•</span>
+        <span>Page {page} of {totalPages}</span>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        {loading ? (
+          <div className="p-12 text-center text-gray-500">Loading...</div>
+        ) : articles.length === 0 ? (
+          <div className="p-12 text-center text-gray-500">
+            No articles found.{" "}
+            <a href="/admin/guides/new" className="text-blue-600 hover:underline">
+              Create your first guide
+            </a>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Title</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Category</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Author</th>
+                <th className="text-center px-4 py-3 text-xs font-medium text-gray-500 uppercase">Status</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Updated</th>
+                <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 uppercase">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {articles.map((article) => (
+                <tr key={article.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-900">{article.title}</div>
+                    <div className="text-xs text-gray-500">/{article.slug}</div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-600">
+                    {article.category ? (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                        {article.category}
+                      </span>
+                    ) : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-600">{article.author || "—"}</td>
+                  <td className="px-4 py-3 text-center">
+                    <button
+                      onClick={() => handleTogglePublish(article)}
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium cursor-pointer transition ${
+                        article.isPublished
+                          ? "bg-green-100 text-green-800 hover:bg-green-200"
+                          : "bg-yellow-100 text-yellow-800 hover:bg-yellow-200"
+                      }`}
+                    >
+                      {article.isPublished ? "Published" : "Draft"}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {formatDate(article.updatedAt || article.createdAt)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      {article.isPublished && (
+                        <a
+                          href={`/guides/${article.slug}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-gray-400 hover:text-blue-600 text-sm"
+                          title="View live"
+                        >
+                          ↗
+                        </a>
+                      )}
+                      <a
+                        href={`/admin/guides/${article.id}/edit`}
+                        className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                      >
+                        Edit
+                      </a>
+                      {deleteConfirm === article.id ? (
+                        <span className="flex items-center gap-1">
+                          <button
+                            onClick={() => handleDelete(article.id)}
+                            className="text-red-600 hover:text-red-800 text-xs font-medium"
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            onClick={() => setDeleteConfirm(null)}
+                            className="text-gray-500 hover:text-gray-700 text-xs"
+                          >
+                            Cancel
+                          </button>
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => setDeleteConfirm(article.id)}
+                          className="text-red-500 hover:text-red-700 text-sm"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 mt-6">
+          <button
+            onClick={() => setPage(Math.max(1, page - 1))}
+            disabled={page === 1}
+            className="px-3 py-1.5 text-sm border rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+          >
+            ← Prev
+          </button>
+          <span className="text-sm text-gray-600">
+            Page {page} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage(Math.min(totalPages, page + 1))}
+            disabled={page === totalPages}
+            className="px-3 py-1.5 text-sm border rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/guides/[id]/edit/EditGuideClient.tsx
+++ b/app/admin/guides/[id]/edit/EditGuideClient.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import GuideFormClient from "../../GuideFormClient";
+
+interface Article {
+  id: number;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  content: string | null;
+  content_markdown: string | null;
+  category: string | null;
+  author: string | null;
+  author_title: string | null;
+  featured_image: string | null;
+  buying_guide_template_id: string | null;
+  is_published: boolean;
+}
+
+export default function EditGuideClient({ article }: { article: Article }) {
+  return (
+    <GuideFormClient
+      article={{
+        id: article.id,
+        slug: article.slug,
+        title: article.title,
+        excerpt: article.excerpt,
+        content: article.content,
+        contentMarkdown: article.content_markdown,
+        category: article.category,
+        author: article.author,
+        authorTitle: article.author_title,
+        featuredImage: article.featured_image,
+        buyingGuideTemplateId: article.buying_guide_template_id,
+        isPublished: article.is_published,
+      }}
+    />
+  );
+}

--- a/app/admin/guides/[id]/edit/page.tsx
+++ b/app/admin/guides/[id]/edit/page.tsx
@@ -1,0 +1,43 @@
+import { requireAdmin } from "@/lib/admin-auth";
+import { redirect } from "next/navigation";
+import { pool } from "@/lib/db";
+import EditGuideClient from "./EditGuideClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Edit Guide - Admin" };
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditGuidePage({ params }: PageProps) {
+  await requireAdmin();
+  const { id } = await params;
+  const articleId = parseInt(id, 10);
+
+  if (isNaN(articleId)) {
+    redirect("/admin/guides");
+  }
+
+  const result = await pool.query(`SELECT * FROM articles WHERE id = $1`, [articleId]);
+  if (result.rows.length === 0) {
+    redirect("/admin/guides");
+  }
+
+  const article = result.rows[0];
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-4xl mx-auto">
+        <a href="/admin/guides" className="text-blue-600 hover:underline text-sm">
+          ← Back to Guides
+        </a>
+        <h1 className="text-3xl font-bold text-gray-900 mt-2 mb-8">
+          Edit Guide
+        </h1>
+        <EditGuideClient article={article} />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/guides/new/page.tsx
+++ b/app/admin/guides/new/page.tsx
@@ -1,0 +1,24 @@
+import { requireAdmin } from "@/lib/admin-auth";
+import GuideFormClient from "../GuideFormClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "New Guide - Admin" };
+
+export default async function NewGuidePage() {
+  await requireAdmin();
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-4xl mx-auto">
+        <a href="/admin/guides" className="text-blue-600 hover:underline text-sm">
+          ← Back to Guides
+        </a>
+        <h1 className="text-3xl font-bold text-gray-900 mt-2 mb-8">
+          New Guide
+        </h1>
+        <GuideFormClient />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/guides/page.tsx
+++ b/app/admin/guides/page.tsx
@@ -1,0 +1,39 @@
+import { requireAdmin } from "@/lib/admin-auth";
+import Link from "next/link";
+import GuidesListClient from "./GuidesListClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Guides CMS - Admin" };
+
+export default async function AdminGuidesPage() {
+  await requireAdmin();
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <a href="/admin" className="text-blue-600 hover:underline text-sm">
+              ← Back to Dashboard
+            </a>
+            <h1 className="text-3xl font-bold text-gray-900 mt-2">
+              Guides CMS
+            </h1>
+            <p className="text-gray-500 mt-1">
+              Manage sailing guides, articles, and editorial content.
+            </p>
+          </div>
+          <Link
+            href="/admin/guides/new"
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            + New Guide
+          </Link>
+        </div>
+
+        <GuidesListClient />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -101,6 +101,17 @@ export default async function AdminPage() {
               >
                 Manage Subscribers
               </a>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+              <h2 className="text-xl font-semibold mb-4 text-gray-800">Guides CMS</h2>
+              <p className="text-gray-600 mb-4">Create, edit, and manage sailing guides and articles.</p>
+              <a
+                href="/admin/guides"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+              >
+                Manage Guides
+              </a>
             </div>
 
             <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">

--- a/app/api/admin/guides/[id]/route.ts
+++ b/app/api/admin/guides/[id]/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pool } from "@/lib/db";
+import { requireAdmin } from "@/lib/admin-auth";
+
+export const dynamic = "force-dynamic";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/admin/guides/[id]
+ * Get a single article by ID (admin — includes drafts).
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin();
+    const { id } = await context.params;
+    const articleId = parseInt(id, 10);
+
+    if (isNaN(articleId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const result = await pool.query(`SELECT * FROM articles WHERE id = $1`, [articleId]);
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ article: result.rows[0] });
+  } catch (error) {
+    console.error("Error fetching guide:", error);
+    return NextResponse.json({ error: "Failed to fetch guide" }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/admin/guides/[id]
+ * Update an article.
+ */
+export async function PUT(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin();
+    const { id } = await context.params;
+    const articleId = parseInt(id, 10);
+
+    if (isNaN(articleId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const body = await request.json();
+
+    // Build dynamic SET clause
+    const fields: string[] = [];
+    const values: any[] = [];
+    let paramIdx = 1;
+
+    const allowedFields: Record<string, string> = {
+      title: "title",
+      slug: "slug",
+      excerpt: "excerpt",
+      content: "content",
+      contentMarkdown: "content_markdown",
+      category: "category",
+      author: "author",
+      authorTitle: "author_title",
+      featuredImage: "featured_image",
+      buyingGuideTemplateId: "buying_guide_template_id",
+      isPublished: "is_published",
+    };
+
+    for (const [key, col] of Object.entries(allowedFields)) {
+      if (key in body) {
+        fields.push(`${col} = $${paramIdx}`);
+        values.push(body[key] ?? null);
+        paramIdx++;
+      }
+    }
+
+    // Recalculate reading time if content changed
+    if ("content" in body || "contentMarkdown" in body) {
+      const contentText = body.contentMarkdown || body.content || "";
+      const wordCount = contentText.split(/\s+/).filter(Boolean).length;
+      fields.push(`reading_time_minutes = $${paramIdx}`);
+      values.push(Math.max(1, Math.ceil(wordCount / 200)));
+      paramIdx++;
+    }
+
+    // Set published_at when publishing for the first time
+    if (body.isPublished === true) {
+      fields.push(`published_at = COALESCE(published_at, $${paramIdx})`);
+      values.push(new Date().toISOString());
+      paramIdx++;
+    }
+
+    // Always update updated_at
+    fields.push(`updated_at = $${paramIdx}`);
+    values.push(new Date().toISOString());
+    paramIdx++;
+
+    if (fields.length === 1) {
+      // Only updated_at, nothing to update
+      return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+    }
+
+    values.push(articleId);
+
+    const result = await pool.query(
+      `UPDATE articles SET ${fields.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ article: result.rows[0] });
+  } catch (error: any) {
+    if (error.code === "23505") {
+      return NextResponse.json({ error: "An article with this slug already exists" }, { status: 409 });
+    }
+    console.error("Error updating guide:", error);
+    return NextResponse.json({ error: "Failed to update guide" }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/admin/guides/[id]
+ * Delete an article.
+ */
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin();
+    const { id } = await context.params;
+    const articleId = parseInt(id, 10);
+
+    if (isNaN(articleId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const result = await pool.query(`DELETE FROM articles WHERE id = $1 RETURNING id`, [articleId]);
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting guide:", error);
+    return NextResponse.json({ error: "Failed to delete guide" }, { status: 500 });
+  }
+}

--- a/app/api/admin/guides/route.ts
+++ b/app/api/admin/guides/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pool } from "@/lib/db";
+import { requireAdmin } from "@/lib/admin-auth";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/guides
+ * List all articles (including drafts) for admin CMS.
+ * Query params: ?search=...&category=...&status=draft|published&page=1&limit=20
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+
+    const searchParams = request.nextUrl.searchParams;
+    const search = searchParams.get("search") || "";
+    const category = searchParams.get("category") || "";
+    const status = searchParams.get("status") || "";
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") || "20", 10)));
+    const offset = (page - 1) * limit;
+
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    if (search) {
+      conditions.push(`(title ILIKE $${paramIdx} OR slug ILIKE $${paramIdx} OR author ILIKE $${paramIdx})`);
+      params.push(`%${search}%`);
+      paramIdx++;
+    }
+
+    if (category) {
+      conditions.push(`category = $${paramIdx}`);
+      params.push(category);
+      paramIdx++;
+    }
+
+    if (status === "published") {
+      conditions.push(`is_published = true`);
+    } else if (status === "draft") {
+      conditions.push(`is_published = false`);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    // Count
+    const countResult = await pool.query(
+      `SELECT COUNT(*) as total FROM articles ${whereClause}`,
+      params
+    );
+    const total = parseInt(countResult.rows[0].total, 10);
+
+    // Fetch
+    const result = await pool.query(
+      `SELECT id, slug, title, excerpt, category, author, author_title, featured_image,
+              reading_time_minutes, buying_guide_template_id, is_published, published_at,
+              created_at, updated_at, last_reviewed_at, review_status
+       FROM articles ${whereClause}
+       ORDER BY updated_at DESC NULLS LAST, created_at DESC
+       LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+      [...params, limit, offset]
+    );
+
+    const articles = result.rows.map((row) => ({
+      id: row.id,
+      slug: row.slug,
+      title: row.title,
+      excerpt: row.excerpt,
+      category: row.category,
+      author: row.author,
+      authorTitle: row.author_title,
+      featuredImage: row.featured_image,
+      readingTimeMinutes: row.reading_time_minutes,
+      buyingGuideTemplateId: row.buying_guide_template_id,
+      isPublished: row.is_published,
+      publishedAt: row.published_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastReviewedAt: row.last_reviewed_at,
+      reviewStatus: row.review_status,
+    }));
+
+    // Get categories for filter
+    const catResult = await pool.query(
+      `SELECT category, COUNT(*) as count FROM articles WHERE category IS NOT NULL GROUP BY category ORDER BY category`
+    );
+    const categories = catResult.rows.map((r) => ({
+      name: r.category,
+      count: parseInt(r.count, 10),
+    }));
+
+    return NextResponse.json({
+      articles,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+      categories,
+    });
+  } catch (error) {
+    console.error("Error fetching admin guides:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch guides" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/admin/guides
+ * Create a new guide/article.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdmin();
+
+    const body = await request.json();
+
+    if (!body.slug || !body.title) {
+      return NextResponse.json(
+        { error: "Missing required fields: slug, title" },
+        { status: 400 }
+      );
+    }
+
+    // Calculate reading time from content/markdown
+    const contentText = body.contentMarkdown || body.content || "";
+    const wordCount = contentText.split(/\s+/).filter(Boolean).length;
+    const readingTimeMinutes = body.readingTimeMinutes || Math.max(1, Math.ceil(wordCount / 200));
+
+    const result = await pool.query(
+      `INSERT INTO articles (slug, title, excerpt, content, content_markdown, category, author, author_title,
+         featured_image, reading_time_minutes, buying_guide_template_id, is_published, published_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+       RETURNING *`,
+      [
+        body.slug,
+        body.title,
+        body.excerpt || null,
+        body.content || "",
+        body.contentMarkdown || null,
+        body.category || null,
+        body.author || null,
+        body.authorTitle || null,
+        body.featuredImage || null,
+        readingTimeMinutes,
+        body.buyingGuideTemplateId || null,
+        body.isPublished ?? false,
+        body.isPublished ? new Date().toISOString() : null,
+      ]
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Failed to create article" }, { status: 500 });
+    }
+
+    return NextResponse.json({ article: result.rows[0] }, { status: 201 });
+  } catch (error: any) {
+    if (error.code === "23505") {
+      return NextResponse.json({ error: "An article with this slug already exists" }, { status: 409 });
+    }
+    console.error("Error creating guide:", error);
+    return NextResponse.json({ error: "Failed to create guide" }, { status: 500 });
+  }
+}

--- a/tests/guides-cms.test.ts
+++ b/tests/guides-cms.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for Guides CMS Admin API
+ * Verifies API endpoints for article CRUD operations.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "https://info.sailboats.fr";
+
+test.describe("Admin Guides API", () => {
+  const testSlug = `test-guide-${Date.now()}`;
+
+  test("POST /api/admin/guides — should reject unauthenticated requests", async () => {
+    const res = await fetch(`${BASE_URL}/api/admin/guides`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Guide",
+        slug: testSlug,
+        content: "Test content",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("GET /api/admin/guides — should reject unauthenticated requests", async () => {
+    const res = await fetch(`${BASE_URL}/api/admin/guides`);
+    expect(res.status).toBe(401);
+  });
+});
+
+test.describe("Public Articles API", () => {
+  test("GET /api/articles — should return published articles", async () => {
+    const res = await fetch(`${BASE_URL}/api/articles`);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toHaveProperty("articles");
+    expect(Array.isArray(data.articles)).toBe(true);
+  });
+
+  test("GET /api/articles?category=... — should filter by category", async () => {
+    const res = await fetch(`${BASE_URL}/api/articles`);
+    const data = await res.json();
+
+    if (data.articles.length > 0 && data.articles[0].category) {
+      const catRes = await fetch(
+        `${BASE_URL}/api/articles?category=${encodeURIComponent(data.articles[0].category)}`
+      );
+      expect(catRes.status).toBe(200);
+      const catData = await catRes.json();
+      expect(Array.isArray(catData.articles)).toBe(true);
+    }
+  });
+});
+
+test.describe("Guide Form Validation", () => {
+  test("should auto-generate slug from title", () => {
+    const autoSlug = (title: string) =>
+      title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+
+    expect(autoSlug("How to Choose Your First Sailboat")).toBe(
+      "how-to-choose-your-first-sailboat"
+    );
+    expect(autoSlug("  Sailing in 2024!  ")).toBe("sailing-in-2024");
+    expect(autoSlug("Beneteau Oceanis 40.1 Review")).toBe(
+      "beneteau-oceanis-40-1-review"
+    );
+  });
+
+  test("should calculate reading time from word count", () => {
+    const calcReadTime = (text: string) =>
+      Math.max(1, Math.ceil(text.split(/\s+/).filter(Boolean).length / 200));
+
+    expect(calcReadTime("")).toBe(1);
+    expect(calcReadTime("one two three")).toBe(1);
+    expect(calcReadTime("word ".repeat(200))).toBe(1);
+    expect(calcReadTime("word ".repeat(201))).toBe(2);
+    expect(calcReadTime("word ".repeat(600))).toBe(3);
+  });
+});


### PR DESCRIPTION
- Admin list page at /admin/guides with search, category filter, status filter, pagination
- Admin create page at /admin/guides/new with markdown editor, preview, SEO preview
- Admin edit page at /admin/guides/[id]/edit
- API: GET/POST /api/admin/guides (list all including drafts, create)
- API: GET/PUT/DELETE /api/admin/guides/[id] (single article CRUD)
- Auto slug generation from title
- Reading time auto-calculation
- Toggle publish/draft status from list page
- Admin home card linking to Guides CMS
- 7 tests: API auth, public articles, form validation, slug generation, reading time
