### PR TITLE
feat: P25.2 yacht review aggregation from external sources (closes #403)

### DIFF
--- a/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
+++ b/app/[locale]/yachts/[slug]/YachtDetailClient.tsx
@@ -53,6 +53,10 @@ const ReviewSubmissionForm = dynamic(() => import("@/components/ReviewSubmission
   ssr: false,
   loading: () => <div className="h-48 animate-pulse bg-muted rounded-lg" />,
 });
+const ReviewAggregation = dynamic(() => import("@/components/ReviewAggregation").then((m) => ({ default: m.default })), {
+  ssr: false,
+  loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" />,
+});
 const YachtRatingWidget = dynamic(() => import("@/components/YachtRatingWidget").then(m => ({ default: m.YachtRatingWidget })), {
   ssr: false,
   loading: () => <div className="h-24 animate-pulse bg-muted rounded-lg" />,
@@ -210,6 +214,7 @@ export default function YachtDetailClient() {
   const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<string>("");
   const [variants, setVariants] = useState<Array<import("./VariantSelector").YachtVariant>>([]);
+  const [reviewAggregation, setReviewAggregation] = useState<any>(null);
 
   // Translation-aware GROUP_LABELS
   const GROUP_LABELS: Record<string, string> = {
@@ -295,6 +300,8 @@ export default function YachtDetailClient() {
       })
       .then((data) => {
         setYacht(data);
+        // Fetch review aggregation (non-blocking)
+        fetch(`/api/yachts/${slug}/review-aggregation`).then(r => r.ok ? r.json() : null).then(setReviewAggregation).catch(() => {});
         // Track yacht view for analytics
         try { trackYachtView({ yachtId: data.id, yachtSlug: slug, yachtName: data.modelName, manufacturerName: data.manufacturer }); } catch {}
       })
@@ -798,6 +805,8 @@ export default function YachtDetailClient() {
                 </div>
               );
             })()}
+            {/* P25.2: Review Aggregation by Source */}
+            <ReviewAggregation aggregation={reviewAggregation} />
 
             {/* Reviews Section */}
             {yacht.reviews && yacht.reviews.length > 0 && (

--- a/app/[locale]/yachts/[slug]/page.tsx
+++ b/app/[locale]/yachts/[slug]/page.tsx
@@ -300,6 +300,26 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
     // Rating data unavailable — skip silently
   }
 
+  // P25.2: Fetch source-aware review aggregation for JSON-LD
+  let sourceAggregationJsonLd: Record<string, unknown> | null = null;
+  try {
+    const { getYachtReviewAggregation } = await import("@/lib/review-aggregation");
+    const agg = await getYachtReviewAggregation(data.yacht.id);
+    if (agg.sourceCount > 0) {
+      sourceAggregationJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "AggregateRating",
+        itemReviewed: { "@type": "Product", name: `${manufacturerName} ${yachtData.modelName}` },
+        ratingValue: agg.overallAverage,
+        reviewCount: agg.totalReviewCount,
+        bestRating: 5,
+        worstRating: 1,
+      };
+    }
+  } catch {
+    // Aggregation unavailable
+  }
+
   return (
     <>
       <script
@@ -341,6 +361,12 @@ export default async function YachtDetailPage({ params }: YachtDetailPageProps) 
           dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
         />
       ))}
+      {sourceAggregationJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(sourceAggregationJsonLd) }}
+        />
+      )}
       {/* SSR H1 for SEO — client component also renders a visible H1 */}
       <h1 className="sr-only">
         {manufacturerName} {yachtData.modelName} ({yachtData.year})

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -69,6 +69,12 @@ export default async function AdminPage() {
                 Manage Reviews
               </a>
             </div>
+              <a
+                href="/admin/review-sources"
+                className="inline-block px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition duration-200 ml-2"
+              >
+                Review Sources
+              </a>
 
             <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
               <h2 className="text-xl font-semibold mb-4 text-gray-800">Specification Categories</h2>

--- a/app/admin/review-sources/[id]/edit/page.tsx
+++ b/app/admin/review-sources/[id]/edit/page.tsx
@@ -1,0 +1,115 @@
+import { requireAdmin } from '@/lib/admin-auth'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+async function getReviewSource(id: number) {
+  const headersList = headers()
+  const host = headersList.get('x-forwarded-host') ?? headersList.get('host')
+  const proto = headersList.get('x-forwarded-proto') ?? 'http'
+  const baseUrl = host ? `${proto}://${host}` : 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/admin/review-sources/${id}`, {
+    cache: 'no-store',
+    headers: { cookie: headersList.get('cookie') ?? '' },
+  })
+  if (!res.ok) return null
+  const data = await res.json()
+  return data.source
+}
+
+export default async function EditReviewSourcePage({ params }: { params: Promise<{ id: string }> }) {
+  await requireAdmin()
+  const { id } = await params
+  const numId = parseInt(id, 10)
+  const source = await getReviewSource(numId)
+
+  if (!source) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-8">
+        <div className="max-w-2xl mx-auto">
+          <p className="text-red-600">Review source not found.</p>
+          <Link href="/admin/review-sources" className="text-blue-600 hover:underline mt-4 inline-block">Back to Review Sources</Link>
+        </div>
+      </div>
+    )
+  }
+
+  async function updateSource(formData: FormData) {
+    'use server'
+    const { pool } = await import('@/lib/db')
+    const { revalidatePath } = await import('next/cache')
+
+    const name = (formData.get('name') as string)?.trim()
+    if (!name) throw new Error('Name is required')
+
+    await pool.query(
+      `UPDATE review_sources SET
+        name = $1, website_url = $2, logo_url = $3, description = $4,
+        credibility_score = $5, source_type = $6, is_active = $7, updated_at = NOW()
+       WHERE id = $8`,
+      [
+        name,
+        (formData.get('websiteUrl') as string)?.trim() || null,
+        (formData.get('logoUrl') as string)?.trim() || null,
+        (formData.get('description') as string)?.trim() || null,
+        Math.min(100, Math.max(0, Number(formData.get('credibilityScore')) || 50)),
+        (formData.get('sourceType') as string) || 'magazine',
+        formData.get('isActive') === 'on',
+        numId,
+      ]
+    )
+
+    revalidatePath('/admin/review-sources')
+    redirect('/admin/review-sources')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Edit Review Source: {source.name}</h1>
+        <form action={updateSource} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+            <input name="name" type="text" required defaultValue={source.name} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Source Type</label>
+            <select name="sourceType" defaultValue={source.sourceType} className="w-full border border-gray-300 rounded-md px-3 py-2">
+              <option value="magazine">Magazine</option>
+              <option value="youtube">YouTube</option>
+              <option value="blog">Blog</option>
+              <option value="expert">Expert</option>
+              <option value="forum">Forum</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Website URL</label>
+            <input name="websiteUrl" type="url" defaultValue={source.websiteUrl || ''} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Logo URL</label>
+            <input name="logoUrl" type="url" defaultValue={source.logoUrl || ''} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea name="description" rows={3} defaultValue={source.description || ''} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Credibility Score (0-100)</label>
+            <input name="credibilityScore" type="number" min={0} max={100} defaultValue={source.credibilityScore} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div className="flex items-center gap-2">
+            <input name="isActive" type="checkbox" id="isActive" defaultChecked={source.isActive} className="rounded border-gray-300" />
+            <label htmlFor="isActive" className="text-sm font-medium text-gray-700">Active</label>
+          </div>
+          <div className="flex gap-3 pt-4">
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Save Changes</button>
+            <Link href="/admin/review-sources" className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Cancel</Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/review-sources/new/page.tsx
+++ b/app/admin/review-sources/new/page.tsx
@@ -1,0 +1,81 @@
+import { requireAdmin } from '@/lib/admin-auth'
+import { redirect } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default async function NewReviewSourcePage() {
+  await requireAdmin()
+
+  async function createSource(formData: FormData) {
+    'use server'
+    const { pool } = await import('@/lib/db')
+    const { revalidatePath } = await import('next/cache')
+
+    const name = (formData.get('name') as string)?.trim()
+    if (!name) throw new Error('Name is required')
+
+    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+
+    await pool.query(
+      `INSERT INTO review_sources (name, slug, website_url, logo_url, description, credibility_score, source_type)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        name,
+        slug,
+        (formData.get('websiteUrl') as string)?.trim() || null,
+        (formData.get('logoUrl') as string)?.trim() || null,
+        (formData.get('description') as string)?.trim() || null,
+        Math.min(100, Math.max(0, Number(formData.get('credibilityScore')) || 50)),
+        (formData.get('sourceType') as string) || 'magazine',
+      ]
+    )
+
+    revalidatePath('/admin/review-sources')
+    redirect('/admin/review-sources')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Add Review Source</h1>
+        <form action={createSource} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+            <input name="name" type="text" required className="w-full border border-gray-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. Yachting World" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Source Type</label>
+            <select name="sourceType" className="w-full border border-gray-300 rounded-md px-3 py-2">
+              <option value="magazine">Magazine</option>
+              <option value="youtube">YouTube</option>
+              <option value="blog">Blog</option>
+              <option value="expert">Expert</option>
+              <option value="forum">Forum</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Website URL</label>
+            <input name="websiteUrl" type="url" className="w-full border border-gray-300 rounded-md px-3 py-2" placeholder="https://..." />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Logo URL</label>
+            <input name="logoUrl" type="url" className="w-full border border-gray-300 rounded-md px-3 py-2" placeholder="https://..." />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea name="description" rows={3} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Credibility Score (0-100)</label>
+            <input name="credibilityScore" type="number" min={0} max={100} defaultValue={50} className="w-full border border-gray-300 rounded-md px-3 py-2" />
+            <p className="text-xs text-gray-500 mt-1">Higher scores give more weight in aggregated ratings</p>
+          </div>
+          <div className="flex gap-3 pt-4">
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Create Source</button>
+            <a href="/admin/review-sources" className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Cancel</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/review-sources/page.tsx
+++ b/app/admin/review-sources/page.tsx
@@ -1,0 +1,153 @@
+import { requireAdmin } from '@/lib/admin-auth'
+import { headers } from 'next/headers'
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AdminReviewSourcesPage() {
+  await requireAdmin()
+
+  let sources: any[] = []
+  let errorMsg: string | null = null
+
+  try {
+    const headersList = headers()
+    const host = headersList.get('x-forwarded-host') ?? headersList.get('host')
+    const proto = headersList.get('x-forwarded-proto') ?? 'http'
+    const baseUrl = host ? `${proto}://${host}` : 'http://localhost:3000'
+    const res = await fetch(`${baseUrl}/api/admin/review-sources`, {
+      cache: 'no-store',
+      headers: { cookie: headersList.get('cookie') ?? '' },
+    })
+    if (!res.ok) {
+      const errorBody = await res.json().catch(() => null)
+      throw new Error(errorBody?.error || 'Failed to fetch review sources')
+    }
+    const data = await res.json()
+    sources = data.sources ?? []
+  } catch (error) {
+    console.error('Failed to fetch review sources:', error)
+    errorMsg = error instanceof Error ? error.message : 'Unknown error'
+  }
+
+  const sourceTypeLabels: Record<string, string> = {
+    magazine: 'Magazine',
+    youtube: 'YouTube',
+    blog: 'Blog',
+    expert: 'Expert',
+    forum: 'Forum',
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Review Sources</h1>
+          <div className="flex gap-3">
+            <Link
+              href="/admin/review-sources/new"
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition duration-200"
+            >
+              Add Source
+            </Link>
+            <Link
+              href="/admin"
+              className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition duration-200"
+            >
+              Back to Dashboard
+            </Link>
+          </div>
+        </div>
+
+        {errorMsg && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+            <p className="text-red-700">{errorMsg}</p>
+          </div>
+        )}
+
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">
+            External Review Sources ({sources.length})
+          </h2>
+
+          {sources.length === 0 ? (
+            <p className="text-gray-500 text-center py-8">
+              No review sources yet. Add your first source to start aggregating reviews.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credibility</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Reviews</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-150">
+                  {sources.map((source: any) => (
+                    <tr key={source.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          {source.logoUrl && (
+                            <img src={source.logoUrl} alt="" className="w-6 h-6 rounded" />
+                          )}
+                          <div>
+                            <div className="font-medium text-gray-900">{source.name}</div>
+                            {source.websiteUrl && (
+                              <a href={source.websiteUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:underline">
+                                {new URL(source.websiteUrl).hostname}
+                              </a>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-700">
+                          {sourceTypeLabels[source.sourceType] || source.sourceType}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <div className="w-16 bg-gray-200 rounded-full h-2">
+                            <div
+                              className={`h-2 rounded-full ${
+                                source.credibilityScore >= 70 ? 'bg-green-500' :
+                                source.credibilityScore >= 40 ? 'bg-yellow-500' : 'bg-red-500'
+                              }`}
+                              style={{ width: `${source.credibilityScore}%` }}
+                            />
+                          </div>
+                          <span className="text-sm text-gray-600">{source.credibilityScore}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{source.reviewCount}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          source.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+                        }`}>
+                          {source.isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/review-sources/${source.id}/edit`}
+                          className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                        >
+                          Edit
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/reviews/new/NewReviewForm.tsx
+++ b/app/admin/reviews/new/NewReviewForm.tsx
@@ -11,11 +11,18 @@ interface Yacht {
   year?: number
 }
 
-interface NewReviewFormProps {
-  yachts: Yacht[]
+interface ReviewSource {
+  id: number
+  name: string
+  sourceType: string
 }
 
-export default function NewReviewForm({ yachts }: NewReviewFormProps) {
+interface NewReviewFormProps {
+  yachts: Yacht[]
+  reviewSources?: ReviewSource[]
+}
+
+export default function NewReviewForm({ yachts, reviewSources = [] }: NewReviewFormProps) {
   const router = useRouter()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -35,6 +42,7 @@ export default function NewReviewForm({ yachts }: NewReviewFormProps) {
       reviewDate: formData.get('reviewDate') as string || null,
       authorName: formData.get('authorName') as string || null,
       sourceUrl: formData.get('sourceUrl') as string || null,
+      reviewSourceId: formData.get('reviewSourceId') ? parseInt(formData.get('reviewSourceId') as string, 10) : null,
     }
 
     try {
@@ -85,6 +93,23 @@ export default function NewReviewForm({ yachts }: NewReviewFormProps) {
         </select>
       </div>
 
+      {reviewSources.length > 0 && (
+        <div>
+          <label htmlFor="reviewSourceId" className="block text-sm font-medium text-gray-700 mb-1">
+            Review Source (linked)
+          </label>
+          <select
+            id="reviewSourceId"
+            name="reviewSourceId"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="">— None —</option>
+            {reviewSources.map((rs) => (
+              <option key={rs.id} value={rs.id}>{rs.name} ({rs.sourceType})</option>
+            ))}
+          </select>
+        </div>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label htmlFor="source" className="block text-sm font-medium text-gray-700 mb-1">

--- a/app/admin/reviews/new/page.tsx
+++ b/app/admin/reviews/new/page.tsx
@@ -10,6 +10,7 @@ export default async function AdminNewReviewPage() {
   await requireAdmin()
 
   let yachts: any[] = []
+  let reviewSources: any[] = []
   let fetchError: string | null = null
 
   try {
@@ -27,6 +28,16 @@ export default async function AdminNewReviewPage() {
     }
     const data = await res.json()
     yachts = data.yachts ?? []
+
+    // Fetch review sources
+    const rsRes = await fetch(`${baseUrl}/api/admin/review-sources`, {
+      cache: 'no-store',
+      headers: { cookie: headersList.get('cookie') ?? '' },
+    })
+    if (rsRes.ok) {
+      const rsData = await rsRes.json()
+      reviewSources = rsData.sources ?? []
+    }
   } catch (error) {
     console.error('Failed to fetch yachts:', error)
     fetchError = error instanceof Error ? error.message : 'Unknown error'
@@ -59,7 +70,7 @@ export default async function AdminNewReviewPage() {
               <span className="block sm:inline"> No yachts found. Add some yachts first.</span>
             </div>
           ) : (
-            <NewReviewForm yachts={yachts} />
+            <NewReviewForm yachts={yachts} reviewSources={reviewSources} />
           )}
         </div>
       </div>

--- a/app/api/admin/review-sources/[id]/route.ts
+++ b/app/api/admin/review-sources/[id]/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+
+function mapSource(row: Record<string, unknown>) {
+  return {
+    id: Number(row.id),
+    name: row.name as string,
+    slug: row.slug as string,
+    websiteUrl: row.website_url as string | null,
+    logoUrl: row.logo_url as string | null,
+    description: row.description as string | null,
+    credibilityScore: row.credibility_score != null ? Number(row.credibility_score) : 50,
+    sourceType: row.source_type as string,
+    isActive: row.is_active === true || row.is_active === 'true',
+    lastFetchedAt: row.last_fetched_at as string | null,
+    createdAt: row.created_at as string | null,
+    updatedAt: row.updated_at as string | null,
+  };
+}
+
+/** GET /api/admin/review-sources/[id] */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const numId = parseInt(id, 10);
+    if (isNaN(numId)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+
+    const result = await pool.query('SELECT * FROM review_sources WHERE id = $1', [numId]);
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Review source not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ source: mapSource(result.rows[0]) });
+  } catch (error) {
+    console.error('Failed to fetch review source:', error);
+    return NextResponse.json({ error: 'Failed to fetch review source' }, { status: 500 });
+  }
+}
+
+/** PATCH /api/admin/review-sources/[id] */
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const numId = parseInt(id, 10);
+    if (isNaN(numId)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const allowedFields = ['name', 'website_url', 'logo_url', 'description', 'credibility_score', 'source_type', 'is_active'];
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+    let paramIdx = 1;
+
+    for (const field of allowedFields) {
+      if (field in body) {
+        setClauses.push(`${field} = $${paramIdx++}`);
+        values.push(body[field]);
+      }
+    }
+
+    if (setClauses.length === 0) {
+      return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
+    }
+
+    setClauses.push(`updated_at = NOW()`);
+    values.push(numId);
+
+    const result = await pool.query(
+      `UPDATE review_sources SET ${setClauses.join(', ')} WHERE id = $${paramIdx} RETURNING *`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Review source not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ source: mapSource(result.rows[0]) });
+  } catch (error: any) {
+    if (error?.code === '23505') {
+      return NextResponse.json({ error: 'A review source with this name already exists' }, { status: 409 });
+    }
+    console.error('Failed to update review source:', error);
+    return NextResponse.json({ error: 'Failed to update review source' }, { status: 500 });
+  }
+}
+
+/** DELETE /api/admin/review-sources/[id] */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const numId = parseInt(id, 10);
+    if (isNaN(numId)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+
+    const result = await pool.query('DELETE FROM review_sources WHERE id = $1 RETURNING id', [numId]);
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Review source not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: 'Review source deleted successfully' });
+  } catch (error) {
+    console.error('Failed to delete review source:', error);
+    return NextResponse.json({ error: 'Failed to delete review source' }, { status: 500 });
+  }
+}

--- a/app/api/admin/review-sources/route.ts
+++ b/app/api/admin/review-sources/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+
+function mapSource(row: Record<string, unknown>) {
+  return {
+    id: Number(row.id),
+    name: row.name as string,
+    slug: row.slug as string,
+    websiteUrl: row.website_url as string | null,
+    logoUrl: row.logo_url as string | null,
+    description: row.description as string | null,
+    credibilityScore: row.credibility_score != null ? Number(row.credibility_score) : 50,
+    sourceType: row.source_type as string,
+    isActive: row.is_active === true || row.is_active === 'true',
+    lastFetchedAt: row.last_fetched_at as string | null,
+    createdAt: row.created_at as string | null,
+    updatedAt: row.updated_at as string | null,
+    reviewCount: row.review_count != null ? Number(row.review_count) : 0,
+  };
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/** GET /api/admin/review-sources — list all review sources */
+export async function GET() {
+  try {
+    const result = await pool.query(
+      `SELECT rs.*, COUNT(r.id)::int as review_count
+       FROM review_sources rs
+       LEFT JOIN reviews r ON r.review_source_id = rs.id
+       GROUP BY rs.id
+       ORDER BY rs.name`
+    );
+    return NextResponse.json({ sources: result.rows.map(mapSource) });
+  } catch (error) {
+    console.error('Failed to fetch review sources:', error);
+    return NextResponse.json({ error: 'Failed to fetch review sources' }, { status: 500 });
+  }
+}
+
+/** POST /api/admin/review-sources — create a review source */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, websiteUrl, logoUrl, description, credibilityScore, sourceType } = body;
+
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+    }
+
+    const slug = slugify(name);
+    const score = credibilityScore != null ? Math.min(100, Math.max(0, Number(credibilityScore))) : 50;
+    const type = sourceType || 'magazine';
+
+    const result = await pool.query(
+      `INSERT INTO review_sources (name, slug, website_url, logo_url, description, credibility_score, source_type)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [name.trim(), slug, websiteUrl || null, logoUrl || null, description || null, score, type]
+    );
+
+    return NextResponse.json({ source: mapSource(result.rows[0]) }, { status: 201 });
+  } catch (error: any) {
+    if (error?.code === '23505') {
+      return NextResponse.json({ error: 'A review source with this name already exists' }, { status: 409 });
+    }
+    console.error('Failed to create review source:', error);
+    return NextResponse.json({ error: 'Failed to create review source' }, { status: 500 });
+  }
+}

--- a/app/api/admin/reviews/import/route.ts
+++ b/app/api/admin/reviews/import/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+import { revalidateTag } from 'next/cache';
+
+/**
+ * POST /api/admin/reviews/import
+ * CSV import: expects JSON array of review objects or CSV text.
+ * JSON format: [{ yachtModelId, reviewSourceId?, source?, rating, summary?, ... }]
+ */
+export async function POST(request: Request) {
+  try {
+    const contentType = request.headers.get('content-type') || '';
+    let reviews: Array<Record<string, unknown>>;
+
+    if (contentType.includes('text/csv')) {
+      const text = await request.text();
+      const lines = text.trim().split('\n');
+      if (lines.length < 2) {
+        return NextResponse.json({ error: 'CSV must have a header row and at least one data row' }, { status: 400 });
+      }
+      const headers = lines[0].split(',').map(h => h.trim().toLowerCase());
+      reviews = lines.slice(1).map(line => {
+        const values = line.split(',').map(v => v.trim());
+        const obj: Record<string, unknown> = {};
+        headers.forEach((h, i) => { obj[h] = values[i]; });
+        return obj;
+      });
+    } else {
+      const body = await request.json();
+      reviews = Array.isArray(body) ? body : body.reviews;
+    }
+
+    if (!Array.isArray(reviews) || reviews.length === 0) {
+      return NextResponse.json({ error: 'No reviews provided' }, { status: 400 });
+    }
+
+    if (reviews.length > 500) {
+      return NextResponse.json({ error: 'Maximum 500 reviews per batch' }, { status: 400 });
+    }
+
+    let imported = 0;
+    let errors = 0;
+    const errorDetails: string[] = [];
+
+    for (let i = 0; i < reviews.length; i++) {
+      const r = reviews[i];
+      const yachtModelId = Number(r.yachtmodelid || r.yacht_model_id || r.yachtModelId);
+      const rating = Number(r.rating);
+
+      if (!yachtModelId || isNaN(rating) || rating < 1 || rating > 5) {
+        errors++;
+        errorDetails.push(`Row ${i + 1}: invalid yachtModelId or rating`);
+        continue;
+      }
+
+      try {
+        const reviewSourceId = r.reviewsourceid || r.review_source_id || r.reviewSourceId || null;
+        const source = (r.source as string) || 'import';
+        const summary = (r.summary as string) || null;
+        const fullText = (r.fulltext || r.full_text || r.fullText) as string || null;
+        const authorName = (r.authorname || r.author_name || r.authorName) as string || null;
+        const sourceUrl = (r.sourceurl || r.source_url || r.sourceUrl) as string || null;
+        const reviewDate = (r.reviewdate || r.review_date || r.reviewDate) as string || null;
+        const reviewType = (r.reviewtype || r.review_type || r.reviewType) as string || 'expert';
+
+        let pros: string[] = [];
+        let cons: string[] = [];
+        if (r.pros) {
+          pros = typeof r.pros === 'string' ? r.pros.split(';').filter(Boolean) : (r.pros as string[]);
+        }
+        if (r.cons) {
+          cons = typeof r.cons === 'string' ? r.cons.split(';').filter(Boolean) : (r.cons as string[]);
+        }
+
+        await pool.query(
+          `INSERT INTO reviews (
+            yacht_model_id, review_source_id, source, rating, summary, full_text,
+            author_name, source_url, review_date, review_type, pros, cons, verified
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, true)`,
+          [
+            yachtModelId,
+            reviewSourceId ? Number(reviewSourceId) : null,
+            source,
+            String(rating),
+            summary,
+            fullText,
+            authorName,
+            sourceUrl,
+            reviewDate,
+            reviewType,
+            pros,
+            cons,
+          ]
+        );
+        imported++;
+      } catch (e: any) {
+        errors++;
+        errorDetails.push(`Row ${i + 1}: ${e.message}`);
+      }
+    }
+
+    revalidateTag('yachts');
+
+    return NextResponse.json({
+      imported,
+      errors,
+      ...(errorDetails.length > 0 && { errorDetails: errorDetails.slice(0, 20) }),
+    }, { status: 201 });
+  } catch (error) {
+    console.error('Failed to import reviews:', error);
+    return NextResponse.json({ error: 'Failed to import reviews' }, { status: 500 });
+  }
+}

--- a/app/api/yachts/[slug]/review-aggregation/route.ts
+++ b/app/api/yachts/[slug]/review-aggregation/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { pool } from '@/lib/db';
+import { getYachtReviewAggregation } from '@/lib/review-aggregation';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/yachts/[slug]/review-aggregation */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+
+    // Look up yacht model ID from slug
+    const yachtResult = await pool.query(
+      'SELECT id FROM yacht_models WHERE slug = $1',
+      [slug]
+    );
+    if (yachtResult.rows.length === 0) {
+      return NextResponse.json({ error: 'Yacht not found' }, { status: 404 });
+    }
+
+    const yachtModelId = Number(yachtResult.rows[0].id);
+    const aggregation = await getYachtReviewAggregation(yachtModelId);
+    return NextResponse.json(aggregation);
+  } catch (error) {
+    console.error('Failed to fetch review aggregation:', error);
+    return NextResponse.json({ error: 'Failed to fetch review aggregation' }, { status: 500 });
+  }
+}

--- a/components/ReviewAggregation.tsx
+++ b/components/ReviewAggregation.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { ExternalLink } from 'lucide-react';
+
+interface ReviewSourceAggregation {
+  sourceId: number;
+  sourceName: string;
+  sourceSlug: string;
+  sourceType: string;
+  sourceLogoUrl: string | null;
+  sourceWebsiteUrl: string | null;
+  credibilityScore: number;
+  reviewCount: number;
+  averageRating: number;
+  latestReviewDate: string | null;
+}
+
+interface ReviewAggregationProps {
+  aggregation: {
+    overallAverage: number;
+    totalReviewCount: number;
+    sourceCount: number;
+    bySource: ReviewSourceAggregation[];
+    unassignedCount: number;
+  } | null;
+}
+
+function StarRating({ rating, max = 5 }: { rating: number; max?: number }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {Array.from({ length: max }, (_, i) => (
+        <svg
+          key={i}
+          className={`w-4 h-4 ${i < Math.round(rating) ? 'text-yellow-400 fill-yellow-400' : 'text-gray-300 fill-gray-300'}`}
+          viewBox="0 0 20 20"
+        >
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      ))}
+      <span className="ml-1 text-sm font-medium text-gray-700">{rating.toFixed(1)}</span>
+    </div>
+  );
+}
+
+const sourceTypeIcons: Record<string, string> = {
+  magazine: '📰',
+  youtube: '🎥',
+  blog: '📝',
+  expert: '🏆',
+  forum: '💬',
+};
+
+export default function ReviewAggregation({ aggregation }: ReviewAggregationProps) {
+  if (!aggregation || aggregation.sourceCount === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-border p-5 sm:p-6">
+      <h3 className="text-lg font-bold text-gray-900 mb-4">
+        Expert Review Aggregation
+      </h3>
+
+      {/* Overall score */}
+      <div className="flex items-center gap-4 mb-5 pb-5 border-b border-gray-100">
+        <div className="text-center">
+          <div className="text-4xl font-bold text-gray-900">{aggregation.overallAverage.toFixed(1)}</div>
+          <div className="text-xs text-gray-500 mt-1">Weighted Score</div>
+        </div>
+        <div className="flex-1">
+          <StarRating rating={aggregation.overallAverage} />
+          <p className="text-sm text-gray-500 mt-1">
+            Based on {aggregation.totalReviewCount} reviews from {aggregation.sourceCount} {aggregation.sourceCount === 1 ? 'source' : 'sources'}
+          </p>
+        </div>
+      </div>
+
+      {/* Source breakdown */}
+      <div className="space-y-3">
+        {aggregation.bySource.map((source) => (
+          <div key={source.sourceId} className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 hover:bg-gray-100 transition-colors">
+            {source.sourceLogoUrl ? (
+              <img src={source.sourceLogoUrl} alt={source.sourceName} className="w-8 h-8 rounded object-contain" />
+            ) : (
+              <span className="text-xl w-8 text-center">{sourceTypeIcons[source.sourceType] || '📋'}</span>
+            )}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-gray-900 truncate">{source.sourceName}</span>
+                {source.sourceWebsiteUrl && (
+                  <a
+                    href={source.sourceWebsiteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-gray-400 hover:text-blue-500 shrink-0"
+                    aria-label={`Visit ${source.sourceName}`}
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                )}
+              </div>
+              <div className="flex items-center gap-2 mt-0.5">
+                <StarRating rating={source.averageRating} />
+                <span className="text-xs text-gray-400">({source.reviewCount})</span>
+              </div>
+            </div>
+            <div className="text-right shrink-0">
+              <div className="text-lg font-bold text-gray-900">{source.averageRating.toFixed(1)}</div>
+              <div className="text-xs text-gray-400">cred: {source.credibilityScore}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {aggregation.unassignedCount > 0 && (
+        <p className="text-xs text-gray-400 mt-3 italic">
+          + {aggregation.unassignedCount} review{aggregation.unassignedCount > 1 ? 's' : ''} from unassigned sources
+        </p>
+      )}
+    </div>
+  );
+}

--- a/drizzle/migrations/0024_review_sources.sql
+++ b/drizzle/migrations/0024_review_sources.sql
@@ -1,0 +1,22 @@
+-- P25.2: Review sources for external review aggregation
+CREATE TABLE IF NOT EXISTS review_sources (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(200) NOT NULL UNIQUE,
+  slug VARCHAR(200) NOT NULL UNIQUE,
+  website_url VARCHAR(500),
+  logo_url VARCHAR(500),
+  description TEXT,
+  credibility_score INTEGER DEFAULT 50,
+  source_type VARCHAR(50) NOT NULL DEFAULT 'magazine',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  last_fetched_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_review_sources_slug ON review_sources(slug);
+CREATE INDEX IF NOT EXISTS idx_review_sources_active ON review_sources(is_active);
+
+-- Add review_source_id FK to existing reviews table
+ALTER TABLE reviews ADD COLUMN IF NOT EXISTS review_source_id INTEGER REFERENCES review_sources(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_reviews_source ON reviews(review_source_id);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -226,6 +226,7 @@ export const reviews = pgTable(
       .notNull()
       .references(() => yachtModels.id, { onDelete: "cascade" }),
     source: varchar("source", { length: 100 }),
+    reviewSourceId: integer("review_source_id").references(() => reviewSources.id, { onDelete: "set null" }),
     rating: numeric("rating", { precision: 2, scale: 1 }),
     summary: text("summary"),
     fullText: text("full_text"),
@@ -1135,3 +1136,29 @@ export const articleYachts = pgTable(
 
 export const insertArticleYachtSchema = createInsertSchema(articleYachts);
 export const selectArticleYachtSchema = createSelectSchema(articleYachts);
+
+// P25.2: External review sources (magazines, YouTube channels, expert sites)
+export const reviewSources = pgTable(
+  "review_sources",
+  {
+    id: serial("id").primaryKey(),
+    name: varchar("name", { length: 200 }).notNull().unique(),
+    slug: varchar("slug", { length: 200 }).notNull().unique(),
+    websiteUrl: varchar("website_url", { length: 500 }),
+    logoUrl: varchar("logo_url", { length: 500 }),
+    description: text("description"),
+    credibilityScore: integer("credibility_score").default(50),
+    sourceType: varchar("source_type", { length: 50 }).notNull().default("magazine"),
+    isActive: boolean("is_active").notNull().default(true),
+    lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => ({
+    idxSlug: uniqueIndex("idx_review_sources_slug").on(table.slug),
+    idxActive: index("idx_review_sources_active").on(table.isActive),
+  }),
+);
+
+export const insertReviewSourceSchema = createInsertSchema(reviewSources);
+export const selectReviewSourceSchema = createSelectSchema(reviewSources);

--- a/lib/review-aggregation.ts
+++ b/lib/review-aggregation.ts
@@ -1,0 +1,163 @@
+import { pool } from '@/lib/db';
+
+export interface ReviewSourceAggregation {
+  sourceId: number;
+  sourceName: string;
+  sourceSlug: string;
+  sourceType: string;
+  sourceLogoUrl: string | null;
+  sourceWebsiteUrl: string | null;
+  credibilityScore: number;
+  reviewCount: number;
+  averageRating: number;
+  latestReviewDate: string | null;
+}
+
+export interface YachtReviewAggregation {
+  overallAverage: number;
+  totalReviewCount: number;
+  sourceCount: number;
+  bySource: ReviewSourceAggregation[];
+  unassignedCount: number;
+}
+
+/**
+ * Get aggregated review data for a yacht, grouped by review source.
+ */
+export async function getYachtReviewAggregation(yachtModelId: number): Promise<YachtReviewAggregation> {
+  const result = await pool.query(
+    `SELECT
+       rs.id as source_id,
+       rs.name as source_name,
+       rs.slug as source_slug,
+       rs.source_type,
+       rs.logo_url as source_logo_url,
+       rs.website_url as source_website_url,
+       COALESCE(rs.credibility_score, 50) as credibility_score,
+       COUNT(r.id)::int as review_count,
+       AVG(r.rating::numeric) as avg_rating,
+       MAX(r.review_date) as latest_review_date
+     FROM review_sources rs
+     INNER JOIN reviews r ON r.review_source_id = rs.id
+     WHERE r.yacht_model_id = $1 AND r.rating IS NOT NULL
+     GROUP BY rs.id, rs.name, rs.slug, rs.source_type, rs.logo_url, rs.website_url, rs.credibility_score
+     ORDER BY credibility_score DESC, review_count DESC`,
+    [yachtModelId]
+  );
+
+  // Count reviews without a source
+  const unassigned = await pool.query(
+    `SELECT COUNT(*)::int as cnt, AVG(rating::numeric) as avg
+     FROM reviews
+     WHERE yacht_model_id = $1 AND rating IS NOT NULL AND review_source_id IS NULL`,
+    [yachtModelId]
+  );
+
+  const bySource: ReviewSourceAggregation[] = result.rows.map(row => ({
+    sourceId: Number(row.source_id),
+    sourceName: row.source_name,
+    sourceSlug: row.source_slug,
+    sourceType: row.source_type,
+    sourceLogoUrl: row.source_logo_url,
+    sourceWebsiteUrl: row.source_website_url,
+    credibilityScore: Number(row.credibility_score),
+    reviewCount: Number(row.review_count),
+    averageRating: row.avg_rating ? Math.round(Number(row.avg_rating) * 10) / 10 : 0,
+    latestReviewDate: row.latest_review_date,
+  }));
+
+  const unassignedCount = Number(unassigned.rows[0]?.cnt ?? 0);
+  const totalReviewCount = bySource.reduce((sum, s) => sum + s.reviewCount, 0) + unassignedCount;
+
+  // Weighted average based on credibility scores
+  let weightedSum = 0;
+  let weightedDivisor = 0;
+  for (const source of bySource) {
+    weightedSum += source.averageRating * source.reviewCount * source.credibilityScore;
+    weightedDivisor += source.reviewCount * source.credibilityScore;
+  }
+
+  const overallAverage = weightedDivisor > 0
+    ? Math.round((weightedSum / weightedDivisor) * 10) / 10
+    : 0;
+
+  return {
+    overallAverage,
+    totalReviewCount,
+    sourceCount: bySource.length,
+    bySource,
+    unassignedCount,
+  };
+}
+
+/**
+ * Get all active review sources for admin dropdowns.
+ */
+export async function getActiveReviewSources() {
+  const result = await pool.query(
+    `SELECT id, name, slug, source_type, credibility_score
+     FROM review_sources
+     WHERE is_active = true
+     ORDER BY name`
+  );
+  return result.rows.map(row => ({
+    id: Number(row.id),
+    name: row.name,
+    slug: row.slug,
+    sourceType: row.source_type,
+    credibilityScore: Number(row.credibility_score ?? 50),
+  }));
+}
+
+/**
+ * Batch import reviews from CSV-like data.
+ */
+export async function batchImportReviews(
+  reviews: Array<{
+    yachtModelId: number;
+    reviewSourceId?: number;
+    source?: string;
+    rating: number;
+    summary?: string;
+    fullText?: string;
+    authorName?: string;
+    sourceUrl?: string;
+    reviewDate?: string;
+    reviewType?: string;
+    pros?: string[];
+    cons?: string[];
+  }>
+): Promise<{ imported: number; errors: number }> {
+  let imported = 0;
+  let errors = 0;
+
+  for (const review of reviews) {
+    try {
+      await pool.query(
+        `INSERT INTO reviews (
+          yacht_model_id, review_source_id, source, rating, summary, full_text,
+          author_name, source_url, review_date, review_type, pros, cons, verified
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, true)`,
+        [
+          review.yachtModelId,
+          review.reviewSourceId ?? null,
+          review.source ?? 'import',
+          String(review.rating),
+          review.summary ?? null,
+          review.fullText ?? null,
+          review.authorName ?? null,
+          review.sourceUrl ?? null,
+          review.reviewDate ?? null,
+          review.reviewType ?? 'expert',
+          review.pros ?? [],
+          review.cons ?? [],
+        ]
+      );
+      imported++;
+    } catch {
+      errors++;
+    }
+  }
+
+  return { imported, errors };
+}

--- a/tests/review-sources.spec.ts
+++ b/tests/review-sources.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+
+test.describe('Review Sources API', () => {
+  test('GET /api/admin/review-sources returns sources list', async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/admin/review-sources`);
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data).toHaveProperty('sources');
+    expect(Array.isArray(data.sources)).toBeTruthy();
+  });
+
+  test('POST /api/admin/review-sources creates a source', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/admin/review-sources`, {
+      data: {
+        name: `Test Source ${Date.now()}`,
+        sourceType: 'magazine',
+        websiteUrl: 'https://example.com',
+        credibilityScore: 75,
+      },
+    });
+    expect(res.status()).toBe(201);
+    const data = await res.json();
+    expect(data).toHaveProperty('source');
+    expect(data.source).toHaveProperty('id');
+    expect(data.source).toHaveProperty('name');
+    expect(data.source).toHaveProperty('slug');
+    expect(data.source.sourceType).toBe('magazine');
+    expect(data.source.credibilityScore).toBe(75);
+  });
+
+  test('POST /api/admin/review-sources rejects missing name', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/admin/review-sources`, {
+      data: { sourceType: 'blog' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('GET /api/admin/review-sources/[id] returns single source', async ({ request }) => {
+    // Create first
+    const createRes = await request.post(`${BASE_URL}/api/admin/review-sources`, {
+      data: {
+        name: `Single Test Source ${Date.now()}`,
+        sourceType: 'expert',
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const { source } = await createRes.json();
+
+    // Fetch by ID
+    const res = await request.get(`${BASE_URL}/api/admin/review-sources/${source.id}`);
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data.source.id).toBe(source.id);
+    expect(data.source.name).toBe(source.name);
+  });
+
+  test('PATCH /api/admin/review-sources/[id] updates a source', async ({ request }) => {
+    // Create first
+    const createRes = await request.post(`${BASE_URL}/api/admin/review-sources`, {
+      data: {
+        name: `Update Test Source ${Date.now()}`,
+        sourceType: 'magazine',
+      },
+    });
+    const { source } = await createRes.json();
+
+    // Update
+    const res = await request.patch(`${BASE_URL}/api/admin/review-sources/${source.id}`, {
+      data: { credibility_score: 90 },
+    });
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data.source.credibilityScore).toBe(90);
+  });
+
+  test('DELETE /api/admin/review-sources/[id] deletes a source', async ({ request }) => {
+    // Create first
+    const createRes = await request.post(`${BASE_URL}/api/admin/review-sources`, {
+      data: {
+        name: `Delete Test Source ${Date.now()}`,
+        sourceType: 'forum',
+      },
+    });
+    const { source } = await createRes.json();
+
+    // Delete
+    const res = await request.delete(`${BASE_URL}/api/admin/review-sources/${source.id}`);
+    expect(res.ok()).toBeTruthy();
+
+    // Verify deleted
+    const getRes = await request.get(`${BASE_URL}/api/admin/review-sources/${source.id}`);
+    expect(getRes.status()).toBe(404);
+  });
+});
+
+test.describe('Review Aggregation API', () => {
+  test('GET /api/yachts/[slug]/review-aggregation returns aggregation', async ({ request }) => {
+    // This may return empty aggregation for most yachts - that's OK
+    const res = await request.get(`${BASE_URL}/api/yachts/beneteau-oceanis-40-1/review-aggregation`);
+    // Could be 404 if yacht doesn't exist, or 200
+    if (res.ok()) {
+      const data = await res.json();
+      expect(data).toHaveProperty('overallAverage');
+      expect(data).toHaveProperty('totalReviewCount');
+      expect(data).toHaveProperty('sourceCount');
+      expect(data).toHaveProperty('bySource');
+      expect(data).toHaveProperty('unassignedCount');
+      expect(Array.isArray(data.bySource)).toBeTruthy();
+    }
+  });
+});
+
+test.describe('Review Import API', () => {
+  test('POST /api/admin/reviews/import with empty array returns 400', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/admin/reviews/import`, {
+      data: { reviews: [] },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('POST /api/admin/reviews/import rejects invalid reviews gracefully', async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/admin/reviews/import`, {
+      data: [
+        { yachtModelId: 999999, rating: 5 }, // Non-existent yacht
+        { rating: 'invalid' }, // Missing yachtModelId
+      ],
+    });
+    // Should return results with errors count
+    expect(res.status()).toBe(201);
+    const data = await res.json();
+    expect(data).toHaveProperty('imported');
+    expect(data).toHaveProperty('errors');
+    expect(data.errors).toBeGreaterThan(0);
+  });
+});
+
+test.describe('Review Sources Admin Pages', () => {
+  test('Admin review sources list page loads', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/review-sources`);
+    // Should show page content (may redirect to login if not authenticated)
+    const content = await page.content();
+    expect(content).toContain('Review Sources');
+  });
+});


### PR DESCRIPTION
- review_sources table: named external sources with credibility scores
- Admin CRUD: /api/admin/review-sources with create/update/delete
- Admin UI: review sources list, add, edit pages
- Review aggregation service: weighted average by credibility score
- Public API: /api/yachts/[slug]/review-aggregation
- ReviewAggregation component on yacht detail pages
- CSV/batch import endpoint: /api/admin/reviews/import
- Review source dropdown in admin review creation form
- Schema.org AggregateRating JSON-LD for source-aware ratings
- DB migration: review_sources table + review_source_id FK on reviews
- Tests: API CRUD, aggregation, import, admin pages
