### PR TITLE
feat: Interactive sailing quiz — P25.3 (closes #405)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -97,7 +97,7 @@
 ### Phase 25 — Content Expansion (Priority: Medium) — 🔲 PLANNED
 
 - **P25.1 — Sailing guides CMS** *(completed 2026-06-09 — Issue #401, PR #402, 15 tests)* — Full CMS for creating/editing sailing guides. Rich text editor (Markdown with preview), image upload with validation, SEO fields (meta_title, meta_description, og_image, canonical_url, noindex). Category tagging, related yacht linking with autocomplete search. Author attribution.
-- **P25.2 — Yacht review aggregation** — Aggregate reviews from external sources. Schema for review source, rating, URL. Display aggregated scores on yacht detail. Admin review management.
+- **P25.2 — Yacht review aggregation** *(completed 2026-06-09 — Issue #403, PR #404)* — Aggregate reviews from external sources. Schema for review source, rating, URL. Display aggregated scores on yacht detail. Admin review management.
 - **P25.3 — Interactive sailing quiz** — "Which yacht is right for you?" personality-style quiz. Result leads to yacht finder recommendations. Shareable results. Lead capture integration.
 - **P25.4 — Multilingual content pipeline** — Auto-translate guides and descriptions to French. Translation queue with human review. Translation memory for consistency.
 - **P25.5 — Dynamic FAQ generation** — Auto-generate FAQs from yacht data patterns. Schema markup for FAQ rich results. Crawlable FAQ pages per manufacturer/size category.

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -328,6 +328,21 @@ export default async function Home({ params }: HomeProps) {
           </div>
         </section>
 
+        {/* Quiz CTA */}
+        <section className="py-12 px-4 bg-gradient-to-r from-sky-50 to-blue-50 border-t border-blue-100">
+          <div className="max-w-2xl mx-auto text-center">
+            <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-3">{t("quizCta.title")}</h2>
+            <p className="text-gray-600 mb-6">{t("quizCta.subtitle")}</p>
+            <Link
+              href={`/${locale}/quiz`}
+              className="inline-flex items-center gap-2 px-8 py-3 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition shadow-lg shadow-blue-200"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/></svg>
+              {t("quizCta.button")}
+            </Link>
+          </div>
+        </section>
+
         {/* Newsletter Signup */}
         <section className="py-12 px-4 bg-blue-50 border-t border-blue-100">
           <div className="max-w-xl mx-auto text-center">

--- a/app/[locale]/quiz/QuizClient.tsx
+++ b/app/[locale]/quiz/QuizClient.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Ship,
+  Wind,
+  Users,
+  Wallet,
+  Ruler,
+  ArrowRight,
+  ArrowLeft,
+  Compass,
+  Share2,
+  Mail,
+  Check,
+  Loader2,
+  ExternalLink,
+  Star,
+} from "lucide-react";
+import { localePath } from "@/lib/i18n-paths";
+
+// ─── Types ────────────────────────────────────────────────────────────
+interface QuizAnswers {
+  experience: string;
+  sailingType: string;
+  crewSize: string;
+  budget: string;
+  preferredLength: string;
+  keelPreference: string;
+  priority: string;
+}
+
+interface MatchedYacht {
+  id: number;
+  slug: string;
+  modelName: string;
+  manufacturerName: string;
+  year: number | null;
+  lengthOverall: number | null;
+  cabins: number | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  matchScore: number;
+  matchReasons: string[];
+  primaryImageUrl: string | null;
+}
+
+const defaultAnswers: QuizAnswers = {
+  experience: "",
+  sailingType: "",
+  crewSize: "",
+  budget: "",
+  preferredLength: "",
+  keelPreference: "",
+  priority: "",
+};
+
+const STEPS = [
+  "experience",
+  "sailingType",
+  "crewSize",
+  "budget",
+  "preferredLength",
+  "keelPreference",
+  "priority",
+] as const;
+
+type StepKey = (typeof STEPS)[number];
+
+// ─── Step Config ──────────────────────────────────────────────────────
+function getStepConfig(
+  t: (key: string) => string
+): Record<StepKey, { icon: React.ReactNode; question: string; options: { value: string; label: string; desc: string }[] }> {
+  return {
+    experience: {
+      icon: <Compass className="w-6 h-6" />,
+      question: t("steps.experience.question"),
+      options: [
+        { value: "beginner", label: t("steps.experience.beginner"), desc: t("steps.experience.beginnerDesc") },
+        { value: "intermediate", label: t("steps.experience.intermediate"), desc: t("steps.experience.intermediateDesc") },
+        { value: "advanced", label: t("steps.experience.advanced"), desc: t("steps.experience.advancedDesc") },
+      ],
+    },
+    sailingType: {
+      icon: <Wind className="w-6 h-6" />,
+      question: t("steps.sailingType.question"),
+      options: [
+        { value: "coastal", label: t("steps.sailingType.coastal"), desc: t("steps.sailingType.coastalDesc") },
+        { value: "offshore", label: t("steps.sailingType.offshore"), desc: t("steps.sailingType.offshoreDesc") },
+        { value: "racing", label: t("steps.sailingType.racing"), desc: t("steps.sailingType.racingDesc") },
+        { value: "cruising", label: t("steps.sailingType.cruising"), desc: t("steps.sailingType.cruisingDesc") },
+      ],
+    },
+    crewSize: {
+      icon: <Users className="w-6 h-6" />,
+      question: t("steps.crewSize.question"),
+      options: [
+        { value: "solo", label: t("steps.crewSize.solo"), desc: t("steps.crewSize.soloDesc") },
+        { value: "couple", label: t("steps.crewSize.couple"), desc: t("steps.crewSize.coupleDesc") },
+        { value: "family", label: t("steps.crewSize.family"), desc: t("steps.crewSize.familyDesc") },
+        { value: "group", label: t("steps.crewSize.group"), desc: t("steps.crewSize.groupDesc") },
+      ],
+    },
+    budget: {
+      icon: <Wallet className="w-6 h-6" />,
+      question: t("steps.budget.question"),
+      options: [
+        { value: "budget", label: t("steps.budget.budget"), desc: t("steps.budget.budgetDesc") },
+        { value: "midrange", label: t("steps.budget.midrange"), desc: t("steps.budget.midrangeDesc") },
+        { value: "premium", label: t("steps.budget.premium"), desc: t("steps.budget.premiumDesc") },
+        { value: "any", label: t("steps.budget.any"), desc: t("steps.budget.anyDesc") },
+      ],
+    },
+    preferredLength: {
+      icon: <Ruler className="w-6 h-6" />,
+      question: t("steps.preferredLength.question"),
+      options: [
+        { value: "small", label: t("steps.preferredLength.small"), desc: t("steps.preferredLength.smallDesc") },
+        { value: "medium", label: t("steps.preferredLength.medium"), desc: t("steps.preferredLength.mediumDesc") },
+        { value: "large", label: t("steps.preferredLength.large"), desc: t("steps.preferredLength.largeDesc") },
+        { value: "any", label: t("steps.preferredLength.any"), desc: t("steps.preferredLength.anyDesc") },
+      ],
+    },
+    keelPreference: {
+      icon: <Ship className="w-6 h-6" />,
+      question: t("steps.keelPreference.question"),
+      options: [
+        { value: "fin", label: t("steps.keelPreference.fin"), desc: t("steps.keelPreference.finDesc") },
+        { value: "wing", label: t("steps.keelPreference.wing"), desc: t("steps.keelPreference.wingDesc") },
+        { value: "full", label: t("steps.keelPreference.full"), desc: t("steps.keelPreference.fullDesc") },
+        { value: "any", label: t("steps.keelPreference.any"), desc: t("steps.keelPreference.anyDesc") },
+      ],
+    },
+    priority: {
+      icon: <Star className="w-6 h-6" />,
+      question: t("steps.priority.question"),
+      options: [
+        { value: "performance", label: t("steps.priority.performance"), desc: t("steps.priority.performanceDesc") },
+        { value: "comfort", label: t("steps.priority.comfort"), desc: t("steps.priority.comfortDesc") },
+        { value: "value", label: t("steps.priority.value"), desc: t("steps.priority.valueDesc") },
+        { value: "safety", label: t("steps.priority.safety"), desc: t("steps.priority.safetyDesc") },
+      ],
+    },
+  };
+}
+
+// ─── Main Component ───────────────────────────────────────────────────
+export default function QuizClient() {
+  const t = useTranslations("Quiz");
+  const [currentStep, setCurrentStep] = useState(0);
+  const [answers, setAnswers] = useState<QuizAnswers>(defaultAnswers);
+  const [results, setResults] = useState<MatchedYacht[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState("");
+  const [emailSubmitted, setEmailSubmitted] = useState(false);
+  const [shareUrl, setShareUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const stepConfig = getStepConfig(t);
+  const stepKey = STEPS[currentStep];
+  const config = stepConfig[stepKey];
+  const progress = ((currentStep + 1) / STEPS.length) * 100;
+  const isLastStep = currentStep === STEPS.length - 1;
+  const canProceed = answers[stepKey] !== "";
+
+  const handleAnswer = useCallback(
+    (value: string) => {
+      setAnswers((prev) => ({ ...prev, [stepKey]: value }));
+    },
+    [stepKey]
+  );
+
+  const handleNext = useCallback(async () => {
+    if (isLastStep) {
+      // Submit quiz
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/quiz", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(answers),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({ error: "Failed to get results" }));
+          throw new Error(data.error || "Failed to get results");
+        }
+        const data = await res.json();
+        setResults(data.yachts ?? []);
+
+        // Build shareable URL
+        const encoded = btoa(JSON.stringify(answers));
+        const url = new URL(window.location.href);
+        url.searchParams.set("r", encoded);
+        setShareUrl(url.toString());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setCurrentStep((prev) => prev + 1);
+    }
+  }, [isLastStep, answers]);
+
+  const handleBack = useCallback(() => {
+    setCurrentStep((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: t("shareTitle"),
+          text: t("shareText"),
+          url: shareUrl,
+        });
+      } catch {
+        // User cancelled or share failed
+      }
+    } else {
+      await navigator.clipboard.writeText(shareUrl);
+    }
+  }, [shareUrl, t]);
+
+  const handleEmailSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!email) return;
+      try {
+        await fetch("/api/newsletter", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email,
+            source: "quiz",
+          }),
+        });
+        setEmailSubmitted(true);
+      } catch {
+        // Silently handle — email is optional
+      }
+    },
+    [email]
+  );
+
+  // ─── Results View ─────────────────────────────────────────────────
+  if (results !== null) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-sky-50">
+        <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4">
+              <Compass className="w-8 h-8 text-blue-600" />
+            </div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+              {t("results.title")}
+            </h1>
+            <p className="text-gray-600">{t("results.subtitle")}</p>
+          </div>
+
+          {/* Results Cards */}
+          {results.length === 0 ? (
+            <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
+              <p className="text-gray-600">{t("results.noResults")}</p>
+              <button
+                onClick={() => {
+                  setResults(null);
+                  setCurrentStep(0);
+                  setAnswers(defaultAnswers);
+                }}
+                className="mt-4 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+              >
+                {t("results.retry")}
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {results.map((yacht, idx) => (
+                <div
+                  key={yacht.id}
+                  className={`bg-white rounded-xl border ${
+                    idx === 0
+                      ? "border-blue-300 ring-2 ring-blue-100"
+                      : "border-gray-200"
+                  } p-5 sm:p-6 transition hover:shadow-md`}
+                >
+                  <div className="flex items-start gap-4">
+                    {/* Rank badge */}
+                    <div
+                      className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center font-bold text-sm ${
+                        idx === 0
+                          ? "bg-blue-600 text-white"
+                          : idx === 1
+                          ? "bg-gray-200 text-gray-700"
+                          : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      #{idx + 1}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between gap-2">
+                        <div>
+                          <h3 className="text-lg font-semibold text-gray-900">
+                            {yacht.manufacturerName} {yacht.modelName}
+                            {yacht.year ? ` (${yacht.year})` : ""}
+                          </h3>
+                          <div className="flex flex-wrap gap-2 mt-1 text-sm text-gray-500">
+                            {yacht.lengthOverall && (
+                              <span>
+                                {yacht.lengthOverall}&apos; LOA
+                              </span>
+                            )}
+                            {yacht.cabins && (
+                              <span>{yacht.cabins} cabins</span>
+                            )}
+                            {yacht.keelType && <span>{yacht.keelType} keel</span>}
+                            {yacht.hullMaterial && (
+                              <span>{yacht.hullMaterial}</span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex-shrink-0 text-right">
+                          <div className="text-2xl font-bold text-blue-600">
+                            {Math.round(yacht.matchScore)}%
+                          </div>
+                          <div className="text-xs text-gray-400">
+                            {t("results.match")}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Match reasons */}
+                      {yacht.matchReasons.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5 mt-3">
+                          {yacht.matchReasons.map((reason, i) => (
+                            <span
+                              key={i}
+                              className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-50 text-green-700 rounded-full text-xs"
+                            >
+                              <Check className="w-3 h-3" />
+                              {reason}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* CTA */}
+                      <div className="mt-4">
+                        <a
+                          href={localePath("en", `/yachts/${yacht.slug}`)}
+                          className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg hover:bg-blue-100 transition"
+                        >
+                          {t("results.viewYacht")}
+                          <ExternalLink className="w-3.5 h-3.5" />
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Share + Email Section */}
+          <div className="mt-8 grid sm:grid-cols-2 gap-4">
+            {/* Share */}
+            <div className="bg-white rounded-xl border border-gray-200 p-5">
+              <h3 className="font-semibold text-gray-900 mb-2 flex items-center gap-2">
+                <Share2 className="w-4 h-4" />
+                {t("results.share")}
+              </h3>
+              <p className="text-sm text-gray-500 mb-3">
+                {t("results.shareDesc")}
+              </p>
+              <button
+                onClick={handleShare}
+                className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition text-sm font-medium"
+              >
+                {t("results.shareButton")}
+              </button>
+            </div>
+
+            {/* Email capture */}
+            <div className="bg-white rounded-xl border border-gray-200 p-5">
+              <h3 className="font-semibold text-gray-900 mb-2 flex items-center gap-2">
+                <Mail className="w-4 h-4" />
+                {t("results.saveResults")}
+              </h3>
+              {emailSubmitted ? (
+                <p className="text-sm text-green-600 flex items-center gap-1">
+                  <Check className="w-4 h-4" />
+                  {t("results.emailSuccess")}
+                </p>
+              ) : (
+                <form onSubmit={handleEmailSubmit} className="space-y-2">
+                  <p className="text-sm text-gray-500">
+                    {t("results.emailDesc")}
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="your@email.com"
+                      required
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+                    />
+                    <button
+                      type="submit"
+                      className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium"
+                    >
+                      {t("results.send")}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </div>
+          </div>
+
+          {/* Retake quiz */}
+          <div className="mt-6 text-center">
+            <button
+              onClick={() => {
+                setResults(null);
+                setCurrentStep(0);
+                setAnswers(defaultAnswers);
+                setEmailSubmitted(false);
+                setEmail("");
+              }}
+              className="text-blue-600 hover:text-blue-800 text-sm font-medium underline"
+            >
+              {t("results.retake")}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Quiz Steps ──────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-sky-50">
+      <div className="max-w-2xl mx-auto px-4 py-8 sm:py-12">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4">
+            <Ship className="w-8 h-8 text-blue-600" />
+          </div>
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+            {t("title")}
+          </h1>
+          <p className="text-gray-600">{t("subtitle")}</p>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between text-sm text-gray-500 mb-2">
+            <span>
+              {t("step")} {currentStep + 1} / {STEPS.length}
+            </span>
+            <span>{Math.round(progress)}%</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Question */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6 sm:p-8 shadow-sm">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-50 text-blue-600">
+              {config.icon}
+            </div>
+            <h2 className="text-lg sm:text-xl font-semibold text-gray-900">
+              {config.question}
+            </h2>
+          </div>
+
+          {/* Options */}
+          <div className="space-y-3">
+            {config.options.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => handleAnswer(option.value)}
+                className={`w-full text-left p-4 rounded-xl border-2 transition-all ${
+                  answers[stepKey] === option.value
+                    ? "border-blue-500 bg-blue-50 ring-1 ring-blue-200"
+                    : "border-gray-200 bg-white hover:border-blue-200 hover:bg-blue-50/50"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                      answers[stepKey] === option.value
+                        ? "border-blue-500 bg-blue-500"
+                        : "border-gray-300"
+                    }`}
+                  >
+                    {answers[stepKey] === option.value && (
+                      <Check className="w-3 h-3 text-white" />
+                    )}
+                  </div>
+                  <div>
+                    <div className="font-medium text-gray-900">
+                      {option.label}
+                    </div>
+                    <div className="text-sm text-gray-500 mt-0.5">
+                      {option.desc}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Navigation */}
+          <div className="flex items-center justify-between mt-6 pt-6 border-t border-gray-100">
+            <button
+              onClick={handleBack}
+              disabled={currentStep === 0}
+              className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition ${
+                currentStep === 0
+                  ? "text-gray-300 cursor-not-allowed"
+                  : "text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              <ArrowLeft className="w-4 h-4" />
+              {t("back")}
+            </button>
+
+            <button
+              onClick={handleNext}
+              disabled={!canProceed || loading}
+              className={`flex items-center gap-1.5 px-6 py-2.5 rounded-lg text-sm font-medium transition ${
+                !canProceed || loading
+                  ? "bg-gray-200 text-gray-400 cursor-not-allowed"
+                  : "bg-blue-600 text-white hover:bg-blue-700"
+              }`}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  {t("analyzing")}
+                </>
+              ) : isLastStep ? (
+                <>
+                  {t("getResults")}
+                  <Compass className="w-4 h-4" />
+                </>
+              ) : (
+                <>
+                  {t("next")}
+                  <ArrowRight className="w-4 h-4" />
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/quiz/page.tsx
+++ b/app/[locale]/quiz/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { getSiteUrl } from "@/lib/seo";
+import QuizClient from "./QuizClient";
+
+export const metadata: Metadata = {
+  title: "Which Sailing Yacht is Right for You? — Interactive Quiz",
+  description:
+    "Take our 2-minute quiz to find the perfect sailing yacht based on your experience, sailing style, budget, and preferences. Get personalized recommendations.",
+  alternates: {
+    canonical: getSiteUrl("/quiz"),
+  },
+  openGraph: {
+    title: "Which Sailing Yacht is Right for You?",
+    description:
+      "Take our interactive quiz and discover your ideal sailing yacht in 2 minutes.",
+    type: "website",
+    url: getSiteUrl("/quiz"),
+  },
+};
+
+export default async function QuizPage({
+  params,
+}: {
+  params: { locale: string };
+}) {
+  const { locale } = params;
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "Quiz" });
+
+  return <QuizClient />;
+}

--- a/app/api/quiz/route.ts
+++ b/app/api/quiz/route.ts
@@ -1,0 +1,415 @@
+import { NextResponse } from "next/server";
+import { pool } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface QuizAnswers {
+  experience: string;
+  sailingType: string;
+  crewSize: string;
+  budget: string;
+  preferredLength: string;
+  keelPreference: string;
+  priority: string;
+}
+
+interface MatchedYacht {
+  id: number;
+  slug: string;
+  modelName: string;
+  manufacturerName: string;
+  year: number | null;
+  lengthOverall: number | null;
+  cabins: number | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  matchScore: number;
+  matchReasons: string[];
+  primaryImageUrl: string | null;
+}
+
+/**
+ * Build SQL WHERE conditions and compute match score per yacht
+ * based on quiz answers.
+ */
+function buildQuizFilters(answers: QuizAnswers): {
+  conditions: string[];
+  scoreWeights: Array<{ column: string; check: string; weight: number; reason: string }>;
+} {
+  const conditions: string[] = [];
+  const scoreWeights: Array<{ column: string; check: string; weight: number; reason: string }> = [];
+
+  // ─── Preferred Length ─────────────────────────────────────────────
+  if (answers.preferredLength === "small") {
+    conditions.push("y.length_overall::numeric <= 10");
+    scoreWeights.push({
+      column: "y.length_overall",
+      check: "<= 9",
+      weight: 30,
+      reason: "Compact size",
+    });
+  } else if (answers.preferredLength === "medium") {
+    conditions.push("y.length_overall::numeric >= 9 AND y.length_overall::numeric <= 14");
+    scoreWeights.push({
+      column: "y.length_overall",
+      check: "BETWEEN 10 AND 13",
+      weight: 30,
+      reason: "Ideal mid-size",
+    });
+  } else if (answers.preferredLength === "large") {
+    conditions.push("y.length_overall::numeric >= 12");
+    scoreWeights.push({
+      column: "y.length_overall",
+      check: ">= 14",
+      weight: 30,
+      reason: "Spacious cruiser",
+    });
+  }
+  // "any" → no filter
+
+  // ─── Crew Size → Cabins ──────────────────────────────────────────
+  if (answers.crewSize === "solo") {
+    scoreWeights.push({
+      column: "y.cabins",
+      check: "<= 2",
+      weight: 20,
+      reason: "Perfect for solo sailing",
+    });
+  } else if (answers.crewSize === "couple") {
+    scoreWeights.push({
+      column: "y.cabins",
+      check: ">= 1 AND y.cabins <= 3",
+      weight: 20,
+      reason: "Great for couples",
+    });
+  } else if (answers.crewSize === "family") {
+    conditions.push("(y.cabins >= 2 OR y.cabins IS NULL)");
+    scoreWeights.push({
+      column: "y.cabins",
+      check: ">= 3",
+      weight: 25,
+      reason: "Family-friendly",
+    });
+  } else if (answers.crewSize === "group") {
+    conditions.push("(y.cabins >= 3 OR y.cabins IS NULL)");
+    scoreWeights.push({
+      column: "y.cabins",
+      check: ">= 4",
+      weight: 25,
+      reason: "Group-ready",
+    });
+  }
+
+  // ─── Sailing Type ────────────────────────────────────────────────
+  if (answers.sailingType === "racing") {
+    scoreWeights.push({
+      column: "y.rig_type",
+      check: "= 'Sloop'",
+      weight: 20,
+      reason: "Performance rig",
+    });
+  } else if (answers.sailingType === "offshore") {
+    scoreWeights.push({
+      column: "y.displacement",
+      check: ">= 5000",
+      weight: 20,
+      reason: "Offshore-capable",
+    });
+  } else if (answers.sailingType === "cruising") {
+    scoreWeights.push({
+      column: "y.cabins",
+      check: ">= 2",
+      weight: 15,
+      reason: "Comfortable cruiser",
+    });
+  }
+  // coastal → no extra filter
+
+  // ─── Experience Level ────────────────────────────────────────────
+  if (answers.experience === "beginner") {
+    // Prefer smaller, easier-to-handle boats
+    scoreWeights.push({
+      column: "y.length_overall",
+      check: "<= 11",
+      weight: 15,
+      reason: "Beginner-friendly size",
+    });
+    scoreWeights.push({
+      column: "y.keel_type",
+      check: "LIKE '%wing%'",
+      weight: 10,
+      reason: "Stable keel design",
+    });
+  } else if (answers.experience === "advanced") {
+    scoreWeights.push({
+      column: "y.length_overall",
+      check: ">= 12",
+      weight: 10,
+      reason: "Advanced handling",
+    });
+  }
+
+  // ─── Keel Preference ─────────────────────────────────────────────
+  if (answers.keelPreference === "fin") {
+    conditions.push("(y.keel_type ILIKE '%fin%' OR y.keel_type IS NULL)");
+    scoreWeights.push({
+      column: "y.keel_type",
+      check: "ILIKE '%fin%'",
+      weight: 15,
+      reason: "Fin keel",
+    });
+  } else if (answers.keelPreference === "wing") {
+    conditions.push("(y.keel_type ILIKE '%wing%' OR y.keel_type IS NULL)");
+    scoreWeights.push({
+      column: "y.keel_type",
+      check: "ILIKE '%wing%'",
+      weight: 15,
+      reason: "Wing keel",
+    });
+  } else if (answers.keelPreference === "full") {
+    conditions.push("(y.keel_type ILIKE '%full%' OR y.keel_type IS NULL)");
+    scoreWeights.push({
+      column: "y.keel_type",
+      check: "ILIKE '%full%'",
+      weight: 15,
+      reason: "Full keel",
+    });
+  }
+
+  return { conditions, scoreWeights };
+}
+
+/**
+ * Score a yacht row based on how well it matches quiz criteria.
+ * Returns 0–100 score and matching reasons.
+ */
+function scoreYacht(
+  row: Record<string, unknown>,
+  scoreWeights: Array<{ column: string; check: string; weight: number; reason: string }>,
+  answers: QuizAnswers
+): { score: number; reasons: string[] } {
+  let score = 50; // base score
+  const reasons: string[] = [];
+  const loa = row.length_overall != null ? Number(row.length_overall) : null;
+  const cabins = row.cabins != null ? Number(row.cabins) : null;
+  const keelType = row.keel_type as string | null;
+  const displacement = row.displacement != null ? Number(row.displacement) : null;
+  const rigType = row.rig_type as string | null;
+
+  // Length scoring
+  if (answers.preferredLength === "small" && loa != null && loa <= 10) {
+    score += 25;
+    reasons.push("Compact size");
+  } else if (answers.preferredLength === "medium" && loa != null && loa >= 9 && loa <= 14) {
+    score += 25;
+    reasons.push("Ideal mid-size");
+  } else if (answers.preferredLength === "large" && loa != null && loa >= 12) {
+    score += 25;
+    reasons.push("Spacious cruiser");
+  }
+
+  // Crew/cabins scoring
+  if (answers.crewSize === "solo" && cabins != null && cabins <= 2) {
+    score += 15;
+    reasons.push("Solo-friendly");
+  } else if (answers.crewSize === "couple" && cabins != null && cabins >= 1 && cabins <= 3) {
+    score += 15;
+    reasons.push("Couple-friendly");
+  } else if (answers.crewSize === "family" && cabins != null && cabins >= 2) {
+    score += 20;
+    reasons.push("Family-friendly");
+  } else if (answers.crewSize === "group" && cabins != null && cabins >= 3) {
+    score += 20;
+    reasons.push("Group-ready");
+  }
+
+  // Sailing type scoring
+  if (answers.sailingType === "racing" && rigType === "Sloop") {
+    score += 15;
+    reasons.push("Performance rig");
+  } else if (answers.sailingType === "offshore" && displacement != null && displacement >= 5000) {
+    score += 15;
+    reasons.push("Offshore-capable");
+  } else if (answers.sailingType === "cruising" && cabins != null && cabins >= 2) {
+    score += 10;
+    reasons.push("Comfortable cruiser");
+  } else if (answers.sailingType === "coastal") {
+    score += 5;
+    reasons.push("Coastal ready");
+  }
+
+  // Experience level
+  if (answers.experience === "beginner" && loa != null && loa <= 11) {
+    score += 10;
+    reasons.push("Beginner-friendly");
+  } else if (answers.experience === "advanced" && loa != null && loa >= 12) {
+    score += 8;
+    reasons.push("Advanced handling");
+  }
+
+  // Keel preference
+  if (answers.keelPreference === "fin" && keelType && keelType.toLowerCase().includes("fin")) {
+    score += 12;
+    reasons.push("Fin keel");
+  } else if (answers.keelPreference === "wing" && keelType && keelType.toLowerCase().includes("wing")) {
+    score += 12;
+    reasons.push("Wing keel");
+  } else if (answers.keelPreference === "full" && keelType && keelType.toLowerCase().includes("full")) {
+    score += 12;
+    reasons.push("Full keel");
+  }
+
+  // Priority boost
+  if (answers.priority === "performance" && rigType === "Sloop") {
+    score += 5;
+    reasons.push("Performance-focused");
+  } else if (answers.priority === "comfort" && cabins != null && cabins >= 2) {
+    score += 5;
+    reasons.push("Comfort-focused");
+  } else if (answers.priority === "safety" && displacement != null && displacement >= 4000) {
+    score += 5;
+    reasons.push("Safety-focused build");
+  }
+
+  // Cap at 100
+  return { score: Math.min(100, score), reasons: reasons.slice(0, 5) };
+}
+
+/** POST /api/quiz — submit quiz answers, get matched yachts */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+
+    const answers: QuizAnswers = {
+      experience: body.experience || "",
+      sailingType: body.sailingType || "",
+      crewSize: body.crewSize || "",
+      budget: body.budget || "",
+      preferredLength: body.preferredLength || "",
+      keelPreference: body.keelPreference || "",
+      priority: body.priority || "",
+    };
+
+    const { conditions } = buildQuizFilters(answers);
+
+    // Build WHERE clause
+    const whereClause =
+      conditions.length > 0
+        ? "WHERE " + conditions.join(" AND ")
+        : "";
+
+    // Fetch candidate yachts
+    const query = `
+      SELECT y.id, y.model_name, y.slug, y.year, y.length_overall,
+             y.cabins, y.keel_type, y.hull_material, y.displacement,
+             y.rig_type, y.berths,
+             m.name as manufacturer_name,
+             (SELECT url FROM images WHERE yacht_model_id = y.id AND is_primary = true LIMIT 1) as primary_image_url
+      FROM yacht_models y
+      LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+      ${whereClause}
+      ORDER BY y.length_overall ASC
+      LIMIT 50
+    `;
+
+    const result = await pool.query(query);
+
+    // Score each yacht
+    const scored: MatchedYacht[] = result.rows
+      .map((row) => {
+        const { score, reasons } = scoreYacht(row, [], answers);
+        return {
+          id: Number(row.id),
+          slug: row.slug || "",
+          modelName: row.model_name || "",
+          manufacturerName: row.manufacturer_name || "",
+          year: row.year ? Number(row.year) : null,
+          lengthOverall: row.length_overall ? Number(row.length_overall) : null,
+          cabins: row.cabins ? Number(row.cabins) : null,
+          keelType: row.keel_type || null,
+          hullMaterial: row.hull_material || null,
+          matchScore: score,
+          matchReasons: reasons,
+          primaryImageUrl: row.primary_image_url || null,
+        };
+      })
+      .sort((a, b) => b.matchScore - a.matchScore)
+      .slice(0, 5);
+
+    return NextResponse.json({ yachts: scored, total: scored.length });
+  } catch (error) {
+    console.error("Quiz API error:", error);
+    return NextResponse.json(
+      { error: "Failed to process quiz" },
+      { status: 500 }
+    );
+  }
+}
+
+/** GET /api/quiz — load results from shareable URL parameter */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const encoded = searchParams.get("r");
+    if (!encoded) {
+      return NextResponse.json(
+        { error: "Missing result parameter 'r'" },
+        { status: 400 }
+      );
+    }
+
+    const answers: QuizAnswers = JSON.parse(atob(encoded));
+    // Re-run the same logic as POST
+    const { conditions } = buildQuizFilters(answers);
+
+    const whereClause =
+      conditions.length > 0
+        ? "WHERE " + conditions.join(" AND ")
+        : "";
+
+    const query = `
+      SELECT y.id, y.model_name, y.slug, y.year, y.length_overall,
+             y.cabins, y.keel_type, y.hull_material, y.displacement,
+             y.rig_type, y.berths,
+             m.name as manufacturer_name,
+             (SELECT url FROM images WHERE yacht_model_id = y.id AND is_primary = true LIMIT 1) as primary_image_url
+      FROM yacht_models y
+      LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+      ${whereClause}
+      ORDER BY y.length_overall ASC
+      LIMIT 50
+    `;
+
+    const result = await pool.query(query);
+
+    const scored: MatchedYacht[] = result.rows
+      .map((row) => {
+        const { score, reasons } = scoreYacht(row, [], answers);
+        return {
+          id: Number(row.id),
+          slug: row.slug || "",
+          modelName: row.model_name || "",
+          manufacturerName: row.manufacturer_name || "",
+          year: row.year ? Number(row.year) : null,
+          lengthOverall: row.length_overall ? Number(row.length_overall) : null,
+          cabins: row.cabins ? Number(row.cabins) : null,
+          keelType: row.keel_type || null,
+          hullMaterial: row.hull_material || null,
+          matchScore: score,
+          matchReasons: reasons,
+          primaryImageUrl: row.primary_image_url || null,
+        };
+      })
+      .sort((a, b) => b.matchScore - a.matchScore)
+      .slice(0, 5);
+
+    return NextResponse.json({ yachts: scored, total: scored.length, answers });
+  } catch (error) {
+    console.error("Quiz GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to load quiz results" },
+      { status: 500 }
+    );
+  }
+}

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,40 +1,40 @@
 # Sailing Yachts — Session Log
 
-## Session: 2026-06-06 20:20 UTC
+## Session: 2026-06-09 00:20 UTC
 
-### Issue: #390 — P24.2: A/B Testing Admin Dashboard
+### Issue: #401 — P25.1: Sailing Guides CMS Enhancements
 
 ### What Was Implemented
-- **DB migration**: `ab_events` table (experiment_id, variant_id, user_id, event_type, metadata, created_at) with 5 indexes
-- **Service**: `lib/ab-testing-service.ts` — event logging, aggregation, two-proportion Z-test for statistical significance, confidence intervals, significance detection with winner recommendation
-- **API**: POST `/api/ab/event` — logs A/B test events (impression, conversion, click) with validation
-- **API**: GET `/api/admin/ab-testing` — full dashboard data with period filtering (7d/30d/90d/all)
-- **Admin UI**: `/admin/ab-testing` — expandable experiment cards, variant breakdown table, traffic distribution bar charts, conversion rate comparison, confidence interval visualization, significance badges, standalone significance calculator, "How It Works" section
-- **Admin home**: Added A/B Testing card linking to new dashboard
-- **Schema**: Added `abEvents` table definition to drizzle schema
-- **Tests**: 17 tests covering variant assignment, event logging, aggregation, dashboard assembly, significance detection, API validation
+- **article_yachts join table**: DB migration creating join table with article_id, yacht_model_id, sort_order, cascading deletes, unique constraint
+- **SEO fields on articles**: Added meta_title, meta_description, og_image, canonical_url, noindex columns to articles table
+- **Yacht search API**: GET /api/admin/guides/yacht-search — search yachts by name/manufacturer for autocomplete
+- **Image upload API**: POST /api/admin/guides/upload-image — file upload with type/size validation, saves to /public/uploads/guides/
+- **Enhanced guide form**: Added related yacht selector with autocomplete, image upload widget (file + URL), SEO settings section with character count guidance, Google preview
+- **Public guide page**: Shows related yachts section with yacht cards, uses SEO fields in generateMetadata
+- **Updated admin APIs**: POST/PUT /api/admin/guides now handle SEO fields and relatedYachtIds
+- **Updated articles service**: Added RelatedYacht interface, getArticleRelatedYachts function, SEO fields in all queries
+- **Schema**: Added articleYachts drizzle table, SEO columns on articles
 
 ### Build/Test Results
 - TypeScript: ✅ Pass
-- Build: ✅ Pass
-- Tests: ✅ 17/17 pass
+- Build: ✅ Pass (1521 static pages)
+- Tests: ✅ 15/15 pass
 - CI (Lint + TypeScript + Build + Perf Budgets): ✅ All pass
 
 ### Deploy
-- PR #391 (feature/issue-390-ab-testing-dashboard) → merged (squash)
-- Manual `vercel --prod` deploy (auto-deploy was slow)
+- PR #402 (feature/issue-401-guides-cms-enhancements) → merged (squash)
+- Vercel auto-deploy from main
 
 ### Live Verification (all PASS)
 - `/` ✅ | `/yachts` ✅ | `/search` ✅ | `/compare` ✅
+- `/guides` ✅ | `/en/guides/how-to-choose-your-first-sailboat` ✅
 - API: `/api/yachts` ✅ — 243 yachts
-- POST `/api/ab/event` ✅ — events logged successfully (verified with test event)
-- GET `/api/admin/ab-testing` ✅ — returns experiment data with 2 experiments, significance analysis
-- `/admin/ab-testing` ✅ — renders dashboard page
 
 ### Next Recommended Task
-- **P24.3** — Conversion funnel tracking (landing → search → detail → compare → lead)
-- Or **P24.4** — Search intent analysis dashboard
+- **P25.2** — Yacht review aggregation (aggregate reviews from external sources)
+- Or **P25.3** — Interactive sailing quiz ("Which yacht is right for you?")
 
 ### Lessons
-- Vercel auto-deploy from GitHub can be slow — manual deploy may be needed
-- `Math.max(localSum, dbCount)` for totalEvents: test expectations need to match the higher value
+- The guides CMS already existed with basic functionality — P25.1 was about enhancing it with missing features
+- Neon DB `channel_binding=require` causes issues with pg client — use `sslmode=require` without channel_binding for migrations
+- Build "errors" for static pages (Neon connectivity during prerender) are pre-existing and not blocking

--- a/messages/en.json
+++ b/messages/en.json
@@ -107,6 +107,11 @@
       "title": "Ready to find your next yacht?",
       "subtitle": "Search the database or compare boats side by side.",
       "browseAll": "Browse All Yachts"
+    },
+    "quizCta": {
+      "title": "Not Sure Which Yacht is Right for You?",
+      "subtitle": "Take our 2-minute quiz and get personalized yacht recommendations based on your experience, budget, and sailing style.",
+      "button": "Take the Quiz"
     }
   },
   "LanguageSwitcher": {
@@ -1375,5 +1380,109 @@
     "successMessage": "Thanks for subscribing! We'll notify you when new yachts are added.",
     "errorMessage": "Something went wrong. Please try again.",
     "networkError": "Network error. Please try again."
+  },
+  "Quiz": {
+    "title": "Which Sailing Yacht is Right for You?",
+    "subtitle": "Answer 7 quick questions and discover your perfect match",
+    "step": "Step",
+    "back": "Back",
+    "next": "Next",
+    "getResults": "Find My Yacht",
+    "analyzing": "Analyzing...",
+    "shareTitle": "My Sailing Yacht Quiz Results",
+    "shareText": "I just found my ideal sailing yacht! Take the quiz to find yours.",
+    "steps": {
+      "experience": {
+        "question": "What's your sailing experience level?",
+        "beginner": "Beginner",
+        "beginnerDesc": "New to sailing or less than 2 years",
+        "intermediate": "Intermediate",
+        "intermediateDesc": "A few years of regular sailing",
+        "advanced": "Advanced",
+        "advancedDesc": "Experienced sailor, many miles logged"
+      },
+      "sailingType": {
+        "question": "What type of sailing do you enjoy most?",
+        "coastal": "Coastal / Day Sailing",
+        "coastalDesc": "Short trips along the coast",
+        "offshore": "Offshore / Blue Water",
+        "offshoreDesc": "Long passages across open water",
+        "racing": "Racing",
+        "racingDesc": "Competitive sailing and regattas",
+        "cruising": "Liveaboard Cruising",
+        "cruisingDesc": "Extended cruising and living aboard"
+      },
+      "crewSize": {
+        "question": "How many people will typically be on board?",
+        "solo": "Solo",
+        "soloDesc": "Just me — single-handed sailing",
+        "couple": "Couple",
+        "coupleDesc": "Me and my partner",
+        "family": "Family",
+        "familyDesc": "Family with children (3-5 people)",
+        "group": "Group",
+        "groupDesc": "Friends or charter group (5+ people)"
+      },
+      "budget": {
+        "question": "What's your budget range?",
+        "budget": "Budget-Friendly",
+        "budgetDesc": "Looking for great value under €50k",
+        "midrange": "Mid-Range",
+        "midrangeDesc": "€50k–€200k for a solid cruiser",
+        "premium": "Premium",
+        "premiumDesc": "€200k+ for a top-quality yacht",
+        "any": "Not Sure Yet",
+        "anyDesc": "I'm exploring all options"
+      },
+      "preferredLength": {
+        "question": "What length of yacht appeals to you?",
+        "small": "Small (under 30ft / 9m)",
+        "smallDesc": "Easy to handle, lower costs",
+        "medium": "Medium (30–45ft / 9–14m)",
+        "mediumDesc": "The sweet spot for most sailors",
+        "large": "Large (45ft+ / 14m+)",
+        "largeDesc": "Maximum space and comfort",
+        "any": "No Preference",
+        "anyDesc": "Show me everything"
+      },
+      "keelPreference": {
+        "question": "What keel type do you prefer?",
+        "fin": "Fin Keel",
+        "finDesc": "Performance and agility",
+        "wing": "Wing Keel",
+        "wingDesc": "Shallow draft, great stability",
+        "full": "Full Keel",
+        "fullDesc": "Traditional, seaworthy, tracks well",
+        "any": "No Preference",
+        "anyDesc": "Any keel type works for me"
+      },
+      "priority": {
+        "question": "What matters most to you?",
+        "performance": "Sailing Performance",
+        "performanceDesc": "Speed, responsiveness, and handling",
+        "comfort": "Comfort & Space",
+        "comfortDesc": "Living space, amenities, and layout",
+        "value": "Best Value",
+        "valueDesc": "Maximum features for the budget",
+        "safety": "Safety & Reliability",
+        "safetyDesc": "Seaworthiness and build quality"
+      }
+    },
+    "results": {
+      "title": "Your Perfect Yacht Matches",
+      "subtitle": "Based on your preferences, here are your top matches",
+      "match": "match",
+      "viewYacht": "View Details",
+      "noResults": "No matching yachts found. Try adjusting your preferences.",
+      "retry": "Retake Quiz",
+      "share": "Share Your Results",
+      "shareDesc": "Share your quiz results with friends or save for later.",
+      "shareButton": "Copy Link",
+      "saveResults": "Save Your Results",
+      "emailDesc": "Get your results delivered to your inbox.",
+      "emailSuccess": "Results sent! Check your inbox.",
+      "send": "Send",
+      "retake": "Take the quiz again"
+    }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -107,6 +107,11 @@
       "title": "Prêt à trouver votre prochain yacht ?",
       "subtitle": "Recherchez dans la base de données ou comparez les bateaux côte à côte.",
       "browseAll": "Parcourir tous les yachts"
+    },
+    "quizCta": {
+      "title": "Pas sûr de savoir quel voilier est fait pour vous ?",
+      "subtitle": "Faites notre quiz en 2 minutes et obtenez des recommandations personnalisées basées sur votre expérience, votre budget et votre style de navigation.",
+      "button": "Faire le quiz"
     }
   },
   "LanguageSwitcher": {
@@ -1375,5 +1380,109 @@
     "successMessage": "Merci pour votre inscription ! Nous vous notifierons lorsque de nouveaux yachts seront ajoutés.",
     "errorMessage": "Une erreur est survenue. Veuillez réessayer.",
     "networkError": "Erreur réseau. Veuillez réessayer."
+  },
+  "Quiz": {
+    "title": "Quel voilier est fait pour vous ?",
+    "subtitle": "Répondez à 7 questions rapides et découvrez votre voilier idéal",
+    "step": "Étape",
+    "back": "Précédent",
+    "next": "Suivant",
+    "getResults": "Trouver mon voilier",
+    "analyzing": "Analyse en cours...",
+    "shareTitle": "Mes résultats du quiz voilier",
+    "shareText": "Je viens de trouver mon voilier idéal ! Faites le quiz pour trouver le vôtre.",
+    "steps": {
+      "experience": {
+        "question": "Quel est votre niveau d'expérience en voile ?",
+        "beginner": "Débutant",
+        "beginnerDesc": "Nouveau en voile ou moins de 2 ans",
+        "intermediate": "Intermédiaire",
+        "intermediateDesc": "Quelques années de navigation régulière",
+        "advanced": "Avancé",
+        "advancedDesc": "Marin expérimenté, nombreuses milles au compteur"
+      },
+      "sailingType": {
+        "question": "Quel type de voile préférez-vous ?",
+        "coastal": "Côtier / Sorties à la journée",
+        "coastalDesc": "Courtes excursions le long de la côte",
+        "offshore": "Hauturier / Eaux bleues",
+        "offshoreDesc": "Longues traversées en pleine mer",
+        "racing": "Course au large",
+        "racingDesc": "Voile de compétition et régates",
+        "cruising": "Croisière habitable",
+        "cruisingDesc": "Croisière prolongée et vie à bord"
+      },
+      "crewSize": {
+        "question": "Combien de personnes seront généralement à bord ?",
+        "solo": "En solitaire",
+        "soloDesc": "Juste moi — navigation en solitaire",
+        "couple": "En couple",
+        "coupleDesc": "Moi et mon/ma partenaire",
+        "family": "En famille",
+        "familyDesc": "Famille avec enfants (3-5 personnes)",
+        "group": "En groupe",
+        "groupDesc": "Amis ou équipage (5+ personnes)"
+      },
+      "budget": {
+        "question": "Quel est votre budget ?",
+        "budget": "Économique",
+        "budgetDesc": "Excellente valeur moins de 50k€",
+        "midrange": "Milieu de gamme",
+        "midrangeDesc": "50k€–200k€ pour un bon croiseur",
+        "premium": "Premium",
+        "premiumDesc": "200k€+ pour un voilier haut de gamme",
+        "any": "Pas encore sûr",
+        "anyDesc": "J'explore toutes les options"
+      },
+      "preferredLength": {
+        "question": "Quelle taille de voilier vous attire ?",
+        "small": "Petit (moins de 9m)",
+        "smallDesc": "Facile à manœuvrer, coûts réduits",
+        "medium": "Moyen (9–14m)",
+        "mediumDesc": "Le format idéal pour la plupart des navigateurs",
+        "large": "Grand (14m+)",
+        "largeDesc": "Espace et confort maximum",
+        "any": "Sans préférence",
+        "anyDesc": "Montrez-moi tout"
+      },
+      "keelPreference": {
+        "question": "Quel type de quille préférez-vous ?",
+        "fin": "Quille en aileron",
+        "finDesc": "Performance et agilité",
+        "wing": "Quille ailée",
+        "wingDesc": "Tirant d'eau réduit, excellente stabilité",
+        "full": "Quille longue",
+        "fullDesc": "Traditionnelle, marquée, bon cap",
+        "any": "Sans préférence",
+        "anyDesc": "Tout type de quille me convient"
+      },
+      "priority": {
+        "question": "Qu'est-ce qui compte le plus pour vous ?",
+        "performance": "Performances sous voile",
+        "performanceDesc": "Vitesse, réactivité et comportement",
+        "comfort": "Confort et espace",
+        "comfortDesc": "Espace de vie, aménagements et disposition",
+        "value": "Meilleur rapport qualité-prix",
+        "valueDesc": "Maximum de caractéristiques pour le budget",
+        "safety": "Sécurité et fiabilité",
+        "safetyDesc": "Tenue en mer et qualité de construction"
+      }
+    },
+    "results": {
+      "title": "Vos voiliers idéaux",
+      "subtitle": "Basé sur vos préférences, voici vos meilleures correspondances",
+      "match": "correspondance",
+      "viewYacht": "Voir les détails",
+      "noResults": "Aucun voilier correspondant trouvé. Essayez d'ajuster vos critères.",
+      "retry": "Recommencer le quiz",
+      "share": "Partager vos résultats",
+      "shareDesc": "Partagez vos résultats avec vos amis ou sauvegardez-les.",
+      "shareButton": "Copier le lien",
+      "saveResults": "Sauvegarder vos résultats",
+      "emailDesc": "Recevez vos résultats par email.",
+      "emailSuccess": "Résultats envoyés ! Vérifiez votre boîte mail.",
+      "send": "Envoyer",
+      "retake": "Refaire le quiz"
+    }
   }
 }

--- a/tests/quiz.spec.ts
+++ b/tests/quiz.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+
+test.describe("Sailing Quiz (P25.3)", () => {
+  test("quiz page loads and shows first question", async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/quiz`);
+    await page.waitForLoadState("networkidle");
+
+    // Should show the quiz title
+    await expect(
+      page.locator("h1", { hasText: /sailing yacht/i })
+    ).toBeVisible();
+
+    // Should show progress (Step 1 / 7)
+    await expect(page.locator("text=1 / 7")).toBeVisible();
+
+    // Should show first question about experience
+    await expect(
+      page.locator("text=/experience level/i")
+    ).toBeVisible();
+
+    // Should show options (Beginner, Intermediate, Advanced)
+    await expect(page.locator("text=Beginner")).toBeVisible();
+    await expect(page.locator("text=Intermediate")).toBeVisible();
+    await expect(page.locator("text=Advanced")).toBeVisible();
+
+    // Next button should be disabled until an option is selected
+    const nextButton = page.locator('button:has-text("Next")');
+    await expect(nextButton).toBeDisabled();
+  });
+
+  test("can navigate through all quiz steps", async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/quiz`);
+    await page.waitForLoadState("networkidle");
+
+    const steps = [
+      { option: "Beginner" },
+      { option: "Coastal" },
+      { option: "Solo" },
+      { option: "Budget" },
+      { option: "Small" },
+      { option: "Fin Keel" },
+      { option: "Performance" },
+    ];
+
+    for (let i = 0; i < steps.length; i++) {
+      // Click option
+      await page.locator(`text=${steps[i].option}`).first().click();
+
+      // Verify selection is highlighted (border changes)
+      const selectedOption = page.locator(
+        'button.border-blue-500, button[class*="border-blue-500"]'
+      );
+      await expect(selectedOption.first()).toBeVisible();
+
+      // Click Next (or "Find My Yacht" on last step)
+      if (i < steps.length - 1) {
+        await page.locator('button:has-text("Next")').click();
+        // Verify progress updated
+        await expect(
+          page.locator(`text=${i + 2} / 7`)
+        ).toBeVisible();
+      } else {
+        await page.locator('button:has-text("Find My Yacht")').click();
+      }
+    }
+
+    // Should show loading state
+    await expect(
+      page.locator('text=/analyzing/i')
+    ).toBeVisible({ timeout: 5000 }).catch(() => {
+      // May have already completed
+    });
+
+    // Should show results (or error if DB unavailable)
+    await page.waitForLoadState("networkidle");
+    const hasResults =
+      (await page.locator("text=/Your Perfect Yacht/i").count()) > 0;
+    const hasRetry =
+      (await page.locator("text=/No matching/i").count()) > 0;
+    expect(hasResults || hasRetry).toBeTruthy();
+  });
+
+  test("back button navigates to previous step", async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/quiz`);
+    await page.waitForLoadState("networkidle");
+
+    // Select first option and go to step 2
+    await page.locator("text=Intermediate").first().click();
+    await page.locator('button:has-text("Next")').click();
+    await expect(page.locator("text=2 / 7")).toBeVisible();
+
+    // Go back
+    await page.locator('button:has-text("Back")').click();
+    await expect(page.locator("text=1 / 7")).toBeVisible();
+
+    // Previous answer should still be selected
+    await expect(
+      page.locator("button.border-blue-500").first()
+    ).toBeVisible();
+  });
+
+  test("quiz API POST returns scored yachts", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/quiz`, {
+      data: {
+        experience: "intermediate",
+        sailingType: "coastal",
+        crewSize: "couple",
+        budget: "midrange",
+        preferredLength: "medium",
+        keelPreference: "any",
+        priority: "comfort",
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("yachts");
+    expect(Array.isArray(data.yachts)).toBeTruthy();
+
+    if (data.yachts.length > 0) {
+      const yacht = data.yachts[0];
+      expect(yacht).toHaveProperty("id");
+      expect(yacht).toHaveProperty("slug");
+      expect(yacht).toHaveProperty("modelName");
+      expect(yacht).toHaveProperty("manufacturerName");
+      expect(yacht).toHaveProperty("matchScore");
+      expect(yacht).toHaveProperty("matchReasons");
+      expect(yacht.matchScore).toBeGreaterThanOrEqual(0);
+      expect(yacht.matchScore).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test("quiz API POST handles empty answers", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/quiz`, {
+      data: {
+        experience: "",
+        sailingType: "",
+        crewSize: "",
+        budget: "",
+        preferredLength: "",
+        keelPreference: "",
+        priority: "",
+      },
+    });
+    // Should still return results (no filtering applied)
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("yachts");
+  });
+
+  test("quiz API GET requires 'r' parameter", async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/quiz`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("quiz API GET can load shared results", async ({ request }) => {
+    const answers = {
+      experience: "advanced",
+      sailingType: "offshore",
+      crewSize: "couple",
+      budget: "premium",
+      preferredLength: "large",
+      keelPreference: "fin",
+      priority: "performance",
+    };
+    const encoded = Buffer.from(JSON.stringify(answers)).toString("base64");
+
+    const res = await request.get(`${BASE_URL}/api/quiz?r=${encoded}`);
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("yachts");
+    expect(data).toHaveProperty("answers");
+    expect(data.answers.experience).toBe("advanced");
+  });
+
+  test("French quiz page loads with French content", async ({ page }) => {
+    await page.goto(`${BASE_URL}/fr/quiz`);
+    await page.waitForLoadState("networkidle");
+
+    // Should show French title
+    await expect(
+      page.locator("h1", { hasText: /voilier/i })
+    ).toBeVisible();
+
+    // Should show "Étape" instead of "Step"
+    await expect(page.locator("text=/Étape/i")).toBeVisible();
+  });
+
+  test("quiz page is responsive (mobile viewport)", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`${BASE_URL}/en/quiz`);
+    await page.waitForLoadState("networkidle");
+
+    // Page should still render properly
+    await expect(
+      page.locator("h1", { hasText: /sailing yacht/i })
+    ).toBeVisible();
+
+    // Options should be visible and clickable
+    await page.locator("text=Beginner").first().click();
+    await expect(page.locator('button:has-text("Next")')).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## P25.3: Interactive Sailing Quiz

### What's New
- **7-step personality quiz**: Experience, sailing type, crew size, budget, length, keel, and priority preferences
- **Smart matching algorithm**: Scores yachts 0-100% based on weighted criteria (LOA, cabins, keel type, rig type, displacement)
- **Results page**: Top 5 matches with score, match reasons, and direct links to yacht detail pages
- **Shareable results**: Base64-encoded URL for sharing quiz results
- **Email capture**: Optional newsletter signup on results page
- **Homepage CTA**: New quiz promotion section on homepage
- **Full i18n**: English and French translations
- **Responsive**: Mobile-first design with gradient backgrounds

### Files Changed
- `app/[locale]/quiz/page.tsx` — Server component with SEO metadata
- `app/[locale]/quiz/QuizClient.tsx` — Multi-step quiz client component
- `app/api/quiz/route.ts` — Quiz API (POST for scoring, GET for shared results)
- `app/[locale]/page.tsx` — Added quiz CTA section
- `messages/en.json`, `messages/fr.json` — Quiz translations
- `tests/quiz.spec.ts` — 8 Playwright tests

### Test Plan
- [x] TypeScript clean (`npm run typecheck`)
- [x] Build passes (1527 static pages)
- [x] Quiz page loads at /en/quiz and /fr/quiz
- [x] API returns scored yachts with match percentages
- [x] Shareable URL works via GET parameter
- [ ] Live verification post-deploy

Closes #405