### PR TITLE
feat: P25.4 — Multilingual content pipeline (EN→FR)

### DIFF
--- a/FUTURE_ROADMAP.md
+++ b/FUTURE_ROADMAP.md
@@ -94,11 +94,11 @@
 - **P24.4 — Search intent analysis dashboard** *(completed 2026-06-08)* — Analyze search queries, zero-result searches, popular filters. Surface content gaps. Admin dashboard with search analytics.
 - **P24.5 — Competitive positioning matrix** *(completed 2026-06-08)* — Auto-generate competitive positioning analysis for each manufacturer. Market segment coverage visualization. Price positioning charts.
 
-### Phase 25 — Content Expansion (Priority: Medium) — 🔲 PLANNED
+### Phase 25 — Content Expansion (Priority: Medium) — 🔧 IN PROGRESS
 
 - **P25.1 — Sailing guides CMS** *(completed 2026-06-09 — Issue #401, PR #402, 15 tests)* — Full CMS for creating/editing sailing guides. Rich text editor (Markdown with preview), image upload with validation, SEO fields (meta_title, meta_description, og_image, canonical_url, noindex). Category tagging, related yacht linking with autocomplete search. Author attribution.
 - **P25.2 — Yacht review aggregation** *(completed 2026-06-09 — Issue #403, PR #404)* — Aggregate reviews from external sources. Schema for review source, rating, URL. Display aggregated scores on yacht detail. Admin review management.
-- **P25.3 — Interactive sailing quiz** — "Which yacht is right for you?" personality-style quiz. Result leads to yacht finder recommendations. Shareable results. Lead capture integration.
+- **P25.3 — Interactive sailing quiz** *(completed 2026-06-10 — pre-existing implementation)* — 7-step personality quiz with yacht recommendation API, shareable results (GET/POST /api/quiz), email capture, i18n (EN + FR), Playwright tests.
 - **P25.4 — Multilingual content pipeline** — Auto-translate guides and descriptions to French. Translation queue with human review. Translation memory for consistency.
 - **P25.5 — Dynamic FAQ generation** — Auto-generate FAQs from yacht data patterns. Schema markup for FAQ rich results. Crawlable FAQ pages per manufacturer/size category.
 

--- a/app/admin/translations/TranslationsClient.tsx
+++ b/app/admin/translations/TranslationsClient.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Languages,
+  Check,
+  X,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  Eye,
+  Edit3,
+  Zap,
+  Database,
+  FileText,
+  Factory,
+  BarChart3,
+  Loader2,
+  AlertCircle,
+  ArrowRight,
+} from "lucide-react";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+interface TranslationStats {
+  total: number;
+  byStatus: Record<string, number>;
+  byContentType: Record<string, number>;
+  byMethod: Record<string, number>;
+  coverageByType: Record<string, { total: number; translated: number; pct: number }>;
+}
+
+interface MemoryStats {
+  total: number;
+  byCategory: Record<string, number>;
+  totalMatchCount: number;
+}
+
+interface QueueItem {
+  id: number;
+  contentType: string;
+  contentId: number;
+  fieldName: string;
+  sourceText: string | null;
+  translatedText: string;
+  translationMethod: string;
+  status: string;
+  qualityScore: number | null;
+  createdAt: string;
+}
+
+// ─── Component ──────────────────────────────────────────────────────
+
+export default function TranslationsClient() {
+  const [stats, setStats] = useState<TranslationStats | null>(null);
+  const [memoryStats, setMemoryStats] = useState<MemoryStats | null>(null);
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [filterStatus, setFilterStatus] = useState<string>("pending");
+  const [filterType, setFilterType] = useState<string>("");
+  const [page, setPage] = useState(0);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editText, setEditText] = useState("");
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const PAGE_SIZE = 20;
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/translations?action=stats");
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data.stats);
+        setMemoryStats(data.memoryStats);
+      }
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const fetchQueue = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (filterStatus) params.set("status", filterStatus);
+      if (filterType) params.set("contentType", filterType);
+      params.set("limit", String(PAGE_SIZE));
+      params.set("offset", String(page * PAGE_SIZE));
+
+      const res = await fetch(`/api/admin/translations?${params}`);
+      if (!res.ok) throw new Error("Failed to fetch queue");
+      const data = await res.json();
+      setQueue(data.items ?? []);
+      setTotalItems(data.total ?? 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [filterStatus, filterType, page]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  useEffect(() => {
+    fetchQueue();
+  }, [fetchQueue]);
+
+  const handleAction = async (action: string, body: Record<string, unknown> = {}) => {
+    setActionLoading(action);
+    try {
+      const res = await fetch("/api/admin/translations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, ...body }),
+      });
+      if (!res.ok) throw new Error("Action failed");
+      const data = await res.json();
+      await fetchStats();
+      await fetchQueue();
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+      return null;
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleStatusUpdate = async (id: number, status: string) => {
+    setActionLoading(`status-${id}`);
+    try {
+      const res = await fetch("/api/admin/translations", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, status }),
+      });
+      if (!res.ok) throw new Error("Update failed");
+      await fetchQueue();
+      await fetchStats();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleEditTextSave = async (id: number) => {
+    setActionLoading(`edit-${id}`);
+    try {
+      const res = await fetch("/api/admin/translations", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, translatedText: editText }),
+      });
+      if (!res.ok) throw new Error("Update failed");
+      setEditingId(null);
+      await fetchQueue();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const totalPages = Math.ceil(totalItems / PAGE_SIZE);
+  const statusColors: Record<string, string> = {
+    pending: "bg-yellow-100 text-yellow-800",
+    auto_translated: "bg-blue-100 text-blue-800",
+    in_review: "bg-purple-100 text-purple-800",
+    approved: "bg-green-100 text-green-800",
+    rejected: "bg-red-100 text-red-800",
+  };
+
+  const typeIcons: Record<string, React.ReactNode> = {
+    yacht_description: <Database className="w-4 h-4" />,
+    manufacturer_description: <Factory className="w-4 h-4" />,
+    article: <FileText className="w-4 h-4" />,
+    guide: <FileText className="w-4 h-4" />,
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
+              <Languages className="w-7 h-7 text-blue-600" />
+              Translation Management
+            </h1>
+            <p className="text-gray-500 mt-1">Multilingual content pipeline — EN → FR</p>
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm flex items-center gap-2">
+            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            {error}
+            <button onClick={() => setError(null)} className="ml-auto text-red-500 hover:text-red-700">×</button>
+          </div>
+        )}
+
+        {/* Stats Cards */}
+        {stats && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <div className="bg-white rounded-lg border p-4">
+              <div className="text-sm text-gray-500">Total Translations</div>
+              <div className="text-2xl font-bold text-gray-900">{stats.total}</div>
+            </div>
+            <div className="bg-white rounded-lg border p-4">
+              <div className="text-sm text-gray-500">Pending Review</div>
+              <div className="text-2xl font-bold text-yellow-600">
+                {(stats.byStatus as Record<string, number>)?.pending ?? 0}
+              </div>
+            </div>
+            <div className="bg-white rounded-lg border p-4">
+              <div className="text-sm text-gray-500">Approved</div>
+              <div className="text-2xl font-bold text-green-600">
+                {(stats.byStatus as Record<string, number>)?.approved ?? 0}
+              </div>
+            </div>
+            <div className="bg-white rounded-lg border p-4">
+              <div className="text-sm text-gray-500">Memory Entries</div>
+              <div className="text-2xl font-bold text-blue-600">{memoryStats?.total ?? 0}</div>
+            </div>
+          </div>
+        )}
+
+        {/* Coverage */}
+        {stats?.coverageByType && (
+          <div className="bg-white rounded-lg border p-5 mb-6">
+            <h2 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+              <BarChart3 className="w-5 h-5" />
+              Translation Coverage
+            </h2>
+            <div className="grid md:grid-cols-3 gap-4">
+              {Object.entries(stats.coverageByType).map(([type, cov]) => (
+                <div key={type} className="flex items-center gap-3">
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between text-sm mb-1">
+                      <span className="text-gray-600 capitalize">{type.replace(/_/g, " ")}</span>
+                      <span className="text-gray-900 font-medium">{cov.pct}%</span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2">
+                      <div
+                        className={`h-2 rounded-full transition-all ${cov.pct >= 80 ? "bg-green-500" : cov.pct >= 40 ? "bg-yellow-500" : "bg-red-500"}`}
+                        style={{ width: `${cov.pct}%` }}
+                      />
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      {cov.translated} / {cov.total} items
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="bg-white rounded-lg border p-5 mb-6">
+          <h2 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+            <Zap className="w-5 h-5" />
+            Auto-Generate Translations
+          </h2>
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={() => handleAction("auto-generate-yachts")}
+              disabled={actionLoading !== null}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+            >
+              {actionLoading === "auto-generate-yachts" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Database className="w-4 h-4" />}
+              Generate Yacht Descriptions
+            </button>
+            <button
+              onClick={() => handleAction("auto-generate-manufacturers")}
+              disabled={actionLoading !== null}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+            >
+              {actionLoading === "auto-generate-manufacturers" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Factory className="w-4 h-4" />}
+              Generate Manufacturer Descs
+            </button>
+            <button
+              onClick={() => handleAction("auto-generate-articles")}
+              disabled={actionLoading !== null}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+            >
+              {actionLoading === "auto-generate-articles" ? <Loader2 className="w-4 h-4 animate-spin" /> : <FileText className="w-4 h-4" />}
+              Generate Article Translations
+            </button>
+            <button
+              onClick={() => handleAction("bulk-approve")}
+              disabled={actionLoading !== null}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+            >
+              {actionLoading === "bulk-approve" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+              Bulk Approve Auto-Translated
+            </button>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          <select
+            value={filterStatus}
+            onChange={(e) => { setFilterStatus(e.target.value); setPage(0); }}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+          >
+            <option value="">All Statuses</option>
+            <option value="pending">Pending</option>
+            <option value="auto_translated">Auto-Translated</option>
+            <option value="in_review">In Review</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </select>
+          <select
+            value={filterType}
+            onChange={(e) => { setFilterType(e.target.value); setPage(0); }}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+          >
+            <option value="">All Types</option>
+            <option value="yacht_description">Yacht Descriptions</option>
+            <option value="manufacturer_description">Manufacturer Descs</option>
+            <option value="article">Articles</option>
+            <option value="guide">Guides</option>
+          </select>
+          <button
+            onClick={() => fetchQueue()}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50 flex items-center gap-1"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Refresh
+          </button>
+          <span className="text-sm text-gray-500">{totalItems} items</span>
+        </div>
+
+        {/* Queue */}
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+          </div>
+        ) : queue.length === 0 ? (
+          <div className="bg-white rounded-lg border p-8 text-center text-gray-500">
+            No translations found for this filter.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {queue.map((item) => (
+              <div key={item.id} className="bg-white rounded-lg border p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      {typeIcons[item.contentType] ?? <FileText className="w-4 h-4" />}
+                      <span className="text-sm font-medium text-gray-900 capitalize">
+                        {item.contentType.replace(/_/g, " ")}
+                      </span>
+                      <span className="text-xs text-gray-400">#{item.contentId}</span>
+                      <span className="text-xs text-gray-400">•</span>
+                      <span className="text-xs text-gray-400">{item.fieldName}</span>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusColors[item.status] ?? "bg-gray-100 text-gray-600"}`}>
+                        {item.status.replace(/_/g, " ")}
+                      </span>
+                      {item.translationMethod !== "manual" && (
+                        <span className="px-1.5 py-0.5 bg-gray-100 text-gray-500 rounded text-xs">
+                          {item.translationMethod}
+                        </span>
+                      )}
+                      {item.qualityScore != null && (
+                        <span className="text-xs text-gray-400">Score: {item.qualityScore}</span>
+                      )}
+                    </div>
+
+                    {/* Source text (collapsed) */}
+                    {item.sourceText && (
+                      <div className="text-sm text-gray-600 mb-1">
+                        <span className="text-xs text-gray-400 mr-1">EN:</span>
+                        {expandedId === item.id
+                          ? item.sourceText
+                          : item.sourceText.slice(0, 150) + (item.sourceText.length > 150 ? "…" : "")}
+                      </div>
+                    )}
+
+                    {/* Translated text */}
+                    {editingId === item.id ? (
+                      <div className="mt-2">
+                        <textarea
+                          value={editText}
+                          onChange={(e) => setEditText(e.target.value)}
+                          rows={4}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+                        />
+                        <div className="flex gap-2 mt-2">
+                          <button
+                            onClick={() => handleEditTextSave(item.id)}
+                            disabled={actionLoading !== null}
+                            className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="px-3 py-1.5 border border-gray-300 rounded text-sm hover:bg-gray-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="text-sm text-gray-800">
+                        <span className="text-xs text-blue-400 mr-1">FR:</span>
+                        {expandedId === item.id
+                          ? item.translatedText
+                          : item.translatedText.slice(0, 150) + (item.translatedText.length > 150 ? "…" : "")}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                    <button
+                      onClick={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                      className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded"
+                      title="Expand"
+                    >
+                      <Eye className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => { setEditingId(item.id); setEditText(item.translatedText); }}
+                      className="p-1.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded"
+                      title="Edit"
+                    >
+                      <Edit3 className="w-4 h-4" />
+                    </button>
+                    {(item.status === "pending" || item.status === "auto_translated" || item.status === "in_review") && (
+                      <>
+                        <button
+                          onClick={() => handleStatusUpdate(item.id, "approved")}
+                          disabled={actionLoading !== null}
+                          className="p-1.5 text-green-600 hover:bg-green-50 rounded"
+                          title="Approve"
+                        >
+                          <Check className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => handleStatusUpdate(item.id, "rejected")}
+                          disabled={actionLoading !== null}
+                          className="p-1.5 text-red-500 hover:bg-red-50 rounded"
+                          title="Reject"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 mt-6">
+            <button
+              onClick={() => setPage(Math.max(0, page - 1))}
+              disabled={page === 0}
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm disabled:opacity-50 hover:bg-gray-50"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-sm text-gray-600">
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm disabled:opacity-50 hover:bg-gray-50"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/translations/page.tsx
+++ b/app/admin/translations/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import TranslationsClient from "./TranslationsClient";
+
+export const metadata: Metadata = {
+  title: "Translation Management — Admin",
+  description: "Manage multilingual content translations",
+};
+
+export default function TranslationsAdminPage() {
+  return <TranslationsClient />;
+}

--- a/app/api/admin/translations/route.ts
+++ b/app/api/admin/translations/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getTranslationStats,
+  getTranslationQueue,
+  getTranslation,
+  updateTranslationStatus,
+  updateTranslationText,
+  upsertTranslation,
+  autoGenerateYachtTranslations,
+  autoGenerateManufacturerTranslations,
+  autoGenerateArticleTranslations,
+  bulkApproveAutoTranslations,
+  getTranslationMemoryStats,
+  type TranslationStatus,
+  type ContentType,
+} from "@/lib/translation-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/translations — stats + queue */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const action = searchParams.get("action");
+
+    // /api/admin/translations?action=stats
+    if (action === "stats") {
+      const [stats, memoryStats] = await Promise.all([
+        getTranslationStats(),
+        getTranslationMemoryStats(),
+      ]);
+      return NextResponse.json({ stats, memoryStats });
+    }
+
+    // /api/admin/translations?action=memory
+    if (action === "memory") {
+      const memoryStats = await getTranslationMemoryStats();
+      return NextResponse.json(memoryStats);
+    }
+
+    // /api/admin/translations?id=123
+    const id = searchParams.get("id");
+    if (id) {
+      const translation = await getTranslation(Number(id));
+      if (!translation) {
+        return NextResponse.json({ error: "Translation not found" }, { status: 404 });
+      }
+      return NextResponse.json(translation);
+    }
+
+    // Default: return queue
+    const status = searchParams.get("status") as TranslationStatus | null;
+    const contentType = searchParams.get("contentType") as ContentType | null;
+    const limit = Math.min(100, Math.max(1, Number(searchParams.get("limit") ?? 50)));
+    const offset = Math.max(0, Number(searchParams.get("offset") ?? 0));
+
+    const queue = await getTranslationQueue(
+      status ?? undefined,
+      contentType ?? undefined,
+      limit,
+      offset
+    );
+    return NextResponse.json(queue);
+  } catch (error) {
+    console.error("Translation API GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+/** POST /api/admin/translations — create/update, auto-generate, bulk approve */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const action = body.action;
+
+    // Auto-generate yacht translations
+    if (action === "auto-generate-yachts") {
+      const result = await autoGenerateYachtTranslations();
+      return NextResponse.json(result);
+    }
+
+    // Auto-generate manufacturer translations
+    if (action === "auto-generate-manufacturers") {
+      const result = await autoGenerateManufacturerTranslations();
+      return NextResponse.json(result);
+    }
+
+    // Auto-generate article translations
+    if (action === "auto-generate-articles") {
+      const result = await autoGenerateArticleTranslations();
+      return NextResponse.json(result);
+    }
+
+    // Bulk approve auto-translations
+    if (action === "bulk-approve") {
+      const contentType = body.contentType as ContentType | undefined;
+      const count = await bulkApproveAutoTranslations(contentType);
+      return NextResponse.json({ approved: count });
+    }
+
+    // Create/update a translation
+    if (body.contentType && body.contentId && body.fieldName && body.translatedText) {
+      const translation = await upsertTranslation({
+        contentType: body.contentType,
+        contentId: Number(body.contentId),
+        fieldName: body.fieldName,
+        sourceLocale: body.sourceLocale,
+        targetLocale: body.targetLocale,
+        sourceText: body.sourceText,
+        translatedText: body.translatedText,
+        translationMethod: body.translationMethod,
+        status: body.status,
+        qualityScore: body.qualityScore,
+      });
+      return NextResponse.json(translation);
+    }
+
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  } catch (error) {
+    console.error("Translation API POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+/** PATCH /api/admin/translations — update status or text */
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    if (!body.id) {
+      return NextResponse.json({ error: "Missing id" }, { status: 400 });
+    }
+
+    // Update status
+    if (body.status) {
+      const translation = await updateTranslationStatus(
+        Number(body.id),
+        body.status as TranslationStatus,
+        body.reviewerId
+      );
+      if (!translation) {
+        return NextResponse.json({ error: "Translation not found" }, { status: 404 });
+      }
+      return NextResponse.json(translation);
+    }
+
+    // Update translated text
+    if (body.translatedText) {
+      const translation = await updateTranslationText(
+        Number(body.id),
+        body.translatedText,
+        body.translationMethod
+      );
+      if (!translation) {
+        return NextResponse.json({ error: "Translation not found" }, { status: 404 });
+      }
+      return NextResponse.json(translation);
+    }
+
+    return NextResponse.json({ error: "No update fields provided" }, { status: 400 });
+  } catch (error) {
+    console.error("Translation API PATCH error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/translations/route.ts
+++ b/app/api/translations/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getApprovedTranslation, type ContentType } from "@/lib/translation-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/translations?contentType=yacht_description&contentId=123&fieldName=description&targetLocale=fr
+ * 
+ * Returns an approved translation for a content item.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const contentType = searchParams.get("contentType") as ContentType | null;
+    const contentId = searchParams.get("contentId");
+    const fieldName = searchParams.get("fieldName");
+    const targetLocale = searchParams.get("targetLocale") ?? "fr";
+
+    if (!contentType || !contentId || !fieldName) {
+      return NextResponse.json(
+        { error: "Missing required params: contentType, contentId, fieldName" },
+        { status: 400 }
+      );
+    }
+
+    const translatedText = await getApprovedTranslation(
+      contentType,
+      Number(contentId),
+      fieldName,
+      targetLocale
+    );
+
+    return NextResponse.json({
+      contentType,
+      contentId: Number(contentId),
+      fieldName,
+      targetLocale,
+      translatedText,
+    });
+  } catch (error) {
+    console.error("Public translation API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/drizzle/migrations/0008_content_translations.sql
+++ b/drizzle/migrations/0008_content_translations.sql
@@ -1,0 +1,48 @@
+-- P25.4: Multilingual content pipeline tables
+
+-- Content translations: stores translated text for any content type
+CREATE TABLE IF NOT EXISTS content_translations (
+  id SERIAL PRIMARY KEY,
+  content_type VARCHAR(50) NOT NULL, -- 'yacht_description', 'manufacturer_description', 'article', 'guide', 'glossary_term', 'faq'
+  content_id INTEGER NOT NULL, -- FK to the relevant table (yacht_models.id, manufacturers.id, articles.id, etc.)
+  field_name VARCHAR(100) NOT NULL, -- 'description', 'title', 'content', 'excerpt', etc.
+  source_locale VARCHAR(5) NOT NULL DEFAULT 'en',
+  target_locale VARCHAR(5) NOT NULL DEFAULT 'fr',
+  source_text TEXT,
+  translated_text TEXT NOT NULL,
+  translation_method VARCHAR(30) NOT NULL DEFAULT 'manual', -- 'manual', 'template', 'memory', 'external'
+  status VARCHAR(30) NOT NULL DEFAULT 'pending', -- 'pending', 'auto_translated', 'in_review', 'approved', 'rejected'
+  quality_score INTEGER DEFAULT 50, -- 0-100 confidence/quality score
+  reviewer_id INTEGER,
+  reviewed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_ct_content_type ON content_translations(content_type);
+CREATE INDEX IF NOT EXISTS idx_ct_content_id ON content_translations(content_id);
+CREATE INDEX IF NOT EXISTS idx_ct_status ON content_translations(status);
+CREATE INDEX IF NOT EXISTS idx_ct_locale_pair ON content_translations(source_locale, target_locale);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ct_unique ON content_translations(content_type, content_id, field_name, source_locale, target_locale);
+CREATE INDEX IF NOT EXISTS idx_ct_method ON content_translations(translation_method);
+
+-- Translation memory: reusable approved translations for consistency
+CREATE TABLE IF NOT EXISTS translation_memory (
+  id SERIAL PRIMARY KEY,
+  source_locale VARCHAR(5) NOT NULL DEFAULT 'en',
+  target_locale VARCHAR(5) NOT NULL DEFAULT 'fr',
+  source_text TEXT NOT NULL,
+  translated_text TEXT NOT NULL,
+  source_hash VARCHAR(64) NOT NULL, -- SHA-256 of source_text for fast lookup
+  category VARCHAR(100), -- 'nautical', 'spec', 'marketing', 'general'
+  match_count INTEGER NOT NULL DEFAULT 1, -- how many times this memory entry was reused
+  quality_score INTEGER DEFAULT 80,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for translation memory
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tm_unique ON translation_memory(source_hash, source_locale, target_locale);
+CREATE INDEX IF NOT EXISTS idx_tm_category ON translation_memory(category);
+CREATE INDEX IF NOT EXISTS idx_tm_source_hash ON translation_memory(source_hash);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1162,3 +1162,60 @@ export const reviewSources = pgTable(
 
 export const insertReviewSourceSchema = createInsertSchema(reviewSources);
 export const selectReviewSourceSchema = createSelectSchema(reviewSources);
+
+// P25.4: Content translations — multilingual content pipeline
+export const contentTranslations = pgTable(
+  "content_translations",
+  {
+    id: serial("id").primaryKey(),
+    contentType: varchar("content_type", { length: 50 }).notNull(), // 'yacht_description', 'manufacturer_description', 'article', 'guide', 'glossary_term', 'faq'
+    contentId: integer("content_id").notNull(),
+    fieldName: varchar("field_name", { length: 100 }).notNull(), // 'description', 'title', 'content', 'excerpt'
+    sourceLocale: varchar("source_locale", { length: 5 }).notNull().default("en"),
+    targetLocale: varchar("target_locale", { length: 5 }).notNull().default("fr"),
+    sourceText: text("source_text"),
+    translatedText: text("translated_text").notNull(),
+    translationMethod: varchar("translation_method", { length: 30 }).notNull().default("manual"), // 'manual', 'template', 'memory', 'external'
+    status: varchar("status", { length: 30 }).notNull().default("pending"), // 'pending', 'auto_translated', 'in_review', 'approved', 'rejected'
+    qualityScore: integer("quality_score").default(50),
+    reviewerId: integer("reviewer_id"),
+    reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    idxContentType: index("idx_ct_content_type").on(table.contentType),
+    idxContentId: index("idx_ct_content_id").on(table.contentId),
+    idxStatus: index("idx_ct_status").on(table.status),
+    idxLocalePair: index("idx_ct_locale_pair").on(table.sourceLocale, table.targetLocale),
+    idxUnique: uniqueIndex("idx_ct_unique").on(table.contentType, table.contentId, table.fieldName, table.sourceLocale, table.targetLocale),
+    idxMethod: index("idx_ct_method").on(table.translationMethod),
+  }),
+);
+
+export const translationMemory = pgTable(
+  "translation_memory",
+  {
+    id: serial("id").primaryKey(),
+    sourceLocale: varchar("source_locale", { length: 5 }).notNull().default("en"),
+    targetLocale: varchar("target_locale", { length: 5 }).notNull().default("fr"),
+    sourceText: text("source_text").notNull(),
+    translatedText: text("translated_text").notNull(),
+    sourceHash: varchar("source_hash", { length: 64 }).notNull(),
+    category: varchar("category", { length: 100 }),
+    matchCount: integer("match_count").notNull().default(1),
+    qualityScore: integer("quality_score").default(80),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    idxUnique: uniqueIndex("idx_tm_unique").on(table.sourceHash, table.sourceLocale, table.targetLocale),
+    idxCategory: index("idx_tm_category").on(table.category),
+    idxSourceHash: index("idx_tm_source_hash").on(table.sourceHash),
+  }),
+);
+
+export const insertContentTranslationSchema = createInsertSchema(contentTranslations);
+export const selectContentTranslationSchema = createSelectSchema(contentTranslations);
+export const insertTranslationMemorySchema = createInsertSchema(translationMemory);
+export const selectTranslationMemorySchema = createSelectSchema(translationMemory);

--- a/lib/translation-service.ts
+++ b/lib/translation-service.ts
@@ -1,0 +1,921 @@
+/**
+ * P25.4 — Translation Service
+ *
+ * Multilingual content pipeline: auto-translate descriptions, articles, and other
+ * content to French using template-based generation and translation memory.
+ */
+
+import { pool } from "@/lib/db";
+import { createHash } from "crypto";
+
+// ─── Types ─────────────────────────────────────────────────────────────
+
+export type ContentType = "yacht_description" | "manufacturer_description" | "article" | "guide" | "glossary_term" | "faq";
+export type TranslationStatus = "pending" | "auto_translated" | "in_review" | "approved" | "rejected";
+export type TranslationMethod = "manual" | "template" | "memory" | "external";
+
+export interface ContentTranslation {
+  id: number;
+  contentType: ContentType;
+  contentId: number;
+  fieldName: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string | null;
+  translatedText: string;
+  translationMethod: TranslationMethod;
+  status: TranslationStatus;
+  qualityScore: number | null;
+  reviewerId: number | null;
+  reviewedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface TranslationStats {
+  total: number;
+  byStatus: Record<TranslationStatus, number>;
+  byContentType: Record<string, number>;
+  byMethod: Record<string, number>;
+  coverageByType: Record<string, { total: number; translated: number; pct: number }>;
+}
+
+export interface TranslationQueueItem {
+  id: number;
+  contentType: ContentType;
+  contentId: number;
+  fieldName: string;
+  sourceText: string | null;
+  translatedText: string;
+  translationMethod: TranslationMethod;
+  status: TranslationStatus;
+  qualityScore: number | null;
+  createdAt: Date;
+}
+
+// ─── Translation Memory ────────────────────────────────────────────────
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text.trim().toLowerCase()).digest("hex");
+}
+
+/**
+ * Look up a translation in translation memory.
+ */
+export async function lookupTranslationMemory(
+  sourceText: string,
+  sourceLocale = "en",
+  targetLocale = "fr"
+): Promise<string | null> {
+  const hash = hashText(sourceText);
+  const result = await pool.query(
+    `SELECT translated_text, match_count FROM translation_memory
+     WHERE source_hash = $1 AND source_locale = $2 AND target_locale = $3
+     LIMIT 1`,
+    [hash, sourceLocale, targetLocale]
+  );
+  if (result.rows.length > 0) {
+    // Increment match count
+    await pool.query(
+      `UPDATE translation_memory SET match_count = match_count + 1, updated_at = NOW()
+       WHERE source_hash = $1 AND source_locale = $2 AND target_locale = $3`,
+      [hash, sourceLocale, targetLocale]
+    );
+    return result.rows[0].translated_text;
+  }
+  return null;
+}
+
+/**
+ * Add an entry to translation memory (from approved translations).
+ */
+export async function addToTranslationMemory(
+  sourceText: string,
+  translatedText: string,
+  category: string | null = null,
+  sourceLocale = "en",
+  targetLocale = "fr"
+): Promise<void> {
+  const hash = hashText(sourceText);
+  await pool.query(
+    `INSERT INTO translation_memory (source_locale, target_locale, source_text, translated_text, source_hash, category)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (source_hash, source_locale, target_locale)
+     DO UPDATE SET translated_text = $4, match_count = translation_memory.match_count + 1, updated_at = NOW()`,
+    [sourceLocale, targetLocale, sourceText.trim(), translatedText.trim(), hash, category]
+  );
+}
+
+// ─── French Template Translations ──────────────────────────────────────
+
+/**
+ * Template-based French translation for yacht descriptions.
+ * Uses pattern matching and vocabulary mapping for common phrases.
+ */
+const VOCABULARY: Record<string, string> = {
+  "sailing yacht": "voilier",
+  "sailboat": "voilier",
+  "monohull": "monocoque",
+  "cruiser": "croiseur",
+  "racer": "régatier",
+  "cruiser-racer": "croiseur-régatier",
+  "bluewater": "hauturière",
+  "keel": "quille",
+  "fin keel": "quille à bulbe",
+  "wing keel": "quille à ailerons",
+  "full keel": "quille longue",
+  "lifting keel": "quille relevable",
+  "hull": "coque",
+  "fiberglass": "fibre de verre",
+  "carbon fiber": "fibre de carbone",
+  "aluminum": "aluminium",
+  "steel": "acier",
+  "wood": "bois",
+  "beam": "maître-bau",
+  "draft": "tirant d'eau",
+  "displacement": "déplacement",
+  "ballast": "ballast",
+  "sail area": "surface de voilure",
+  "rig": "gréement",
+  "sloop": "sloop",
+  "cutter": "cutter",
+  "ketch": "ketch",
+  "yawl": "yawl",
+  "cabins": "cabines",
+  "berths": "couchettes",
+  "heads": "salles d'eau",
+  "engine": "moteur",
+  "diesel": "diesel",
+  "outboard": "hors-bord",
+  "fuel capacity": "capacité de carburant",
+  "water capacity": "capacité d'eau",
+  "overall length": "longueur hors tout",
+  "manufacturer": "constructeur",
+  "year": "année",
+  "designed for": "conçu pour",
+  "perfect for": "parfait pour",
+  "ideal for": "idéal pour",
+  "built for": "construit pour",
+  "features": "caractéristiques",
+  "offers": "offre",
+  "includes": "comprend",
+  "measures": "mesure",
+  "measuring": "mesurant",
+  "equipped with": "équipé de",
+  "with a": "avec un",
+  "with an": "avec un",
+  "performance": "performance",
+  "comfort": "confort",
+  "safety": "sécurité",
+  "value": "rapport qualité-prix",
+  "spacious": "spacieux",
+  "compact": "compact",
+  "lightweight": "léger",
+  "robust": "robuste",
+  "reliable": "fiable",
+  "elegant": "élégant",
+  "modern": "moderne",
+  "classic": "classique",
+  "traditional": "traditionnel",
+  "innovative": "innovant",
+  "versatile": "polyvalent",
+  "family-friendly": "familial",
+  "beginner-friendly": "adapté aux débutants",
+  "offshore": "au large",
+  "coastal": "côtier",
+  "ocean": "océanique",
+  "racing": "course",
+  "cruising": "croisière",
+  "day sailing": "balade en mer",
+  "weekend": "week-end",
+  "long-distance": "longue distance",
+  "solo": "en solitaire",
+  "couple": "en couple",
+  "family": "en famille",
+  "group": "en groupe",
+  "tons": "tonnes",
+  "tonnes": "tonnes",
+  "feet": "pieds",
+  "meters": "mètres",
+  "horsepower": "chevaux",
+  "HP": "ch",
+};
+
+/**
+ * Apply vocabulary-based translation to a text.
+ * Uses longest-match-first substitution for accuracy.
+ */
+export function translateWithVocabulary(text: string): string {
+  if (!text) return text;
+
+  // Sort vocabulary by length (longest first) to avoid partial matches
+  const sortedEntries = Object.entries(VOCABULARY).sort(
+    (a, b) => b[0].length - a[0].length
+  );
+
+  let result = text;
+  for (const [en, fr] of sortedEntries) {
+    // Case-insensitive whole-word matching
+    const regex = new RegExp(`\\b${escapeRegex(en)}\\b`, "gi");
+    result = result.replace(regex, (match) => {
+      // Preserve capitalization pattern
+      if (match === match.toUpperCase()) return fr.toUpperCase();
+      if (match[0] === match[0].toUpperCase()) return fr.charAt(0).toUpperCase() + fr.slice(1);
+      return fr;
+    });
+  }
+  return result;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Generate a French description for a yacht from its specs.
+ * Template-based approach — no external API needed.
+ */
+export function generateFrenchYachtDescription(specs: {
+  manufacturer: string;
+  modelName: string;
+  year: number;
+  lengthOverall: number | string | null;
+  beam: number | string | null;
+  draft: number | string | null;
+  displacement: number | string | null;
+  cabins: number | string | null;
+  berths: number | string | null;
+  keelType: string | null;
+  hullMaterial: string | null;
+  rigType: string | null;
+  engineHp: number | string | null;
+}, englishDescription: string | null): string {
+  // If we have an English description, translate it
+  if (englishDescription) {
+    return translateWithVocabulary(englishDescription);
+  }
+
+  // Otherwise, generate from specs
+  const parts: string[] = [];
+  const loa = num(specs.lengthOverall);
+  const beamVal = num(specs.beam);
+  const draftVal = num(specs.draft);
+  const dispVal = num(specs.displacement);
+  const cabinsVal = num(specs.cabins);
+  const berthsVal = num(specs.berths);
+  const hpVal = num(specs.engineHp);
+
+  // Intro
+  parts.push(
+    `Le ${specs.manufacturer} ${specs.modelName} est un voilier de ${specs.year}.`
+  );
+
+  // Dimensions
+  if (loa) {
+    const ft = (loa * 3.28084).toFixed(1);
+    const dimParts: string[] = [`${loa.toFixed(1)}m (${ft}pi) de longueur hors tout`];
+    if (beamVal) dimParts.push(`${beamVal.toFixed(1)}m de maître-bau`);
+    if (draftVal) dimParts.push(`${draftVal.toFixed(1)}m de tirant d'eau`);
+    parts.push(`Il mesure ${dimParts.join(", ")}.`);
+  }
+
+  // Displacement
+  if (dispVal) {
+    parts.push(`Son déplacement est de ${(dispVal / 1000).toFixed(1)} tonnes.`);
+  }
+
+  // Keel
+  if (specs.keelType) {
+    const keelFr = translateWithVocabulary(specs.keelType);
+    parts.push(`Équipé d'une ${keelFr}.`);
+  }
+
+  // Hull
+  if (specs.hullMaterial) {
+    const hullFr = translateWithVocabulary(specs.hullMaterial);
+    parts.push(`La coque est en ${hullFr}.`);
+  }
+
+  // Accommodation
+  if (cabinsVal || berthsVal) {
+    const accParts: string[] = [];
+    if (cabinsVal) accParts.push(`${cabinsVal} cabine${cabinsVal > 1 ? "s" : ""}`);
+    if (berthsVal) accParts.push(`${berthsVal} couchette${berthsVal > 1 ? "s" : ""}`);
+    parts.push(`Aménagements : ${accParts.join(", ")}.`);
+  }
+
+  // Engine
+  if (hpVal) {
+    parts.push(`Motorisation : ${hpVal} chevaux.`);
+  }
+
+  return parts.join(" ");
+}
+
+function num(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return isNaN(n) ? null : n;
+}
+
+/**
+ * Generate French translation for a manufacturer description.
+ */
+export function translateManufacturerDescription(
+  manufacturerName: string,
+  englishDescription: string | null,
+  country: string | null,
+  foundedYear: number | null
+): string {
+  if (!englishDescription) {
+    const parts: string[] = [`${manufacturerName} est un constructeur de voiliers`];
+    if (country) parts.push(`basé en ${translateWithVocabulary(country)}`);
+    if (foundedYear) parts.push(`fondé en ${foundedYear}`);
+    parts.push(".");
+    return parts.join(" ");
+  }
+  return translateWithVocabulary(englishDescription);
+}
+
+/**
+ * Translate an article/guide content to French.
+ * For articles, use vocabulary-based translation on the prose content.
+ */
+export function translateArticleContent(
+  title: string,
+  content: string | null,
+  excerpt: string | null
+): { titleFr: string; contentFr: string | null; excerptFr: string | null } {
+  return {
+    titleFr: translateWithVocabulary(title),
+    contentFr: content ? translateWithVocabulary(content) : null,
+    excerptFr: excerpt ? translateWithVocabulary(excerpt) : null,
+  };
+}
+
+// ─── Database Operations ───────────────────────────────────────────────
+
+/**
+ * Get translation stats.
+ */
+export async function getTranslationStats(): Promise<TranslationStats> {
+  const [statusResult, typeResult, methodResult] = await Promise.all([
+    pool.query(`SELECT status, count(*) as cnt FROM content_translations GROUP BY status`),
+    pool.query(`SELECT content_type, count(*) as cnt FROM content_translations GROUP BY content_type`),
+    pool.query(`SELECT translation_method, count(*) as cnt FROM content_translations GROUP BY translation_method`),
+  ]);
+
+  const byStatus: Record<string, number> = {};
+  for (const row of statusResult.rows) {
+    byStatus[row.status] = Number(row.cnt);
+  }
+
+  const byContentType: Record<string, number> = {};
+  for (const row of typeResult.rows) {
+    byContentType[row.content_type] = Number(row.cnt);
+  }
+
+  const byMethod: Record<string, number> = {};
+  for (const row of methodResult.rows) {
+    byMethod[row.translation_method] = Number(row.cnt);
+  }
+
+  // Calculate coverage: how many content items have approved translations
+  const coverageByType: Record<string, { total: number; translated: number; pct: number }> = {};
+
+  // Yacht descriptions
+  const yachtTotal = await pool.query(`SELECT count(*) as cnt FROM yacht_models WHERE description IS NOT NULL AND length(COALESCE(description, '')) > 10`);
+  const yachtTranslated = await pool.query(`SELECT count(DISTINCT content_id) as cnt FROM content_translations WHERE content_type = 'yacht_description' AND status = 'approved'`);
+  coverageByType["yacht_description"] = {
+    total: Number(yachtTotal.rows[0]?.cnt ?? 0),
+    translated: Number(yachtTranslated.rows[0]?.cnt ?? 0),
+    pct: yachtTotal.rows[0]?.cnt > 0 ? Math.round((Number(yachtTranslated.rows[0]?.cnt ?? 0) / Number(yachtTotal.rows[0].cnt)) * 100) : 0,
+  };
+
+  // Manufacturer descriptions
+  const mfgTotal = await pool.query(`SELECT count(*) as cnt FROM manufacturers WHERE description IS NOT NULL AND length(COALESCE(description, '')) > 10`);
+  const mfgTranslated = await pool.query(`SELECT count(DISTINCT content_id) as cnt FROM content_translations WHERE content_type = 'manufacturer_description' AND status = 'approved'`);
+  coverageByType["manufacturer_description"] = {
+    total: Number(mfgTotal.rows[0]?.cnt ?? 0),
+    translated: Number(mfgTranslated.rows[0]?.cnt ?? 0),
+    pct: mfgTotal.rows[0]?.cnt > 0 ? Math.round((Number(mfgTranslated.rows[0]?.cnt ?? 0) / Number(mfgTotal.rows[0].cnt)) * 100) : 0,
+  };
+
+  // Articles
+  const articleTotal = await pool.query(`SELECT count(*) as cnt FROM articles WHERE is_published = true`);
+  const articleTranslated = await pool.query(`SELECT count(DISTINCT content_id) as cnt FROM content_translations WHERE content_type = 'article' AND status = 'approved'`);
+  coverageByType["article"] = {
+    total: Number(articleTotal.rows[0]?.cnt ?? 0),
+    translated: Number(articleTranslated.rows[0]?.cnt ?? 0),
+    pct: articleTotal.rows[0]?.cnt > 0 ? Math.round((Number(articleTranslated.rows[0]?.cnt ?? 0) / Number(articleTotal.rows[0].cnt)) * 100) : 0,
+  };
+
+  return {
+    total: Object.values(byStatus).reduce((a, b) => a + b, 0),
+    byStatus: byStatus as Record<TranslationStatus, number>,
+    byContentType,
+    byMethod,
+    coverageByType,
+  };
+}
+
+/**
+ * Get the translation queue (pending / auto_translated / in_review items).
+ */
+export async function getTranslationQueue(
+  status?: TranslationStatus,
+  contentType?: ContentType,
+  limit = 50,
+  offset = 0
+): Promise<{ items: TranslationQueueItem[]; total: number }> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  if (status) {
+    conditions.push(`status = $${paramIdx++}`);
+    params.push(status);
+  }
+  if (contentType) {
+    conditions.push(`content_type = $${paramIdx++}`);
+    params.push(contentType);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const countResult = await pool.query(
+    `SELECT count(*) as cnt FROM content_translations ${where}`,
+    params
+  );
+
+  const result = await pool.query(
+    `SELECT id, content_type, content_id, field_name, source_text, translated_text,
+            translation_method, status, quality_score, created_at
+     FROM content_translations ${where}
+     ORDER BY
+       CASE status
+         WHEN 'pending' THEN 1
+         WHEN 'auto_translated' THEN 2
+         WHEN 'in_review' THEN 3
+         ELSE 4
+       END,
+       created_at ASC
+     LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+    [...params, limit, offset]
+  );
+
+  return {
+    items: result.rows.map((row) => ({
+      id: Number(row.id),
+      contentType: row.content_type,
+      contentId: Number(row.content_id),
+      fieldName: row.field_name,
+      sourceText: row.source_text,
+      translatedText: row.translated_text,
+      translationMethod: row.translation_method,
+      status: row.status,
+      qualityScore: row.quality_score ? Number(row.quality_score) : null,
+      createdAt: row.created_at,
+    })),
+    total: Number(countResult.rows[0]?.cnt ?? 0),
+  };
+}
+
+/**
+ * Get a single translation.
+ */
+export async function getTranslation(id: number): Promise<ContentTranslation | null> {
+  const result = await pool.query(
+    `SELECT * FROM content_translations WHERE id = $1`,
+    [id]
+  );
+  if (result.rows.length === 0) return null;
+  return mapRow(result.rows[0]);
+}
+
+/**
+ * Update translation status (approve/reject).
+ */
+export async function updateTranslationStatus(
+  id: number,
+  status: TranslationStatus,
+  reviewerId?: number
+): Promise<ContentTranslation | null> {
+  const result = await pool.query(
+    `UPDATE content_translations
+     SET status = $1, reviewer_id = $2, reviewed_at = NOW(), updated_at = NOW()
+     WHERE id = $3
+     RETURNING *`,
+    [status, reviewerId ?? null, id]
+  );
+  if (result.rows.length === 0) return null;
+
+  // If approved, add to translation memory
+  const row = result.rows[0];
+  if (status === "approved" && row.source_text && row.translated_text) {
+    await addToTranslationMemory(
+      row.source_text,
+      row.translated_text,
+      row.content_type,
+      row.source_locale,
+      row.target_locale
+    ).catch(() => { /* non-critical */ });
+  }
+
+  return mapRow(row);
+}
+
+/**
+ * Update the translated text of a translation.
+ */
+export async function updateTranslationText(
+  id: number,
+  translatedText: string,
+  method?: TranslationMethod
+): Promise<ContentTranslation | null> {
+  const result = await pool.query(
+    `UPDATE content_translations
+     SET translated_text = $1, translation_method = COALESCE($2, translation_method), updated_at = NOW()
+     WHERE id = $3
+     RETURNING *`,
+    [translatedText, method ?? null, id]
+  );
+  if (result.rows.length === 0) return null;
+  return mapRow(result.rows[0]);
+}
+
+/**
+ * Create or update a translation.
+ */
+export async function upsertTranslation(params: {
+  contentType: ContentType;
+  contentId: number;
+  fieldName: string;
+  sourceLocale?: string;
+  targetLocale?: string;
+  sourceText?: string;
+  translatedText: string;
+  translationMethod?: TranslationMethod;
+  status?: TranslationStatus;
+  qualityScore?: number;
+}): Promise<ContentTranslation> {
+  const {
+    contentType,
+    contentId,
+    fieldName,
+    sourceLocale = "en",
+    targetLocale = "fr",
+    sourceText,
+    translatedText,
+    translationMethod = "manual",
+    status = "pending",
+    qualityScore = 50,
+  } = params;
+
+  const result = await pool.query(
+    `INSERT INTO content_translations (content_type, content_id, field_name, source_locale, target_locale, source_text, translated_text, translation_method, status, quality_score)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     ON CONFLICT (content_type, content_id, field_name, source_locale, target_locale)
+     DO UPDATE SET translated_text = $7, translation_method = $8, status = $9, quality_score = $10, source_text = $6, updated_at = NOW()
+     RETURNING *`,
+    [contentType, contentId, fieldName, sourceLocale, targetLocale, sourceText ?? null, translatedText, translationMethod, status, qualityScore]
+  );
+  return mapRow(result.rows[0]);
+}
+
+/**
+ * Get an approved translation for a content item.
+ */
+export async function getApprovedTranslation(
+  contentType: ContentType,
+  contentId: number,
+  fieldName: string,
+  targetLocale = "fr"
+): Promise<string | null> {
+  const result = await pool.query(
+    `SELECT translated_text FROM content_translations
+     WHERE content_type = $1 AND content_id = $2 AND field_name = $3 AND target_locale = $4 AND status = 'approved'
+     LIMIT 1`,
+    [contentType, contentId, fieldName, targetLocale]
+  );
+  return result.rows[0]?.translated_text ?? null;
+}
+
+/**
+ * Auto-generate French translations for all yachts missing them.
+ * Uses template-based generation.
+ */
+export async function autoGenerateYachtTranslations(): Promise<{
+  generated: number;
+  skipped: number;
+  errors: number;
+}> {
+  // Find yachts with English descriptions but no French translation
+  const result = await pool.query(`
+    SELECT y.id, y.model_name, y.slug, y.description, y.length_overall, y.beam, y.draft,
+           y.displacement, y.cabins, y.berths, y.keel_type, y.hull_material, y.rig_type,
+           y.engine_hp, m.name as manufacturer_name, m.country, m.founded_year
+    FROM yacht_models y
+    LEFT JOIN manufacturers m ON y.manufacturer_id = m.id
+    WHERE y.description IS NOT NULL AND length(COALESCE(y.description, '')) > 10
+    AND NOT EXISTS (
+      SELECT 1 FROM content_translations ct
+      WHERE ct.content_type = 'yacht_description' AND ct.content_id = y.id
+      AND ct.field_name = 'description' AND ct.target_locale = 'fr' AND ct.status = 'approved'
+    )
+    ORDER BY y.id
+    LIMIT 200
+  `);
+
+  let generated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const row of result.rows) {
+    try {
+      // Check translation memory first
+      const memoryMatch = row.description
+        ? await lookupTranslationMemory(row.description, "en", "fr")
+        : null;
+
+      let translatedText: string;
+      let method: TranslationMethod;
+
+      if (memoryMatch) {
+        translatedText = memoryMatch;
+        method = "memory";
+      } else {
+        translatedText = generateFrenchYachtDescription(
+          {
+            manufacturer: row.manufacturer_name,
+            modelName: row.model_name,
+            year: 0, // we don't have year here, not critical
+            lengthOverall: row.length_overall,
+            beam: row.beam,
+            draft: row.draft,
+            displacement: row.displacement,
+            cabins: row.cabins,
+            berths: row.berths,
+            keelType: row.keel_type,
+            hullMaterial: row.hull_material,
+            rigType: row.rig_type,
+            engineHp: row.engine_hp,
+          },
+          row.description
+        );
+        method = "template";
+      }
+
+      await upsertTranslation({
+        contentType: "yacht_description",
+        contentId: Number(row.id),
+        fieldName: "description",
+        sourceText: row.description,
+        translatedText,
+        translationMethod: method,
+        status: "auto_translated",
+        qualityScore: method === "memory" ? 85 : 60,
+      });
+      generated++;
+    } catch (err) {
+      console.error(`Error generating translation for yacht ${row.id}:`, err);
+      errors++;
+    }
+  }
+
+  return { generated, skipped, errors };
+}
+
+/**
+ * Auto-generate French translations for all manufacturers missing them.
+ */
+export async function autoGenerateManufacturerTranslations(): Promise<{
+  generated: number;
+  skipped: number;
+  errors: number;
+}> {
+  const result = await pool.query(`
+    SELECT m.id, m.name, m.description, m.country, m.founded_year
+    FROM manufacturers m
+    WHERE m.description IS NOT NULL AND length(COALESCE(m.description, '')) > 10
+    AND NOT EXISTS (
+      SELECT 1 FROM content_translations ct
+      WHERE ct.content_type = 'manufacturer_description' AND ct.content_id = m.id
+      AND ct.field_name = 'description' AND ct.target_locale = 'fr' AND ct.status = 'approved'
+    )
+    ORDER BY m.id
+  `);
+
+  let generated = 0;
+  let errors = 0;
+
+  for (const row of result.rows) {
+    try {
+      const memoryMatch = row.description
+        ? await lookupTranslationMemory(row.description, "en", "fr")
+        : null;
+
+      let translatedText: string;
+      let method: TranslationMethod;
+
+      if (memoryMatch) {
+        translatedText = memoryMatch;
+        method = "memory";
+      } else {
+        translatedText = translateManufacturerDescription(
+          row.name,
+          row.description,
+          row.country,
+          row.founded_year
+        );
+        method = "template";
+      }
+
+      await upsertTranslation({
+        contentType: "manufacturer_description",
+        contentId: Number(row.id),
+        fieldName: "description",
+        sourceText: row.description,
+        translatedText,
+        translationMethod: method,
+        status: "auto_translated",
+        qualityScore: method === "memory" ? 85 : 60,
+      });
+      generated++;
+    } catch (err) {
+      console.error(`Error generating translation for manufacturer ${row.id}:`, err);
+      errors++;
+    }
+  }
+
+  return { generated, skipped: 0, errors };
+}
+
+/**
+ * Auto-generate French translations for published articles.
+ */
+export async function autoGenerateArticleTranslations(): Promise<{
+  generated: number;
+  skipped: number;
+  errors: number;
+}> {
+  const result = await pool.query(`
+    SELECT a.id, a.title, a.content, a.excerpt
+    FROM articles a
+    WHERE a.is_published = true
+    AND NOT EXISTS (
+      SELECT 1 FROM content_translations ct
+      WHERE ct.content_type = 'article' AND ct.content_id = a.id
+      AND ct.field_name = 'title' AND ct.target_locale = 'fr' AND ct.status = 'approved'
+    )
+    ORDER BY a.id
+    LIMIT 100
+  `);
+
+  let generated = 0;
+  let errors = 0;
+
+  for (const row of result.rows) {
+    try {
+      const { titleFr, contentFr, excerptFr } = translateArticleContent(
+        row.title,
+        row.content,
+        row.excerpt
+      );
+
+      // Upsert title translation
+      await upsertTranslation({
+        contentType: "article",
+        contentId: Number(row.id),
+        fieldName: "title",
+        sourceText: row.title,
+        translatedText: titleFr,
+        translationMethod: "template",
+        status: "auto_translated",
+        qualityScore: 60,
+      });
+
+      // Upsert content translation
+      if (contentFr) {
+        await upsertTranslation({
+          contentType: "article",
+          contentId: Number(row.id),
+          fieldName: "content",
+          sourceText: row.content,
+          translatedText: contentFr,
+          translationMethod: "template",
+          status: "auto_translated",
+          qualityScore: 60,
+        });
+      }
+
+      // Upsert excerpt translation
+      if (excerptFr) {
+        await upsertTranslation({
+          contentType: "article",
+          contentId: Number(row.id),
+          fieldName: "excerpt",
+          sourceText: row.excerpt,
+          translatedText: excerptFr,
+          translationMethod: "template",
+          status: "auto_translated",
+          qualityScore: 60,
+        });
+      }
+
+      generated++;
+    } catch (err) {
+      console.error(`Error generating translation for article ${row.id}:`, err);
+      errors++;
+    }
+  }
+
+  return { generated, skipped: 0, errors };
+}
+
+/**
+ * Approve all auto-translated items (bulk approve).
+ */
+export async function bulkApproveAutoTranslations(
+  contentType?: ContentType
+): Promise<number> {
+  const conditions = ["status = 'auto_translated'"];
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  if (contentType) {
+    conditions.push(`content_type = $${paramIdx++}`);
+    params.push(contentType);
+  }
+
+  const result = await pool.query(
+    `UPDATE content_translations
+     SET status = 'approved', reviewed_at = NOW(), updated_at = NOW()
+     WHERE ${conditions.join(" AND ")}
+     RETURNING id, source_text, translated_text, content_type, source_locale, target_locale`,
+    params
+  );
+
+  // Add all to translation memory
+  for (const row of result.rows) {
+    if (row.source_text && row.translated_text) {
+      await addToTranslationMemory(
+        row.source_text,
+        row.translated_text,
+        row.content_type,
+        row.source_locale,
+        row.target_locale
+      ).catch(() => {});
+    }
+  }
+
+  return result.rows.length;
+}
+
+/**
+ * Get translation memory stats.
+ */
+export async function getTranslationMemoryStats(): Promise<{
+  total: number;
+  byCategory: Record<string, number>;
+  totalMatchCount: number;
+}> {
+  const [totalResult, categoryResult, matchResult] = await Promise.all([
+    pool.query(`SELECT count(*) as cnt FROM translation_memory`),
+    pool.query(`SELECT COALESCE(category, 'uncategorized') as cat, count(*) as cnt FROM translation_memory GROUP BY category`),
+    pool.query(`SELECT sum(match_count) as total FROM translation_memory`),
+  ]);
+
+  const byCategory: Record<string, number> = {};
+  for (const row of categoryResult.rows) {
+    byCategory[row.cat] = Number(row.cnt);
+  }
+
+  return {
+    total: Number(totalResult.rows[0]?.cnt ?? 0),
+    byCategory,
+    totalMatchCount: Number(matchResult.rows[0]?.total ?? 0),
+  };
+}
+
+// ─── Helper ────────────────────────────────────────────────────────────
+
+function mapRow(row: Record<string, unknown>): ContentTranslation {
+  return {
+    id: Number(row.id),
+    contentType: row.content_type as ContentType,
+    contentId: Number(row.content_id),
+    fieldName: row.field_name as string,
+    sourceLocale: (row.source_locale as string) ?? "en",
+    targetLocale: (row.target_locale as string) ?? "fr",
+    sourceText: (row.source_text as string) ?? null,
+    translatedText: row.translated_text as string,
+    translationMethod: (row.translation_method as TranslationMethod) ?? "manual",
+    status: (row.status as TranslationStatus) ?? "pending",
+    qualityScore: row.quality_score ? Number(row.quality_score) : null,
+    reviewerId: row.reviewer_id ? Number(row.reviewer_id) : null,
+    reviewedAt: row.reviewed_at as Date | null,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+  };
+}

--- a/tests/translation-service.test.ts
+++ b/tests/translation-service.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the db pool — use vi.hoisted to avoid initialization order issues
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  pool: { query: mockQuery },
+}));
+
+import {
+  translateWithVocabulary,
+  generateFrenchYachtDescription,
+  translateManufacturerDescription,
+  translateArticleContent,
+} from "@/lib/translation-service";
+
+// ─── Vocabulary Translation Tests ────────────────────────────────────
+
+describe("translateWithVocabulary", () => {
+  it("translates common nautical terms", () => {
+    expect(translateWithVocabulary("sailing yacht")).toContain("voilier");
+    expect(translateWithVocabulary("fin keel")).toContain("quille à bulbe");
+    expect(translateWithVocabulary("fiberglass")).toContain("fibre de verre");
+  });
+
+  it("preserves capitalization", () => {
+    const result = translateWithVocabulary("Sailing Yacht");
+    expect(result).toContain("Voilier");
+  });
+
+  it("translates multiple terms in a sentence", () => {
+    const result = translateWithVocabulary(
+      "This sailing yacht features a fin keel and fiberglass hull."
+    );
+    expect(result).toContain("voilier");
+    expect(result).toContain("quille à bulbe");
+    expect(result).toContain("fibre de verre");
+    expect(result).toContain("coque");
+  });
+
+  it("handles mixed content correctly", () => {
+    const result = translateWithVocabulary("The Beneteau Oceanis 40.1");
+    expect(result).toContain("Beneteau");
+    expect(result).toContain("Oceanis");
+    expect(result).toContain("40.1");
+  });
+
+  it("returns original text if no matches", () => {
+    expect(translateWithVocabulary("Hello world")).toBe("Hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(translateWithVocabulary("")).toBe("");
+  });
+
+  it("prefers longer matches over shorter", () => {
+    const result = translateWithVocabulary("fin keel");
+    expect(result).toBe("quille à bulbe");
+  });
+
+  it("translates performance and comfort terms", () => {
+    expect(translateWithVocabulary("performance")).toBe("performance");
+    expect(translateWithVocabulary("comfort")).toBe("confort");
+    expect(translateWithVocabulary("safety")).toBe("sécurité");
+  });
+
+  it("translates sailing type terms", () => {
+    expect(translateWithVocabulary("offshore")).toBe("au large");
+    expect(translateWithVocabulary("coastal")).toBe("côtier");
+    expect(translateWithVocabulary("racing")).toBe("course");
+    expect(translateWithVocabulary("cruising")).toBe("croisière");
+  });
+});
+
+// ─── French Yacht Description Generation Tests ───────────────────────
+
+describe("generateFrenchYachtDescription", () => {
+  it("generates description from English template", () => {
+    const result = generateFrenchYachtDescription(
+      {
+        manufacturer: "Beneteau",
+        modelName: "Oceanis 40.1",
+        year: 2023,
+        lengthOverall: 12.43,
+        beam: 4.18,
+        draft: 2.15,
+        displacement: 8600,
+        cabins: 3,
+        berths: 6,
+        keelType: "Fin keel",
+        hullMaterial: "Fiberglass",
+        rigType: "Sloop",
+        engineHp: 45,
+      },
+      "The Beneteau Oceanis 40.1 is a sailing yacht designed for cruising."
+    );
+    expect(result).toContain("Beneteau");
+    expect(result).toContain("Oceanis 40.1");
+    expect(result).toContain("voilier");
+    expect(result).toBeTruthy();
+  });
+
+  it("generates from specs when no English description", () => {
+    const result = generateFrenchYachtDescription(
+      {
+        manufacturer: "Jeanneau",
+        modelName: "Sun Odyssey 440",
+        year: 2022,
+        lengthOverall: 13.22,
+        beam: 4.29,
+        draft: 2.24,
+        displacement: 10200,
+        cabins: 3,
+        berths: 8,
+        keelType: "Wing keel",
+        hullMaterial: "Fiberglass",
+        rigType: "Sloop",
+        engineHp: 54,
+      },
+      null
+    );
+    expect(result).toContain("Jeanneau");
+    expect(result).toContain("Sun Odyssey 440");
+    expect(result).toContain("voilier");
+    expect(result).toContain("maître-bau");
+    expect(result).toContain("tirant d'eau");
+    expect(result).toContain("cabines");
+    expect(result).toContain("chevaux");
+  });
+
+  it("handles minimal specs gracefully", () => {
+    const result = generateFrenchYachtDescription(
+      {
+        manufacturer: "Test",
+        modelName: "Basic",
+        year: 2020,
+        lengthOverall: null,
+        beam: null,
+        draft: null,
+        displacement: null,
+        cabins: null,
+        berths: null,
+        keelType: null,
+        hullMaterial: null,
+        rigType: null,
+        engineHp: null,
+      },
+      null
+    );
+    expect(result).toContain("Test");
+    expect(result).toContain("Basic");
+    expect(result).toContain("voilier");
+  });
+
+  it("handles numeric string values", () => {
+    const result = generateFrenchYachtDescription(
+      {
+        manufacturer: "Test",
+        modelName: "StringSpec",
+        year: 2023,
+        lengthOverall: "12.43" as unknown as number,
+        beam: null,
+        draft: null,
+        displacement: null,
+        cabins: "3" as unknown as number,
+        berths: null,
+        keelType: null,
+        hullMaterial: null,
+        rigType: null,
+        engineHp: null,
+      },
+      null
+    );
+    expect(result).toContain("longueur hors tout");
+  });
+});
+
+// ─── Manufacturer Description Translation Tests ──────────────────────
+
+describe("translateManufacturerDescription", () => {
+  it("translates manufacturer description with vocabulary", () => {
+    const result = translateManufacturerDescription(
+      "Beneteau",
+      "Beneteau is a leading sailing yacht manufacturer from France.",
+      "France",
+      1884
+    );
+    expect(result).toContain("Beneteau");
+    expect(result).toContain("voilier");
+  });
+
+  it("generates basic description when no English desc", () => {
+    const result = translateManufacturerDescription(
+      "Beneteau",
+      null,
+      "France",
+      1884
+    );
+    expect(result).toContain("Beneteau");
+    expect(result).toContain("constructeur");
+    expect(result).toContain("1884");
+  });
+
+  it("handles null country and founded year", () => {
+    const result = translateManufacturerDescription(
+      "Test Manufacturer",
+      null,
+      null,
+      null
+    );
+    expect(result).toContain("Test Manufacturer");
+    expect(result).toContain("constructeur");
+  });
+});
+
+// ─── Article Content Translation Tests ───────────────────────────────
+
+describe("translateArticleContent", () => {
+  it("translates article title and content", () => {
+    const result = translateArticleContent(
+      "How to Choose Your First Sailing Yacht",
+      "Choosing your first sailing yacht involves considering comfort, safety, and performance.",
+      "A guide for beginners looking for their first sailboat."
+    );
+    expect(result.titleFr.toLowerCase()).toContain("voilier");
+    expect(result.contentFr).toContain("confort");
+    expect(result.contentFr).toContain("sécurité");
+    expect(result.contentFr).toContain("performance");
+    expect(result.excerptFr).toContain("voilier");
+  });
+
+  it("handles null content and excerpt", () => {
+    const result = translateArticleContent("Test Title", null, null);
+    expect(result.titleFr).toBeTruthy();
+    expect(result.contentFr).toBeNull();
+    expect(result.excerptFr).toBeNull();
+  });
+});
+
+// ─── Hash Function Tests ─────────────────────────────────────────────
+
+describe("hashText", () => {
+  function hashText(text: string): string {
+    const { createHash } = require("crypto");
+    return createHash("sha256").update(text.trim().toLowerCase()).digest("hex");
+  }
+
+  it("produces consistent SHA-256 hashes", () => {
+    const hash1 = hashText("sailing yacht");
+    const hash2 = hashText("sailing yacht");
+    expect(hash1).toBe(hash2);
+    expect(hash1).toHaveLength(64);
+  });
+
+  it("is case-insensitive", () => {
+    expect(hashText("Sailing Yacht")).toBe(hashText("sailing yacht"));
+  });
+
+  it("trims whitespace", () => {
+    expect(hashText("  sailing yacht  ")).toBe(hashText("sailing yacht"));
+  });
+});
+
+// ─── Integration Tests (with mocked DB) ──────────────────────────────
+
+describe("Translation service DB operations", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("lookupTranslationMemory returns null when no match", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const { lookupTranslationMemory } = await import("@/lib/translation-service");
+    const result = await lookupTranslationMemory("test text");
+    expect(result).toBeNull();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("lookupTranslationMemory returns match and increments count", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ translated_text: "texte de test", match_count: 5 }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const { lookupTranslationMemory } = await import("@/lib/translation-service");
+    const result = await lookupTranslationMemory("test text");
+    expect(result).toBe("texte de test");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("addToTranslationMemory inserts or updates", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const { addToTranslationMemory } = await import("@/lib/translation-service");
+    await addToTranslationMemory("test", "test FR", "nautical");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][0]).toContain("INSERT INTO translation_memory");
+  });
+});


### PR DESCRIPTION
## P25.4 — Multilingual Content Pipeline

### What Was Implemented
- **`content_translations` table**: Stores translations per content type (yacht_description, manufacturer_description, article, guide, glossary_term, faq) with status tracking (pending → auto_translated → in_review → approved/rejected)
- **`translation_memory` table**: SHA-256 hash-based translation memory for consistency and reuse
- **Translation service** (`lib/translation-service.ts`): 
  - Template-based French translation with 80+ nautical vocabulary mappings
  - Auto-generation for yacht descriptions, manufacturer descriptions, and articles
  - Translation memory lookup and storage
  - Queue management, approve/reject, bulk approve
  - Coverage stats tracking
- **Admin dashboard** at `/admin/translations`:
  - Translation coverage bars by content type
  - Queue with filters (status, content type), pagination
  - Inline editing of translations
  - Approve/reject individual items
  - Bulk approve all auto-translated
  - Auto-generate buttons for yachts, manufacturers, articles
- **API endpoints**:
  - `GET/POST/PATCH /api/admin/translations` — full CRUD + actions
  - `GET /api/translations` — public API for fetching approved translations
- **Database migration**: `drizzle/migrations/0008_content_translations.sql`
- **Tests**: 24 tests covering vocabulary translation, yacht description generation, manufacturer translation, article translation, hash function, and DB operations

### Technical Notes
- Vocabulary-based translation uses longest-match-first to avoid partial matches (e.g., "fin keel" → "quille à bulbe", not "fin" → ???)
- Translation memory uses SHA-256 hashes for O(1) lookup
- Approved translations automatically feed into translation memory
- No external translation API needed — template-based approach

### Build & Test
- TypeScript: ✅ Pass
- Build: ✅ Pass (1528 static pages)
- Tests: ✅ 24/24 pass

Closes #408