### PR TITLE
feat: dynamic FAQ generation with structured data — P25.5 (closes #410)

### DIFF
--- a/app/[locale]/faq/FaqStructuredData.tsx
+++ b/app/[locale]/faq/FaqStructuredData.tsx
@@ -1,0 +1,25 @@
+/**
+ * Client component for JSON-LD structured data injection.
+ */
+"use client";
+
+import { useEffect } from "react";
+
+interface FaqStructuredDataProps {
+  jsonLd: object;
+}
+
+export default function FaqStructuredData({ jsonLd }: FaqStructuredDataProps) {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.type = "application/ld+json";
+    script.textContent = JSON.stringify(jsonLd);
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [jsonLd]);
+
+  return null;
+}

--- a/app/[locale]/faq/[manufacturer]/page.tsx
+++ b/app/[locale]/faq/[manufacturer]/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { getManufacturerStats, generateManufacturerFaqs, getAllManufacturerSlugs } from "@/lib/faq-generation";
+import { getSiteUrl, buildLocaleAlternates } from "@/lib/seo";
+import { localePath } from "@/lib/i18n-paths";
+import { slugify } from "@/lib/utils/slugify";
+import FaqStructuredData from "../FaqStructuredData";
+
+export const revalidate = 3600;
+
+interface MfrFaqPageProps {
+  params: { locale: string; manufacturer: string };
+}
+
+export async function generateStaticParams() {
+  const slugs = await getAllManufacturerSlugs();
+  return slugs.flatMap((slug) => [
+    { locale: "en", manufacturer: slug },
+    { locale: "fr", manufacturer: slug },
+  ]);
+}
+
+export async function generateMetadata({ params }: MfrFaqPageProps): Promise<Metadata> {
+  const { locale, manufacturer } = params;
+  setRequestLocale(locale);
+
+  // Resolve manufacturer name from slug
+  const slugs = await getAllManufacturerSlugs();
+  // We need the actual name — query by slug match
+  // Since slugs are derived from names, we need to find the original name
+  const { db, manufacturers, yachtModels } = await import("@/lib/db-edge");
+  const { eq, count, sql } = await import("drizzle-orm");
+  
+  const mfrRows = await db
+    .select({ name: manufacturers.name })
+    .from(manufacturers)
+    .innerJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+    .groupBy(manufacturers.name)
+    .having(sql`count(*) >= 3`);
+
+  const mfr = mfrRows.find((r: any) => slugify(r.name) === manufacturer);
+  if (!mfr) return {};
+
+  const stats = await getManufacturerStats(mfr.name);
+  if (!stats) return {};
+
+  const data = generateManufacturerFaqs(stats);
+  const title = locale === "fr" ? data.titleFr : data.title;
+
+  return {
+    title,
+    description: locale === "fr" ? data.descriptionFr : data.description,
+    alternates: buildLocaleAlternates(`/faq/${manufacturer}`, locale),
+    openGraph: {
+      title,
+      description: locale === "fr" ? data.descriptionFr : data.description,
+      type: "website",
+      url: getSiteUrl(`/${locale}/faq/${manufacturer}`),
+    },
+  };
+}
+
+export default async function ManufacturerFaqPage({ params }: MfrFaqPageProps) {
+  const { locale, manufacturer: manufacturerSlug } = params;
+  setRequestLocale(locale);
+  const isFr = locale === "fr";
+
+  // Resolve manufacturer name
+  const { db, manufacturers, yachtModels } = await import("@/lib/db-edge");
+  const { eq, count, sql } = await import("drizzle-orm");
+
+  const mfrRows = await db
+    .select({ name: manufacturers.name })
+    .from(manufacturers)
+    .innerJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+    .groupBy(manufacturers.name)
+    .having(sql`count(*) >= 3`);
+
+  const mfr = mfrRows.find((r: any) => slugify(r.name) === manufacturerSlug);
+  if (!mfr) notFound();
+
+  const stats = await getManufacturerStats(mfr.name);
+  if (!stats) notFound();
+
+  const data = generateManufacturerFaqs(stats);
+  const title = isFr ? data.titleFr : data.title;
+
+  return (
+    <main className="min-h-screen bg-white">
+      <FaqStructuredData jsonLd={data.jsonLd} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-b from-blue-50 to-white py-12 border-b">
+        <div className="max-w-4xl mx-auto px-4">
+          <Link
+            href={localePath(locale, "/faq")}
+            className="text-blue-600 hover:text-blue-800 text-sm mb-3 inline-block"
+          >
+            ← {isFr ? "Toutes les FAQ" : "All FAQs"}
+          </Link>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            {title}
+          </h1>
+          <p className="text-lg text-gray-600">
+            {isFr ? data.descriptionFr : data.description}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <span className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
+              {stats.yachtCount} {isFr ? "modèles" : "models"}
+            </span>
+            {stats.minLoa && stats.maxLoa && (
+              <span className="px-3 py-1 bg-green-100 text-green-800 rounded-full text-sm font-medium">
+                {stats.minLoa.toFixed(1)}m – {stats.maxLoa.toFixed(1)}m
+              </span>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Items */}
+      <section className="max-w-4xl mx-auto px-4 py-10">
+        <div className="space-y-6">
+          {data.faqs.map((faq, i) => (
+            <details
+              key={i}
+              className="group border border-gray-200 rounded-lg p-5 hover:border-blue-300 transition-colors"
+              open={i === 0}
+            >
+              <summary className="flex items-center justify-between cursor-pointer text-lg font-semibold text-gray-900 list-none">
+                <span>{isFr ? faq.questionFr : faq.question}</span>
+                <span className="ml-4 text-blue-600 group-open:rotate-180 transition-transform flex-shrink-0">
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                  </svg>
+                </span>
+              </summary>
+              <p className="mt-3 text-gray-600 leading-relaxed">
+                {isFr ? faq.answerFr : faq.answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-blue-50 py-8 border-t">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <Link
+            href={localePath(locale, `/manufacturers/${manufacturerSlug}`)}
+            className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+          >
+            {isFr ? `Voir tous les voiliers ${stats.name}` : `Browse all ${stats.name} yachts`}
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/[locale]/faq/page.tsx
+++ b/app/[locale]/faq/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import { generateGeneralFaqs, getAllManufacturerSlugs } from "@/lib/faq-generation";
+import { SIZE_CATEGORIES } from "@/lib/size-categories";
+import { getSiteUrl, buildLocaleAlternates } from "@/lib/seo";
+import { localePath } from "@/lib/i18n-paths";
+import FaqStructuredData from "./FaqStructuredData";
+
+export const revalidate = 3600; // ISR: revalidate every hour
+
+interface FaqPageProps {
+  params: { locale: string };
+}
+
+export async function generateMetadata({ params }: FaqPageProps): Promise<Metadata> {
+  const { locale } = params;
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "Faq" });
+
+  return {
+    title: locale === "fr" ? "Questions Fréquentes sur les Voiliers" : "Sailing Yachts — Frequently Asked Questions",
+    description: locale === "fr"
+      ? "Questions fréquentes sur les voiliers. Découvrez les constructeurs, tailles, types de gréement et comment choisir le bon voilier."
+      : "Frequently asked questions about sailing yachts. Learn about manufacturers, sizes, rig types, keel configurations, and how to choose the right yacht.",
+    alternates: buildLocaleAlternates("/faq", locale),
+    openGraph: {
+      title: locale === "fr" ? "Questions Fréquentes sur les Voiliers" : "Sailing Yachts — FAQ",
+      description: locale === "fr"
+        ? "Trouvez des réponses aux questions les plus fréquentes sur les voiliers"
+        : "Find answers to the most frequently asked questions about sailing yachts",
+      type: "website",
+      url: getSiteUrl(`/${locale}/faq`),
+    },
+  };
+}
+
+export default async function FaqPage({ params }: FaqPageProps) {
+  const { locale } = params;
+  setRequestLocale(locale);
+  const isFr = locale === "fr";
+
+  const data = await generateGeneralFaqs();
+  const mfrSlugs = await getAllManufacturerSlugs();
+
+  const title = isFr ? data.titleFr : data.title;
+  const description = isFr ? data.descriptionFr : data.description;
+
+  return (
+    <main className="min-h-screen bg-white">
+      <FaqStructuredData jsonLd={data.jsonLd} />
+      
+      {/* Hero */}
+      <section className="bg-gradient-to-b from-blue-50 to-white py-12 border-b">
+        <div className="max-w-4xl mx-auto px-4">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            {title}
+          </h1>
+          <p className="text-lg text-gray-600">{description}</p>
+        </div>
+      </section>
+
+      {/* FAQ Items */}
+      <section className="max-w-4xl mx-auto px-4 py-10">
+        <div className="space-y-6">
+          {data.faqs.map((faq, i) => (
+            <details
+              key={i}
+              className="group border border-gray-200 rounded-lg p-5 hover:border-blue-300 transition-colors"
+              open={i === 0}
+            >
+              <summary className="flex items-center justify-between cursor-pointer text-lg font-semibold text-gray-900 list-none">
+                <span>{isFr ? faq.questionFr : faq.question}</span>
+                <span className="ml-4 text-blue-600 group-open:rotate-180 transition-transform flex-shrink-0">
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                  </svg>
+                </span>
+              </summary>
+              <p className="mt-3 text-gray-600 leading-relaxed">
+                {isFr ? faq.answerFr : faq.answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* Browse by Manufacturer */}
+      {mfrSlugs.length > 0 && (
+        <section className="bg-gray-50 py-10 border-t">
+          <div className="max-w-4xl mx-auto px-4">
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              {isFr ? "FAQ par constructeur" : "FAQ by Manufacturer"}
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+              {mfrSlugs.map((slug) => (
+                <Link
+                  key={slug}
+                  href={localePath(locale, `/faq/${slug}`)}
+                  className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-gray-700 hover:border-blue-400 hover:text-blue-700 transition-colors text-sm font-medium text-center"
+                >
+                  {slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Browse by Size */}
+      <section className="py-10 border-t">
+        <div className="max-w-4xl mx-auto px-4">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">
+            {isFr ? "FAQ par taille" : "FAQ by Size"}
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {SIZE_CATEGORIES.map((cat) => (
+              <Link
+                key={cat.slug}
+                href={localePath(locale, `/faq/size/${cat.slug}`)}
+                className="px-4 py-3 bg-white border border-gray-200 rounded-lg hover:border-blue-400 transition-colors"
+              >
+                <div className="font-semibold text-gray-900 text-sm">
+                  {isFr ? cat.labelFr : cat.labelEn}
+                </div>
+                <div className="text-xs text-gray-500 mt-1">
+                  {cat.loaMin.toFixed(1)}m – {cat.loaMax < 100 ? cat.loaMax.toFixed(1) + "m" : "∞"}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/[locale]/faq/size/[category]/page.tsx
+++ b/app/[locale]/faq/size/[category]/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { getSizeCategoryStats, generateSizeCategoryFaqs } from "@/lib/faq-generation";
+import { SIZE_CATEGORIES } from "@/lib/size-categories";
+import { getSiteUrl, buildLocaleAlternates } from "@/lib/seo";
+import { localePath } from "@/lib/i18n-paths";
+import FaqStructuredData from "../../FaqStructuredData";
+
+export const revalidate = 3600;
+
+interface SizeFaqPageProps {
+  params: { locale: string; category: string };
+}
+
+export async function generateStaticParams() {
+  return SIZE_CATEGORIES.flatMap((cat) => [
+    { locale: "en", category: cat.slug },
+    { locale: "fr", category: cat.slug },
+  ]);
+}
+
+export async function generateMetadata({ params }: SizeFaqPageProps): Promise<Metadata> {
+  const { locale, category } = params;
+  setRequestLocale(locale);
+
+  const cat = SIZE_CATEGORIES.find((c) => c.slug === category);
+  if (!cat) return {};
+
+  const stats = await getSizeCategoryStats(cat);
+  if (!stats) return {};
+
+  const data = generateSizeCategoryFaqs(stats);
+  const title = locale === "fr" ? data.titleFr : data.title;
+
+  return {
+    title,
+    description: locale === "fr" ? data.descriptionFr : data.description,
+    alternates: buildLocaleAlternates(`/faq/size/${category}`, locale),
+    openGraph: {
+      title,
+      description: locale === "fr" ? data.descriptionFr : data.description,
+      type: "website",
+      url: getSiteUrl(`/${locale}/faq/size/${category}`),
+    },
+  };
+}
+
+export default async function SizeCategoryFaqPage({ params }: SizeFaqPageProps) {
+  const { locale, category: categorySlug } = params;
+  setRequestLocale(locale);
+  const isFr = locale === "fr";
+
+  const cat = SIZE_CATEGORIES.find((c) => c.slug === categorySlug);
+  if (!cat) notFound();
+
+  const stats = await getSizeCategoryStats(cat);
+  if (!stats) notFound();
+
+  const data = generateSizeCategoryFaqs(stats);
+  const title = isFr ? data.titleFr : data.title;
+
+  return (
+    <main className="min-h-screen bg-white">
+      <FaqStructuredData jsonLd={data.jsonLd} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-b from-blue-50 to-white py-12 border-b">
+        <div className="max-w-4xl mx-auto px-4">
+          <Link
+            href={localePath(locale, "/faq")}
+            className="text-blue-600 hover:text-blue-800 text-sm mb-3 inline-block"
+          >
+            ← {isFr ? "Toutes les FAQ" : "All FAQs"}
+          </Link>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            {title}
+          </h1>
+          <p className="text-lg text-gray-600">
+            {isFr ? data.descriptionFr : data.description}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <span className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
+              {stats.yachtCount} {isFr ? "voiliers" : "yachts"}
+            </span>
+            <span className="px-3 py-1 bg-green-100 text-green-800 rounded-full text-sm font-medium">
+              {isFr ? cat.labelFr : cat.labelEn}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Items */}
+      <section className="max-w-4xl mx-auto px-4 py-10">
+        <div className="space-y-6">
+          {data.faqs.map((faq, i) => (
+            <details
+              key={i}
+              className="group border border-gray-200 rounded-lg p-5 hover:border-blue-300 transition-colors"
+              open={i === 0}
+            >
+              <summary className="flex items-center justify-between cursor-pointer text-lg font-semibold text-gray-900 list-none">
+                <span>{isFr ? faq.questionFr : faq.question}</span>
+                <span className="ml-4 text-blue-600 group-open:rotate-180 transition-transform flex-shrink-0">
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                  </svg>
+                </span>
+              </summary>
+              <p className="mt-3 text-gray-600 leading-relaxed">
+                {isFr ? faq.answerFr : faq.answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* Top Manufacturers in this size */}
+      {stats.manufacturers.length > 0 && (
+        <section className="bg-gray-50 py-8 border-t">
+          <div className="max-w-4xl mx-auto px-4">
+            <h2 className="text-xl font-bold text-gray-900 mb-4">
+              {isFr ? "Constructeurs populaires dans cette taille" : "Popular manufacturers in this size"}
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {stats.manufacturers.map((m) => (
+                <Link
+                  key={m.name}
+                  href={localePath(locale, `/faq/${m.name.toLowerCase().replace(/\s+/g, "-")}`)}
+                  className="px-4 py-3 bg-white border border-gray-200 rounded-lg hover:border-blue-400 transition-colors"
+                >
+                  <div className="font-semibold text-gray-900 text-sm">{m.name}</div>
+                  <div className="text-xs text-gray-500">{m.count} {isFr ? "modèles" : "models"}</div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -41,6 +41,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
     { nameKey: "manufacturers", path: `/${locale}/manufacturers` },
     { nameKey: "guides", path: `/${locale}/guides` },
     { nameKey: "glossary", path: `/${locale}/glossary` },
+    { nameKey: "faq", path: `/${locale}/faq` },
     { nameKey: "search", path: `/${locale}/search` },
     { nameKey: "compare", path: `/${locale}/compare` },
   ];

--- a/app/sitemap-faq.xml/route.ts
+++ b/app/sitemap-faq.xml/route.ts
@@ -1,0 +1,50 @@
+import { getAllManufacturerSlugs } from "@/lib/faq-generation";
+import { SIZE_CATEGORIES } from "@/lib/size-categories";
+import { SITE_URL, buildSitemapXml, sitemapResponse, SitemapEntry } from "@/lib/sitemap";
+
+export const revalidate = 86400;
+
+const LOCALES = ["en", "fr"] as const;
+
+export async function GET() {
+  const lastmod = new Date().toISOString().split("T")[0];
+  const entries: SitemapEntry[] = [];
+
+  // General FAQ pages
+  for (const locale of LOCALES) {
+    entries.push({
+      loc: `${SITE_URL}/${locale}/faq`,
+      lastmod,
+      changefreq: "weekly",
+      priority: "0.7",
+    });
+  }
+
+  // Manufacturer FAQ pages
+  const mfrSlugs = await getAllManufacturerSlugs();
+  for (const slug of mfrSlugs) {
+    for (const locale of LOCALES) {
+      entries.push({
+        loc: `${SITE_URL}/${locale}/faq/${slug}`,
+        lastmod,
+        changefreq: "weekly",
+        priority: "0.6",
+      });
+    }
+  }
+
+  // Size category FAQ pages
+  for (const cat of SIZE_CATEGORIES) {
+    for (const locale of LOCALES) {
+      entries.push({
+        loc: `${SITE_URL}/${locale}/faq/size/${cat.slug}`,
+        lastmod,
+        changefreq: "weekly",
+        priority: "0.6",
+      });
+    }
+  }
+
+  const xml = buildSitemapXml(entries);
+  return sitemapResponse(xml);
+}

--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
     { path: "/compare", changefreq: "weekly", priority: "0.7" },
     { path: "/search", changefreq: "monthly", priority: "0.6" },
     { path: "/favorites", changefreq: "monthly", priority: "0.4" },
+    { path: "/faq", changefreq: "weekly", priority: "0.7" },
     // Landing pages from /best/[slug]
     ...LANDING_PAGES.map((lp: LandingPageDefinition) => ({
       path: `/best/${lp.slug}`,

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
       { loc: `${SITE_URL}/sitemap-guides.xml`, lastmod },
       { loc: `${SITE_URL}/sitemap-compare.xml`, lastmod },
       { loc: `${SITE_URL}/sitemap-images.xml`, lastmod },
+      { loc: `${SITE_URL}/sitemap-faq.xml`, lastmod },
     ];
 
     const xml = buildSitemapIndexXml(sitemaps);

--- a/lib/faq-generation.ts
+++ b/lib/faq-generation.ts
@@ -1,0 +1,570 @@
+/**
+ * Dynamic FAQ Generation Service (P25.5)
+ *
+ * Auto-generates FAQ Q&A pairs from yacht data patterns.
+ * Produces FAQs per manufacturer, per size category, and a general FAQ page.
+ * Includes JSON-LD FAQPage schema markup for search engine rich results.
+ */
+
+import { db, yachtModels, manufacturers } from "@/lib/db-edge";
+import { eq, sql, isNotNull, and, count, avg, min, max, between } from "drizzle-orm";
+import { SIZE_CATEGORIES, type SizeCategory } from "@/lib/size-categories";
+import { slugify } from "@/lib/utils/slugify";
+
+// --- Types ---
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+  /** French translation */
+  questionFr: string;
+  answerFr: string;
+}
+
+export interface FaqPageData {
+  title: string;
+  titleFr: string;
+  description: string;
+  descriptionFr: string;
+  slug: string;
+  faqs: FaqItem[];
+  /** JSON-LD FAQPage schema */
+  jsonLd: object;
+}
+
+export interface ManufacturerStats {
+  name: string;
+  slug: string;
+  yachtCount: number;
+  minLoa: number | null;
+  maxLoa: number | null;
+  avgLoa: number | null;
+  avgCabins: number | null;
+  avgBerths: number | null;
+  rigTypes: Record<string, number>;
+  keelTypes: Record<string, number>;
+  hullMaterials: Record<string, number>;
+  years: { min: number | null; max: number | null };
+}
+
+export interface SizeCategoryStats {
+  category: SizeCategory;
+  yachtCount: number;
+  manufacturers: { name: string; count: number }[];
+  avgCabins: number | null;
+  avgBerths: number | null;
+  rigTypes: Record<string, number>;
+  keelTypes: Record<string, number>;
+}
+
+// --- Data Aggregation ---
+
+function num(v: string | number | null): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? Math.round(n * 10) / 10 : null;
+}
+
+function fmtM(ft: number | null): string {
+  if (ft === null) return "N/A";
+  return `${ft.toFixed(1)}m`;
+}
+
+function fmtFt(m: number | null): string {
+  if (m === null) return "N/A";
+  return `${(m * 3.28084).toFixed(1)}ft`;
+}
+
+export async function getManufacturerStats(mfrName: string): Promise<ManufacturerStats | null> {
+  const rows = await db
+    .select({
+      yachtCount: count(yachtModels.id),
+      minLoa: min(yachtModels.lengthOverall),
+      maxLoa: max(yachtModels.lengthOverall),
+      avgLoa: avg(yachtModels.lengthOverall),
+      avgCabins: avg(yachtModels.cabins),
+      avgBerths: avg(yachtModels.berths),
+      minYear: min(yachtModels.year),
+      maxYear: max(yachtModels.year),
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(eq(manufacturers.name, mfrName));
+
+  if (!rows[0] || rows[0].yachtCount === 0) return null;
+
+  const stats = rows[0];
+
+  // Get rig type distribution
+  const rigRows = await db
+    .select({
+      rigType: yachtModels.rigType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(and(eq(manufacturers.name, mfrName), isNotNull(yachtModels.rigType)))
+    .groupBy(yachtModels.rigType)
+    .orderBy(sql`count(*) DESC`);
+
+  const keelRows = await db
+    .select({
+      keelType: yachtModels.keelType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(and(eq(manufacturers.name, mfrName), isNotNull(yachtModels.keelType)))
+    .groupBy(yachtModels.keelType)
+    .orderBy(sql`count(*) DESC`);
+
+  const hullRows = await db
+    .select({
+      hullMaterial: yachtModels.hullMaterial,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(and(eq(manufacturers.name, mfrName), isNotNull(yachtModels.hullMaterial)))
+    .groupBy(yachtModels.hullMaterial)
+    .orderBy(sql`count(*) DESC`);
+
+  return {
+    name: mfrName,
+    slug: slugify(mfrName),
+    yachtCount: stats.yachtCount,
+    minLoa: num(stats.minLoa),
+    maxLoa: num(stats.maxLoa),
+    avgLoa: num(stats.avgLoa),
+    avgCabins: num(stats.avgCabins),
+    avgBerths: num(stats.avgBerths),
+    rigTypes: Object.fromEntries(rigRows.map((r: any) => [r.rigType, r.cnt])),
+    keelTypes: Object.fromEntries(keelRows.map((r: any) => [r.keelType, r.cnt])),
+    hullMaterials: Object.fromEntries(hullRows.map((r: any) => [r.hullMaterial, r.cnt])),
+    years: { min: stats.minYear, max: stats.maxYear },
+  };
+}
+
+export async function getAllManufacturerSlugs(): Promise<string[]> {
+  const rows = await db
+    .select({ name: manufacturers.name })
+    .from(manufacturers)
+    .innerJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+    .groupBy(manufacturers.name)
+    .having(sql`count(*) >= 3`)
+    .orderBy(manufacturers.name);
+
+  return rows.map((r: any) => slugify(r.name));
+}
+
+export async function getSizeCategoryStats(cat: SizeCategory): Promise<SizeCategoryStats | null> {
+  const rows = await db
+    .select({
+      yachtCount: count(yachtModels.id),
+      avgCabins: avg(yachtModels.cabins),
+      avgBerths: avg(yachtModels.berths),
+    })
+    .from(yachtModels)
+    .where(
+      and(
+        isNotNull(yachtModels.lengthOverall),
+        sql`length_overall::numeric >= ${cat.loaMin}`,
+        sql`length_overall::numeric < ${cat.loaMax}`,
+      ),
+    );
+
+  if (!rows[0] || rows[0].yachtCount === 0) return null;
+
+  // Top manufacturers in this size
+  const mfrRows = await db
+    .select({
+      name: manufacturers.name,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .innerJoin(manufacturers, eq(yachtModels.manufacturerId, manufacturers.id))
+    .where(
+      and(
+        isNotNull(yachtModels.lengthOverall),
+        sql`length_overall::numeric >= ${cat.loaMin}`,
+        sql`length_overall::numeric < ${cat.loaMax}`,
+      ),
+    )
+    .groupBy(manufacturers.name)
+    .orderBy(sql`count(*) DESC`)
+    .limit(5);
+
+  const rigRows = await db
+    .select({
+      rigType: yachtModels.rigType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .where(
+      and(
+        isNotNull(yachtModels.lengthOverall),
+        sql`length_overall::numeric >= ${cat.loaMin}`,
+        sql`length_overall::numeric < ${cat.loaMax}`,
+        isNotNull(yachtModels.rigType),
+      ),
+    )
+    .groupBy(yachtModels.rigType)
+    .orderBy(sql`count(*) DESC`);
+
+  const keelRows = await db
+    .select({
+      keelType: yachtModels.keelType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .where(
+      and(
+        isNotNull(yachtModels.lengthOverall),
+        sql`length_overall::numeric >= ${cat.loaMin}`,
+        sql`length_overall::numeric < ${cat.loaMax}`,
+        isNotNull(yachtModels.keelType),
+      ),
+    )
+    .groupBy(yachtModels.keelType)
+    .orderBy(sql`count(*) DESC`);
+
+  return {
+    category: cat,
+    yachtCount: rows[0].yachtCount,
+    manufacturers: mfrRows.map((r: any) => ({ name: r.name, count: r.cnt })),
+    avgCabins: num(rows[0].avgCabins),
+    avgBerths: num(rows[0].avgBerths),
+    rigTypes: Object.fromEntries(rigRows.map((r: any) => [r.rigType, r.cnt])),
+    keelTypes: Object.fromEntries(keelRows.map((r: any) => [r.keelType, r.cnt])),
+  };
+}
+
+// --- FAQ Generation Helpers ---
+
+function topKeys(obj: Record<string, number>, maxItems = 3): string[] {
+  return Object.entries(obj)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, maxItems)
+    .map(([k]) => k);
+}
+
+function buildJsonLd(faqs: FaqItem[], pageUrl: string): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+// --- Manufacturer FAQ Generation ---
+
+export function generateManufacturerFaqs(stats: ManufacturerStats): FaqPageData {
+  const faqs: FaqItem[] = [];
+  const topRig = topKeys(stats.rigTypes);
+  const topKeel = topKeys(stats.keelTypes);
+  const topHull = topKeys(stats.hullMaterials);
+
+  // Q1: How many models
+  faqs.push({
+    question: `How many sailing yacht models does ${stats.name} offer?`,
+    answer: `${stats.name} currently has ${stats.yachtCount} sailing yacht models in our database, ranging from ${fmtM(stats.minLoa)} (${fmtFt(stats.minLoa)}) to ${fmtM(stats.maxLoa)} (${fmtFt(stats.maxLoa)}) in length overall.`,
+    questionFr: `Combien de modèles de voiliers ${stats.name} propose-t-il ?`,
+    answerFr: `${stats.name} propose actuellement ${stats.yachtCount} modèles de voiliers dans notre base de données, allant de ${fmtM(stats.minLoa)} (${fmtFt(stats.minLoa)}) à ${fmtM(stats.maxLoa)} (${fmtFt(stats.maxLoa)}) de longueur hors tout.`,
+  });
+
+  // Q2: Size range
+  if (stats.avgLoa) {
+    faqs.push({
+      question: `What is the average length of ${stats.name} sailing yachts?`,
+      answer: `The average length overall of ${stats.name} yachts in our database is approximately ${fmtM(stats.avgLoa)} (${fmtFt(stats.avgLoa)}). The range spans from ${fmtM(stats.minLoa)} to ${fmtM(stats.maxLoa)}.`,
+      questionFr: `Quelle est la longueur moyenne des voiliers ${stats.name} ?`,
+      answerFr: `La longueur hors tout moyenne des voiliers ${stats.name} dans notre base de données est d'environ ${fmtM(stats.avgLoa)} (${fmtFt(stats.avgLoa)}). La gamme s'étend de ${fmtM(stats.minLoa)} à ${fmtM(stats.maxLoa)}.`,
+    });
+  }
+
+  // Q3: Rig types
+  if (topRig.length > 0) {
+    const rigList = topRig.join(", ");
+    const dominant = topRig[0];
+    const dominantPct = Math.round((stats.rigTypes[dominant] / stats.yachtCount) * 100);
+    faqs.push({
+      question: `What rig types do ${stats.name} sailing yachts use?`,
+      answer: `Most ${stats.name} yachts feature a ${dominant} rig configuration (${dominantPct}% of models). Other rig types include ${rigList}.`,
+      questionFr: `Quels types de gréement les voiliers ${stats.name} utilisent-ils ?`,
+      answerFr: `La plupart des voiliers ${stats.name} sont équipés d'un gréement ${dominant} (${dominantPct}% des modèles). D'autres types de gréement incluent ${rigList}.`,
+    });
+  }
+
+  // Q4: Keel types
+  if (topKeel.length > 0) {
+    const keelList = topKeel.join(", ");
+    const dominantKeel = topKeel[0];
+    const keelPct = Math.round((stats.keelTypes[dominantKeel] / stats.yachtCount) * 100);
+    faqs.push({
+      question: `What keel types are available on ${stats.name} yachts?`,
+      answer: `${stats.name} primarily uses ${dominantKeel} configurations (${keelPct}% of models). Available keel types include ${keelList}. The keel type affects stability, draft, and sailing performance.`,
+      questionFr: `Quels types de quilles sont disponibles sur les voiliers ${stats.name} ?`,
+      answerFr: `${stats.name} utilise principalement des configurations ${dominantKeel} (${keelPct}% des modèles). Les types de quilles disponibles incluent ${keelList}. Le type de quille affecte la stabilité, le tirant d'eau et les performances en navigation.`,
+    });
+  }
+
+  // Q5: Accommodation
+  if (stats.avgCabins && stats.avgBerths) {
+    faqs.push({
+      question: `How many cabins and berths do ${stats.name} yachts typically have?`,
+      answer: `${stats.name} yachts average around ${Math.round(stats.avgCabins)} cabins and ${Math.round(stats.avgBerths)} berths. Actual accommodation varies by model — smaller yachts tend to have ${Math.max(1, Math.round(stats.avgCabins) - 1)} cabins while larger models can have ${Math.round(stats.avgCabins) + 1} or more.`,
+      questionFr: `Combien de cabines et de couchettes les voiliers ${stats.name} ont-ils généralement ?`,
+      answerFr: `Les voiliers ${stats.name} ont en moyenne ${Math.round(stats.avgCabins)} cabines et ${Math.round(stats.avgBerths)} couchettes. L'hébergement réel varie selon le modèle — les petits voiliers ont tendance à avoir ${Math.max(1, Math.round(stats.avgCabins) - 1)} cabines tandis que les modèles plus grands peuvent avoir ${Math.round(stats.avgCabins) + 1} ou plus.`,
+    });
+  }
+
+  // Q6: Hull material
+  if (topHull.length > 0) {
+    const dominantHull = topHull[0];
+    const hullPct = Math.round((stats.hullMaterials[dominantHull] / stats.yachtCount) * 100);
+    faqs.push({
+      question: `What hull materials does ${stats.name} use?`,
+      answer: `${stats.name} constructs ${hullPct}% of their yachts with ${dominantHull} hulls. This material choice offers a balance of durability, performance, and maintenance costs suitable for ${stats.yachtCount > 10 ? "a wide range of" : ""} sailing conditions.`,
+      questionFr: `Quels matériaux de coque ${stats.name} utilise-t-il ?`,
+      answerFr: `${stats.name} construit ${hullPct}% de ses voiliers avec des coques en ${dominantHull}. Ce choix de matériau offre un équilibre entre durabilité, performance et coûts d'entretien adapté à ${stats.yachtCount > 10 ? "un large éventail de" : ""} conditions de navigation.`,
+    });
+  }
+
+  // Q7: Year range
+  if (stats.years.min && stats.years.max) {
+    faqs.push({
+      question: `What year range do ${stats.name} yachts in your database cover?`,
+      answer: `Our database includes ${stats.name} yachts from ${stats.years.min} to ${stats.years.max}, spanning ${stats.years.max - stats.years.min} years of production. This includes both classic designs and the latest models.`,
+      questionFr: `Quelle période les voiliers ${stats.name} de votre base de données couvrent-ils ?`,
+      answerFr: `Notre base de données inclut des voiliers ${stats.name} de ${stats.years.min} à ${stats.years.max}, couvrant ${stats.years.max - stats.years.min} années de production. Cela inclut à la fois les designs classiques et les derniers modèles.`,
+    });
+  }
+
+  return {
+    title: `${stats.name} Sailing Yachts — Frequently Asked Questions`,
+    titleFr: `Voiliers ${stats.name} — Questions Fréquentes`,
+    description: `Frequently asked questions about ${stats.name} sailing yachts. Learn about models, sizes, rig types, keel configurations, and accommodation options.`,
+    descriptionFr: `Questions fréquentes sur les voiliers ${stats.name}. Découvrez les modèles, tailles, types de gréement, configurations de quille et options d'hébergement.`,
+    slug: stats.slug,
+    faqs,
+    jsonLd: buildJsonLd(faqs, `https://info.sailboats.fr/faq/${stats.slug}`),
+  };
+}
+
+// --- Size Category FAQ Generation ---
+
+export function generateSizeCategoryFaqs(stats: SizeCategoryStats): FaqPageData {
+  const faqs: FaqItem[] = [];
+  const cat = stats.category;
+  const topRig = topKeys(stats.rigTypes);
+  const topKeel = topKeys(stats.keelTypes);
+
+  // Q1: What is this size category
+  faqs.push({
+    question: `What are the best sailing yachts ${cat.labelEn.toLowerCase()}?`,
+    answer: `There are ${stats.yachtCount} sailing yachts ${cat.labelEn.toLowerCase()} in our database from ${stats.manufacturers.length} manufacturers. Top brands include ${stats.manufacturers.slice(0, 3).map((m: any) => m.name).join(", ")}.`,
+    questionFr: `Quels sont les meilleurs voiliers ${cat.labelFr.toLowerCase()} ?`,
+    answerFr: `Il y a ${stats.yachtCount} voiliers ${cat.labelFr.toLowerCase()} dans notre base de données de ${stats.manufacturers.length} constructeurs. Les meilleures marques incluent ${stats.manufacturers.slice(0, 3).map((m: any) => m.name).join(", ")}.`,
+  });
+
+  // Q2: Manufacturers
+  if (stats.manufacturers.length > 1) {
+    faqs.push({
+      question: `Which manufacturers make sailing yachts ${cat.labelEn.toLowerCase()}?`,
+      answer: `Leading manufacturers in this size range include ${stats.manufacturers.map((m) => `${m.name} (${m.count} models)`).join(", ")}. Each brand offers different design philosophies and target audiences.`,
+      questionFr: `Quels constructeurs fabriquent des voiliers ${cat.labelFr.toLowerCase()} ?`,
+      answerFr: `Les principaux constructeurs dans cette gamme de tailles incluent ${stats.manufacturers.map((m) => `${m.name} (${m.count} modèles)`).join(", ")}. Chaque marque offre différentes philosophies de design et publics cibles.`,
+    });
+  }
+
+  // Q3: Cabins/berths
+  if (stats.avgCabins && stats.avgBerths) {
+    faqs.push({
+      question: `How many cabins can I expect in a ${cat.labelEn.toLowerCase()} sailing yacht?`,
+      answer: `Sailing yachts ${cat.labelEn.toLowerCase()} typically offer around ${Math.round(stats.avgCabins)} cabins and ${Math.round(stats.avgBerths)} berths. This makes them suitable for ${stats.avgBerths >= 6 ? "family cruising with children or groups of friends" : "couples or small families"}.`,
+      questionFr: `Combien de cabines puis-je attendre d'un voilier ${cat.labelFr.toLowerCase()} ?`,
+      answerFr: `Les voiliers ${cat.labelFr.toLowerCase()} offrent généralement environ ${Math.round(stats.avgCabins)} cabines et ${Math.round(stats.avgBerths)} couchettes. Cela les rend adaptés ${stats.avgBerths >= 6 ? "à la croisière familiale avec enfants ou à des groupes d'amis" : "aux couples ou aux petites familles"}.`,
+    });
+  }
+
+  // Q4: Rig types
+  if (topRig.length > 0) {
+    faqs.push({
+      question: `What rig types are common for ${cat.labelEn.toLowerCase()} sailing yachts?`,
+      answer: `The most common rig configuration is ${topRig[0]}, with other options including ${topRig.slice(1).join(", ") || "various custom configurations"}. The sloop rig is popular for its simplicity and performance.`,
+      questionFr: `Quels types de gréement sont courants pour les voiliers ${cat.labelFr.toLowerCase()} ?`,
+      answerFr: `La configuration de gréement la plus courante est ${topRig[0]}, avec d'autres options incluant ${topRig.slice(1).join(", ") || "dives configurations personnalisées"}. Le gréement sloop est populaire pour sa simplicité et ses performances.`,
+    });
+  }
+
+  // Q5: Keel types
+  if (topKeel.length > 0) {
+    faqs.push({
+      question: `What keel options are available for ${cat.labelEn.toLowerCase()} sailing yachts?`,
+      answer: `Common keel configurations include ${topKeel.join(", ")}. The keel type significantly impacts stability, pointing ability, and draft — important factors when choosing a yacht for your sailing grounds.`,
+      questionFr: `Quelles options de quille sont disponibles pour les voiliers ${cat.labelFr.toLowerCase()} ?`,
+      answerFr: `Les configurations de quille courantes incluent ${topKeel.join(", ")}. Le type de quille a un impact significatif sur la stabilité, la capacité de remontée au vent et le tirant d'eau — des facteurs importants lors du choix d'un voilier pour vos zones de navigation.`,
+    });
+  }
+
+  // Q6: Usage
+  const usageHint = cat.loaMin < 9.14
+    ? "ideal for day sailing, coastal cruising, and trailer-sailing"
+    : cat.loaMax <= 12.19
+    ? "perfect for coastal and offshore cruising, offering a great balance of performance and comfort"
+    : "designed for bluewater sailing, long-distance cruising, and living aboard";
+  const usageHintFr = cat.loaMin < 9.14
+    ? "idéaux pour la navigation à la journée, la croisière côtière et le transport sur remorque"
+    : cat.loaMax <= 12.19
+    ? "parfaits pour la croisière côtière et hauturière, offrant un excellent équilibre entre performance et confort"
+    : "conçus pour la navigation hauturière, la croisière au long cours et la vie à bord";
+
+  faqs.push({
+    question: `What is a ${cat.labelEn.toLowerCase()} sailing yacht best suited for?`,
+    answer: `Sailing yachts ${cat.labelEn.toLowerCase()} are ${usageHint}. With ${stats.yachtCount} models available from various manufacturers, you can find options for every sailing style and budget.`,
+    questionFr: `À quoi convient le mieux un voilier ${cat.labelFr.toLowerCase()} ?`,
+    answerFr: `Les voiliers ${cat.labelFr.toLowerCase()} sont ${usageHintFr}. Avec ${stats.yachtCount} modèles disponibles de divers constructeurs, vous pouvez trouver des options pour tous les styles de navigation et tous les budgets.`,
+  });
+
+  return {
+    title: `Sailing Yachts ${cat.labelEn} — Frequently Asked Questions`,
+    titleFr: `Voiliers ${cat.labelFr} — Questions Fréquentes`,
+    description: `Frequently asked questions about sailing yachts ${cat.labelEn.toLowerCase()}. Compare models, manufacturers, and specifications.`,
+    descriptionFr: `Questions fréquentes sur les voiliers ${cat.labelFr.toLowerCase()}. Comparez les modèles, les constructeurs et les spécifications.`,
+    slug: cat.slug,
+    faqs,
+    jsonLd: buildJsonLd(faqs, `https://info.sailboats.fr/faq/size/${cat.slug}`),
+  };
+}
+
+// --- General FAQ Generation ---
+
+export async function generateGeneralFaqs(): Promise<FaqPageData> {
+  const faqs: FaqItem[] = [];
+
+  // Get overall stats
+  const totalYachts = await db.select({ cnt: count() }).from(yachtModels);
+  const totalMfrs = await db.select({ cnt: count() }).from(manufacturers);
+
+  const loaRange = await db
+    .select({
+      minLoa: min(yachtModels.lengthOverall),
+      maxLoa: max(yachtModels.lengthOverall),
+    })
+    .from(yachtModels)
+    .where(isNotNull(yachtModels.lengthOverall));
+
+  const topMfrRows = await db
+    .select({
+      name: manufacturers.name,
+      cnt: count(),
+    })
+    .from(manufacturers)
+    .innerJoin(yachtModels, eq(yachtModels.manufacturerId, manufacturers.id))
+    .groupBy(manufacturers.name)
+    .orderBy(sql`count(*) DESC`)
+    .limit(5);
+
+  const rigRows = await db
+    .select({
+      rigType: yachtModels.rigType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .where(isNotNull(yachtModels.rigType))
+    .groupBy(yachtModels.rigType)
+    .orderBy(sql`count(*) DESC`)
+    .limit(5);
+
+  const keelRows = await db
+    .select({
+      keelType: yachtModels.keelType,
+      cnt: count(),
+    })
+    .from(yachtModels)
+    .where(isNotNull(yachtModels.keelType))
+    .groupBy(yachtModels.keelType)
+    .orderBy(sql`count(*) DESC`)
+    .limit(5);
+
+  const total = totalYachts[0]?.cnt ?? 0;
+  const totalMfr = totalMfrs[0]?.cnt ?? 0;
+  const minLoa = num(loaRange[0]?.minLoa);
+  const maxLoa = num(loaRange[0]?.maxLoa);
+  const topMfrs = topMfrRows.map((m: any) => m.name);
+  const topRigs = rigRows.map((r: any) => r.rigType);
+  const topKeels = keelRows.map((k: any) => k.keelType);
+
+  // Q1: Overview
+  faqs.push({
+    question: "How many sailing yachts are in this database?",
+    answer: `Our database contains ${total} sailing yacht models from ${totalMfr} manufacturers, ranging from ${fmtM(minLoa)} to ${fmtM(maxLoa)} in length overall. We cover everything from compact day sailors to luxury bluewater cruisers.`,
+    questionFr: "Combien de voiliers contient cette base de données ?",
+    answerFr: `Notre base de données contient ${total} modèles de voiliers de ${totalMfr} constructeurs, allant de ${fmtM(minLoa)} à ${fmtM(maxLoa)} de longueur hors tout. Nous couvrons tout, des petits voiliers de journée aux croiseurs hauturiers de luxe.`,
+  });
+
+  // Q2: Top manufacturers
+  faqs.push({
+    question: "Which are the most popular sailing yacht manufacturers?",
+    answer: `The top manufacturers in our database include ${topMfrs.join(", ")}. These brands offer a wide range of models from entry-level to premium bluewater cruisers, with extensive dealer networks worldwide.`,
+    questionFr: "Quels sont les constructeurs de voiliers les plus populaires ?",
+    answerFr: `Les principaux constructeurs de notre base de données incluent ${topMfrs.join(", ")}. Ces marques offrent une large gamme de modèles, de l'entrée de gamme aux croiseurs hauturiers premium, avec des réseaux de concessionnaires étendus dans le monde entier.`,
+  });
+
+  // Q3: Choosing size
+  faqs.push({
+    question: "What size sailing yacht should I choose?",
+    answer: `The right size depends on your experience and plans. Sailboats under 30ft are great for beginners and day sailing. The 30-40ft range is the sweet spot for family cruising. Yachts over 45ft are suitable for bluewater passages and liveaboard lifestyles. Our database spans from ${fmtM(minLoa)} to ${fmtM(maxLoa)}.`,
+    questionFr: "Quelle taille de voilier dois-je choisir ?",
+    answerFr: `La bonne taille dépend de votre expérience et de vos projets. Les voiliers de moins de 30 pieds sont idéaux pour les débutants et la navigation à la journée. La gamme 30-40 pieds est idéale pour la croisière familiale. Les voiliers de plus de 45 pieds conviennent aux passages hauturiers et à la vie à bord. Notre base de données s'étend de ${fmtM(minLoa)} à ${fmtM(maxLoa)}.`,
+  });
+
+  // Q4: Rig types
+  faqs.push({
+    question: "What are the most common rig types for sailing yachts?",
+    answer: `The most common rig types are ${topRigs.join(", ")}. The sloop rig is by far the most popular due to its simplicity, efficiency, and ease of handling. Cutters and ketches offer more sail plan flexibility for offshore sailing.`,
+    questionFr: "Quels sont les types de gréement les plus courants pour les voiliers ?",
+    answerFr: `Les types de gréement les plus courants sont ${topRigs.join(", ")}. Le gréement sloop est de loin le plus populaire en raison de sa simplicité, de son efficacité et de sa facilité de manœuvre. Les cotres et les ketchs offrent plus de flexibilité de plan de voilure pour la navigation hauturière.`,
+  });
+
+  // Q5: Keel types
+  faqs.push({
+    question: "What keel types are available for sailing yachts?",
+    answer: `Common keel configurations include ${topKeels.join(", ")}. Fin keels offer the best performance and pointing ability. Lifting keels and daggerboards allow access to shallow waters. Full keels provide excellent directional stability for long passages.`,
+    questionFr: "Quels types de quilles sont disponibles pour les voiliers ?",
+    answerFr: `Les configurations de quille courantes incluent ${topKeels.join(", ")}. Les quilles à aileron offrent les meilleures performances et la meilleure capacité de remontée au vent. Les quilles relevables et les dérives permettent l'accès aux eaux peu profondes. Les quilles longues offrent une excellente stabilité de route pour les longues traversées.`,
+  });
+
+  // Q6: Hull materials
+  faqs.push({
+    question: "What hull materials are most common for sailing yachts?",
+    answer: "Fiberglass (GRP) is the dominant hull material, used in over 90% of production sailing yachts. It offers an excellent balance of strength, weight, cost, and low maintenance. Other materials include aluminium (for expedition yachts), carbon/epoxy (for high-performance), and wood/epoxy (for classic designs).",
+    questionFr: "Quels matériaux de coque sont les plus courants pour les voiliers ?",
+    answerFr: "La fibre de verre (GRP) est le matériau de coque dominant, utilisé dans plus de 90% des voiliers de série. Elle offre un excellent équilibre entre résistance, poids, coût et faible entretien. D'autres matériaux incluent l'aluminium (pour les yachts d'expédition), le carbone/époxy (pour la haute performance) et le bois/époxy (pour les designs classiques).",
+  });
+
+  // Q7: New vs used
+  faqs.push({
+    question: "Should I buy a new or used sailing yacht?",
+    answer: "Both options have merit. New yachts offer the latest designs, technology, and warranty coverage — but at a premium price. Used yachts provide excellent value, especially 5-15 year old models that have depreciated but still offer modern design and equipment. Consider hiring a surveyor for any used purchase.",
+    questionFr: "Dois-je acheter un voilier neuf ou d'occasion ?",
+    answerFr: "Les deux options ont leurs mérites. Les voiliers neufs offrent les derniers designs, technologies et garanties — mais à un prix premium. Les voiliers d'occasion offrent un excellent rapport qualité-prix, en particulier les modèles de 5 à 15 ans qui se sont dépréciés mais offrent encore un design et un équipement modernes. Envisagez de faire appel à un expert pour tout achat d'occasion.",
+  });
+
+  return {
+    title: "Sailing Yachts — Frequently Asked Questions",
+    titleFr: "Voiliers — Questions Fréquentes",
+    description: "Frequently asked questions about sailing yachts. Learn about manufacturers, sizes, rig types, keel configurations, and how to choose the right yacht.",
+    descriptionFr: "Questions fréquentes sur les voiliers. Découvrez les constructeurs, tailles, types de gréement, configurations de quille et comment choisir le bon voilier.",
+    slug: "general",
+    faqs,
+    jsonLd: buildJsonLd(faqs, "https://info.sailboats.fr/faq"),
+  };
+}

--- a/memory/SAILING-YACHTS.md
+++ b/memory/SAILING-YACHTS.md
@@ -1,40 +1,49 @@
-# Sailing Yachts — Session Log
+# Sailing Yachts — Session Notes
 
-## Session: 2026-06-09 00:20 UTC
+## Session: 2026-06-10 22:20 CEST
 
-### Issue: #401 — P25.1: Sailing Guides CMS Enhancements
+### Issues Worked On
+- **#407** (P25.3 Quiz) — Closed as duplicate. Quiz was already fully implemented.
+- **#408** (P25.4 Multilingual Content Pipeline) — ✅ COMPLETED
 
-### What Was Implemented
-- **article_yachts join table**: DB migration creating join table with article_id, yacht_model_id, sort_order, cascading deletes, unique constraint
-- **SEO fields on articles**: Added meta_title, meta_description, og_image, canonical_url, noindex columns to articles table
-- **Yacht search API**: GET /api/admin/guides/yacht-search — search yachts by name/manufacturer for autocomplete
-- **Image upload API**: POST /api/admin/guides/upload-image — file upload with type/size validation, saves to /public/uploads/guides/
-- **Enhanced guide form**: Added related yacht selector with autocomplete, image upload widget (file + URL), SEO settings section with character count guidance, Google preview
-- **Public guide page**: Shows related yachts section with yacht cards, uses SEO fields in generateMetadata
-- **Updated admin APIs**: POST/PUT /api/admin/guides now handle SEO fields and relatedYachtIds
-- **Updated articles service**: Added RelatedYacht interface, getArticleRelatedYachts function, SEO fields in all queries
-- **Schema**: Added articleYachts drizzle table, SEO columns on articles
+### P25.3 — Interactive Sailing Quiz
+- Pre-existing implementation found (7-step quiz, API, shareable results, email capture, i18n, tests)
+- Already live at /quiz and /fr/quiz
+- Closed #407, updated roadmap
+
+### P25.4 — Multilingual Content Pipeline
+- Created `content_translations` and `translation_memory` DB tables
+- Built `lib/translation-service.ts` with:
+  - Template-based French translation using 80+ nautical vocabulary entries
+  - Translation memory with SHA-256 hash lookup
+  - Auto-generation for yacht descriptions, manufacturer descriptions, articles
+  - Queue management, approve/reject, bulk approve
+  - Coverage stats tracking
+- Admin dashboard at `/admin/translations` with stats, queue, coverage bars
+- API endpoints: `/api/admin/translations` (GET/POST/PATCH) + `/api/translations` (GET)
+- Applied migration via Neon HTTP client (not drizzle-kit push)
+- PR #409 merged via squash
 
 ### Build/Test Results
 - TypeScript: ✅ Pass
-- Build: ✅ Pass (1521 static pages)
-- Tests: ✅ 15/15 pass
-- CI (Lint + TypeScript + Build + Perf Budgets): ✅ All pass
+- Build: ✅ Pass (1528 static pages)
+- Tests: ✅ 24/24 pass
+- Neon timeout errors during SSG are pre-existing (not related to changes)
 
-### Deploy
-- PR #402 (feature/issue-401-guides-cms-enhancements) → merged (squash)
-- Vercel auto-deploy from main
-
-### Live Verification (all PASS)
-- `/` ✅ | `/yachts` ✅ | `/search` ✅ | `/compare` ✅
-- `/guides` ✅ | `/en/guides/how-to-choose-your-first-sailboat` ✅
-- API: `/api/yachts` ✅ — 243 yachts
+### Deploy & Live Verification
+- Vercel deploy: ✅ Ready (10 min build)
+- Core pages: ✅ /, /yachts, /search, /compare — all 200
+- API: ✅ 243 yachts
+- /admin/translations: ✅ 200
+- /api/admin/translations?action=stats: ✅ Returns stats
+- /api/translations: ✅ Returns proper responses
 
 ### Next Recommended Task
-- **P25.2** — Yacht review aggregation (aggregate reviews from external sources)
-- Or **P25.3** — Interactive sailing quiz ("Which yacht is right for you?")
+- **P25.5** — Content freshness signals (last-updated dates, freshness badges)
+- Check FUTURE_ROADMAP.md for remaining Phase 25 items
 
-### Lessons
-- The guides CMS already existed with basic functionality — P25.1 was about enhancing it with missing features
-- Neon DB `channel_binding=require` causes issues with pg client — use `sslmode=require` without channel_binding for migrations
-- Build "errors" for static pages (Neon connectivity during prerender) are pre-existing and not blocking
+### Technical Notes
+- Migration was applied via `node -e` script using Neon HTTP client (not drizzle-kit)
+- Admin pages live under `app/admin/` (top-level, NOT under `app/[locale]/`)
+- Vercel auto-deploys from main but sometimes needs manual trigger (`vercel --prod --yes`)
+- Build takes ~10 minutes on Vercel

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,8 @@
       "glossary": "Glossary",
       "search": "Search",
       "compare": "Compare",
-      "favorites": "Favorites"
+      "favorites": "Favorites",
+      "faq": "FAQ"
     },
     "mobileNav": {
       "browseYachts": "Browse Yachts",
@@ -1484,5 +1485,22 @@
       "send": "Send",
       "retake": "Take the quiz again"
     }
+  },
+  "Faq": {
+    "meta": {
+      "title": "Sailing Yachts — Frequently Asked Questions",
+      "description": "Frequently asked questions about sailing yachts. Learn about manufacturers, sizes, rig types, and more."
+    },
+    "hero": {
+      "title": "Frequently Asked Questions",
+      "subtitle": "Find answers to common questions about sailing yachts, manufacturers, and specifications."
+    },
+    "browseManufacturer": "FAQ by Manufacturer",
+    "browseSize": "FAQ by Size",
+    "allFaqs": "All FAQs",
+    "models": "models",
+    "yachts": "yachts",
+    "viewAllYachts": "Browse all {manufacturer} yachts",
+    "popularInSize": "Popular manufacturers in this size"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -10,7 +10,8 @@
       "glossary": "Glossaire",
       "search": "Recherche",
       "compare": "Comparer",
-      "favorites": "Favoris"
+      "favorites": "Favoris",
+      "faq": "FAQ"
     },
     "mobileNav": {
       "browseYachts": "Parcourir les yachts",
@@ -1484,5 +1485,22 @@
       "send": "Envoyer",
       "retake": "Refaire le quiz"
     }
+  },
+  "Faq": {
+    "meta": {
+      "title": "Questions Fréquentes sur les Voiliers",
+      "description": "Questions fréquentes sur les voiliers. Découvrez les constructeurs, tailles, types de gréement et plus encore."
+    },
+    "hero": {
+      "title": "Questions Fréquentes",
+      "subtitle": "Trouvez des réponses aux questions courantes sur les voiliers, les constructeurs et les spécifications."
+    },
+    "browseManufacturer": "FAQ par constructeur",
+    "browseSize": "FAQ par taille",
+    "allFaqs": "Toutes les FAQ",
+    "models": "modèles",
+    "yachts": "voiliers",
+    "viewAllYachts": "Voir tous les voiliers {manufacturer}",
+    "popularInSize": "Constructeurs populaires dans cette taille"
   }
 }

--- a/tests/faq-generation.test.ts
+++ b/tests/faq-generation.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the database module
+vi.mock("@/lib/db-edge", () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    having: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockImplementation(function (this: any) {
+      return Promise.resolve([]);
+    }),
+  },
+  manufacturers: {
+    id: "id",
+    name: "name",
+    country: "country",
+    foundedYear: "founded_year",
+    description: "description",
+    descriptionFr: "description_fr",
+    logoUrl: "logo_url",
+    websiteUrl: "website_url",
+  },
+  yachtModels: {
+    id: "id",
+    manufacturerId: "manufacturer_id",
+    modelName: "model_name",
+    year: "year",
+    slug: "slug",
+    lengthOverall: "length_overall",
+    beam: "beam",
+    draft: "draft",
+    displacement: "displacement",
+    rigType: "rig_type",
+    keelType: "keel_type",
+    hullMaterial: "hull_material",
+    cabins: "cabins",
+    berths: "berths",
+  },
+}));
+
+// Mock drizzle-orm operators
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((_, val) => val),
+  count: vi.fn(() => "count"),
+  avg: vi.fn(() => "avg"),
+  min: vi.fn(() => "min"),
+  max: vi.fn(() => "max"),
+  isNotNull: vi.fn((col) => col),
+  and: vi.fn((...args) => args),
+  sql: vi.fn((strings, ...values) => strings.join("?")),
+}));
+
+import {
+  generateManufacturerFaqs,
+  generateSizeCategoryFaqs,
+  type ManufacturerStats,
+  type SizeCategoryStats,
+} from "@/lib/faq-generation";
+import { SIZE_CATEGORIES } from "@/lib/size-categories";
+
+describe("FAQ Generation", () => {
+  describe("generateManufacturerFaqs", () => {
+    it("generates FAQs from manufacturer stats", () => {
+      const stats: ManufacturerStats = {
+        name: "Beneteau",
+        slug: "beneteau",
+        yachtCount: 17,
+        minLoa: 7.5,
+        maxLoa: 16.0,
+        avgLoa: 11.2,
+        avgCabins: 3,
+        avgBerths: 6,
+        rigTypes: { Sloop: 15, Cutter: 2 },
+        keelTypes: { "Fin keel with bulb": 10, "Fin keel": 7 },
+        hullMaterials: { Fiberglass: 17 },
+        years: { min: 2005, max: 2024 },
+      };
+
+      const result = generateManufacturerFaqs(stats);
+
+      expect(result.title).toContain("Beneteau");
+      expect(result.titleFr).toContain("Beneteau");
+      expect(result.faqs.length).toBeGreaterThanOrEqual(5);
+      expect(result.jsonLd).toBeDefined();
+      expect((result.jsonLd as any)["@type"]).toBe("FAQPage");
+      expect((result.jsonLd as any).mainEntity.length).toBe(result.faqs.length);
+    });
+
+    it("includes bilingual Q&A", () => {
+      const stats: ManufacturerStats = {
+        name: "Jeanneau",
+        slug: "jeanneau",
+        yachtCount: 15,
+        minLoa: 8.0,
+        maxLoa: 15.0,
+        avgLoa: 10.5,
+        avgCabins: 3,
+        avgBerths: 6,
+        rigTypes: { Sloop: 15 },
+        keelTypes: { "Fin keel": 15 },
+        hullMaterials: { Fiberglass: 15 },
+        years: { min: 2000, max: 2024 },
+      };
+
+      const result = generateManufacturerFaqs(stats);
+
+      for (const faq of result.faqs) {
+        expect(faq.question).toBeTruthy();
+        expect(faq.answer).toBeTruthy();
+        expect(faq.questionFr).toBeTruthy();
+        expect(faq.answerFr).toBeTruthy();
+      }
+    });
+
+    it("handles manufacturer with minimal data", () => {
+      const stats: ManufacturerStats = {
+        name: "Test Yachts",
+        slug: "test-yachts",
+        yachtCount: 3,
+        minLoa: null,
+        maxLoa: null,
+        avgLoa: null,
+        avgCabins: null,
+        avgBerths: null,
+        rigTypes: {},
+        keelTypes: {},
+        hullMaterials: {},
+        years: { min: null, max: null },
+      };
+
+      const result = generateManufacturerFaqs(stats);
+
+      // Should still generate basic FAQs
+      expect(result.faqs.length).toBeGreaterThanOrEqual(1);
+      expect(result.faqs[0].question).toContain("Test Yachts");
+    });
+
+    it("generates valid JSON-LD schema", () => {
+      const stats: ManufacturerStats = {
+        name: "Bavaria Yachts",
+        slug: "bavaria-yachts",
+        yachtCount: 13,
+        minLoa: 9.0,
+        maxLoa: 14.0,
+        avgLoa: 11.0,
+        avgCabins: 3,
+        avgBerths: 6,
+        rigTypes: { Sloop: 13 },
+        keelTypes: { "L-shaped keel (with bulb)": 13 },
+        hullMaterials: { Fiberglass: 13 },
+        years: { min: 2010, max: 2024 },
+      };
+
+      const result = generateManufacturerFaqs(stats);
+      const jsonLd = result.jsonLd as any;
+
+      expect(jsonLd["@context"]).toBe("https://schema.org");
+      expect(jsonLd["@type"]).toBe("FAQPage");
+      expect(Array.isArray(jsonLd.mainEntity)).toBe(true);
+      for (const entity of jsonLd.mainEntity) {
+        expect(entity["@type"]).toBe("Question");
+        expect(entity.name).toBeTruthy();
+        expect(entity.acceptedAnswer["@type"]).toBe("Answer");
+        expect(entity.acceptedAnswer.text).toBeTruthy();
+      }
+    });
+  });
+
+  describe("generateSizeCategoryFaqs", () => {
+    it("generates FAQs from size category stats", () => {
+      const cat = SIZE_CATEGORIES.find((c) => c.slug === "35-40ft")!;
+      const stats: SizeCategoryStats = {
+        category: cat,
+        yachtCount: 50,
+        manufacturers: [
+          { name: "Beneteau", count: 10 },
+          { name: "Jeanneau", count: 8 },
+          { name: "Bavaria Yachts", count: 6 },
+        ],
+        avgCabins: 3,
+        avgBerths: 6,
+        rigTypes: { Sloop: 45, Cutter: 5 },
+        keelTypes: { "Fin keel with bulb": 30, "Fin keel": 20 },
+      };
+
+      const result = generateSizeCategoryFaqs(stats);
+
+      expect(result.title).toContain("35–40ft");
+      expect(result.titleFr).toContain("35–40");
+      expect(result.faqs.length).toBeGreaterThanOrEqual(5);
+      expect(result.jsonLd).toBeDefined();
+    });
+
+    it("generates usage-appropriate advice based on size", () => {
+      const smallCat = SIZE_CATEGORIES.find((c) => c.slug === "under-30ft")!;
+      const smallStats: SizeCategoryStats = {
+        category: smallCat,
+        yachtCount: 20,
+        manufacturers: [{ name: "Test", count: 5 }],
+        avgCabins: 1,
+        avgBerths: 3,
+        rigTypes: { Sloop: 20 },
+        keelTypes: { "Fin keel": 20 },
+      };
+
+      const smallResult = generateSizeCategoryFaqs(smallStats);
+      const usageFaq = smallResult.faqs.find((f) =>
+        f.question.toLowerCase().includes("best suited")
+      );
+      expect(usageFaq).toBeDefined();
+      expect(usageFaq!.answer.toLowerCase()).toContain("day sailing");
+    });
+  });
+});


### PR DESCRIPTION
- FAQ generation service (lib/faq-generation.ts) that auto-generates
  Q&A pairs from yacht data patterns (manufacturer stats, size categories)
- General FAQ page at /[locale]/faq with overall sailing yacht questions
- Manufacturer-specific FAQ pages at /[locale]/faq/[manufacturer]
- Size category FAQ pages at /[locale]/faq/size/[category]
- Bilingual support (EN + FR) for all FAQ content
- JSON-LD FAQPage schema markup for search engine rich results
- FAQ sitemap (sitemap-faq.xml) added to sitemap index
- FAQ link added to main navigation
- 6 unit tests for FAQ generation logic
- Build passes, all existing tests pass
