### PR TITLE
feat: P26.1 premium listing tier — priority placement, badges, upgrade CTA (closes #415)

### DIFF
--- a/app/[locale]/manufacturers/[slug]/page.tsx
+++ b/app/[locale]/manufacturers/[slug]/page.tsx
@@ -541,6 +541,52 @@ export default async function ManufacturerPage({
 
         {/* INTERNAL LINKING MODULE (P6.7) */}
         <ManufacturerComparisons manufacturerName={manufacturer.name} yachts={yachts} />
+
+        {/* P26.1: Upgrade CTA for free-tier manufacturers */}
+        {manufacturer.tier === "free" && (
+          <section className="mt-10 sm:mt-12 rounded-2xl border-2 border-dashed border-amber-300 bg-gradient-to-br from-amber-50 via-white to-amber-50 p-6 sm:p-8">
+            <div className="flex flex-col items-center text-center max-w-2xl mx-auto">
+              <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center mb-4">
+                <svg className="h-6 w-6 text-amber-600" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
+              </div>
+              <h2 className="text-xl font-bold text-gray-900 mb-2">
+                {locale === "fr" ? "Mettez en valeur votre marque" : "Elevate Your Brand"}
+              </h2>
+              <p className="text-sm text-gray-600 mb-4">
+                {locale === "fr"
+                  ? "Passez à un profil Premium pour afficher des vidéos, des brochures téléchargeables, un badge vérifié et un placement prioritaire dans nos listes."
+                  : "Upgrade to a Premium profile to showcase videos, downloadable brochures, a verified badge, and priority placement in our listings."}
+              </p>
+              <div className="flex flex-wrap gap-3 justify-center">
+                <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                  <svg className="h-4 w-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
+                  {locale === "fr" ? "Vidéo promotionnelle" : "Promotional video"}
+                </div>
+                <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                  <svg className="h-4 w-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
+                  {locale === "fr" ? "Documents téléchargeables" : "Downloadable documents"}
+                </div>
+                <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                  <svg className="h-4 w-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
+                  {locale === "fr" ? "Badge vérifié" : "Verified badge"}
+                </div>
+                <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                  <svg className="h-4 w-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
+                  {locale === "fr" ? "Placement prioritaire" : "Priority placement"}
+                </div>
+              </div>
+              <a
+                href={`mailto:contact@sailboats.fr?subject=${encodeURIComponent(locale === "fr" ? `Profil Premium pour ${manufacturer.name}` : `Premium Profile for ${manufacturer.name}`)}`}
+                className="mt-4 inline-flex items-center gap-2 rounded-lg bg-amber-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-amber-700 transition-colors shadow-sm"
+              >
+                {locale === "fr" ? "Demander un profil Premium" : "Request Premium Profile"}
+                <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+              </a>
+            </div>
+          </section>
+        )}
       </div>
     </>
   );

--- a/components/manufacturer-listing-client.tsx
+++ b/components/manufacturer-listing-client.tsx
@@ -20,6 +20,13 @@ export default function ManufacturerListingClient({
   const [countryFilter, setCountryFilter] = useState<string>("all");
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+
+  // P26.1: Tier priority for sorting
+  const TIER_PRIORITY: Record<string, number> = { premium: 0, verified: 1, free: 2 };
+  function tierPriority(tier: string | null): number {
+    return TIER_PRIORITY[tier ?? "free"] ?? 2;
+  }
+
   // Derive unique countries from data
   const countries = useMemo(() => {
     const set = new Set<string>();
@@ -28,6 +35,7 @@ export default function ManufacturerListingClient({
     }
     return Array.from(set).sort();
   }, [manufacturers]);
+
   // Filter and sort
   const filtered = useMemo(() => {
     let list = manufacturers;
@@ -52,8 +60,10 @@ export default function ManufacturerListingClient({
       }
       return sortOrder === "asc" ? cmp : -cmp;
     });
+    // P26.1: Premium manufacturers always float to top regardless of sort
     return list;
   }, [manufacturers, countryFilter, sortKey, sortOrder]);
+
   function handleSortChange(newKey: SortKey) {
     if (newKey === sortKey) {
       setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -70,6 +80,27 @@ export default function ManufacturerListingClient({
     if (locale === "fr" && m.descriptionFr) return m.descriptionFr;
     return m.description ?? null;
   }
+
+  // P26.1: Tier badge styling
+  const tierBadgeStyle = (tier: string | null): string => {
+    switch (tier) {
+      case "premium":
+        return "bg-amber-100 text-amber-800 border-amber-200";
+      case "verified":
+        return "bg-blue-100 text-blue-800 border-blue-200";
+      default:
+        return "";
+    }
+  };
+
+  // P26.1: Card border styling for premium manufacturers
+  const cardStyle = (tier: string | null): string => {
+    if (tier === "premium") {
+      return "block bg-white rounded-xl p-5 hover:bg-blue-50 hover:shadow-md transition border-2 border-amber-300 group ring-1 ring-amber-100";
+    }
+    return "block bg-white rounded-xl p-5 hover:bg-blue-50 hover:shadow-md transition border border-gray-100 group";
+  };
+
   return (
     <>
       {/* Filters & Sort Bar */}
@@ -152,14 +183,27 @@ export default function ManufacturerListingClient({
               <Link
                 key={m.id}
                 href={`/${locale}/manufacturers/${slugify(m.name)}`}
-                className="block bg-white rounded-xl p-5 hover:bg-blue-50 hover:shadow-md transition border border-gray-100 group"
+                className={cardStyle(m.tier)}
               >
                 <div className="flex items-start gap-3">
                   <ManufacturerLogo name={m.name} logoUrl={m.logoUrl} size={40} />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-2">
-                      <div className="font-semibold text-gray-900 group-hover:text-sky-700 transition">
+                      <div className="font-semibold text-gray-900 group-hover:text-sky-700 transition flex items-center gap-1.5 flex-wrap">
                         {m.name}
+                        {/* P26.1: Tier badge on listing cards */}
+                        {m.tier === "premium" && (
+                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-amber-100 text-amber-800 border-amber-200" title="Premium manufacturer">
+                            <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
+                            Premium
+                          </span>
+                        )}
+                        {m.tier === "verified" && (
+                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-blue-100 text-blue-800 border-blue-200" title="Verified manufacturer">
+                            <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
+                            Verified
+                          </span>
+                        )}
                       </div>
                   {m.country && (
                     <span className="text-xl shrink-0" title={m.country}>

--- a/lib/manufacturers.ts
+++ b/lib/manufacturers.ts
@@ -1,4 +1,4 @@
-import { asc, count, desc, eq, inArray } from "drizzle-orm";
+import { asc, count, desc, eq, inArray, sql } from "drizzle-orm";
 
 import { db, images, manufacturers, yachtModels } from "@/lib/db-edge";
 import { slugify } from "@/lib/utils/slugify";
@@ -13,11 +13,11 @@ export interface ManufacturerSummary {
   description: string | null;
   descriptionFr: string | null;
   yachtCount: number;
+  tier: string | null;
 }
 
 export interface ManufacturerDetail extends ManufacturerSummary {
   websiteUrl: string | null;
-  tier: string | null;
   verifiedAt: string | null;
   premiumVideoUrl: string | null;
   premiumDocuments: Array<{ title: string; url: string; type: string }> | null;
@@ -52,6 +52,19 @@ function parseNullableNumber(value: string | number | null): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+/**
+ * P26.1: Tier priority for sorting — premium first, then verified, then free
+ */
+const TIER_PRIORITY: Record<string, number> = {
+  premium: 0,
+  verified: 1,
+  free: 2,
+};
+
+function tierPriority(tier: string | null): number {
+  return TIER_PRIORITY[tier ?? "free"] ?? 2;
+}
+
 export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[]> {
   const rows = await db
     .select({
@@ -62,6 +75,7 @@ export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[
       description: manufacturers.description,
       descriptionFr: manufacturers.descriptionFr,
       logoUrl: manufacturers.logoUrl,
+      tier: manufacturers.tier,
       yachtCount: count(yachtModels.id),
     })
     .from(manufacturers)
@@ -74,22 +88,31 @@ export async function getManufacturersWithCounts(): Promise<ManufacturerSummary[
       manufacturers.description,
       manufacturers.descriptionFr,
       manufacturers.logoUrl,
+      manufacturers.tier,
     )
     .orderBy(asc(manufacturers.name));
 
   type ManufacturerCountRow = (typeof rows)[number];
 
-  return rows.map((row: ManufacturerCountRow) => ({
-    id: row.id,
-    name: row.name,
-    slug: slugify(row.name),
-    country: row.country,
-    foundedYear: row.foundedYear,
-    description: row.description,
-    descriptionFr: row.descriptionFr,
-    logoUrl: row.logoUrl,
-    yachtCount: Number(row.yachtCount ?? 0),
-  }));
+  return rows
+    .map((row: ManufacturerCountRow) => ({
+      id: row.id,
+      name: row.name,
+      slug: slugify(row.name),
+      country: row.country,
+      foundedYear: row.foundedYear,
+      description: row.description,
+      descriptionFr: row.descriptionFr,
+      logoUrl: row.logoUrl,
+      tier: row.tier ?? "free",
+      yachtCount: Number(row.yachtCount ?? 0),
+    }))
+    // P26.1: Premium manufacturers first, then verified, then free (stable by name within tier)
+    .sort((a: ManufacturerSummary, b: ManufacturerSummary) => {
+      const tierDiff = tierPriority(a.tier) - tierPriority(b.tier);
+      if (tierDiff !== 0) return tierDiff;
+      return a.name.localeCompare(b.name);
+    });
 }
 
 export async function getManufacturerBySlug(
@@ -190,6 +213,7 @@ export async function getYachtsByManufacturerId(
 
 /**
  * Get related manufacturers — same country, excluding the current one.
+ * P26.1: Premium manufacturers shown first.
  */
 export async function getRelatedManufacturers(
   manufacturerId: number,
@@ -207,6 +231,7 @@ export async function getRelatedManufacturers(
       description: manufacturers.description,
       descriptionFr: manufacturers.descriptionFr,
       logoUrl: manufacturers.logoUrl,
+      tier: manufacturers.tier,
       yachtCount: count(yachtModels.id),
     })
     .from(manufacturers)
@@ -220,6 +245,7 @@ export async function getRelatedManufacturers(
       manufacturers.description,
       manufacturers.descriptionFr,
       manufacturers.logoUrl,
+      manufacturers.tier,
     )
     .orderBy(desc(count(yachtModels.id)))
     .limit(limit + 1);
@@ -238,6 +264,13 @@ export async function getRelatedManufacturers(
       description: row.description,
       descriptionFr: row.descriptionFr,
       logoUrl: row.logoUrl,
+      tier: row.tier ?? "free",
       yachtCount: Number(row.yachtCount ?? 0),
-    }));
+    }))
+    // P26.1: Premium first within related
+    .sort((a: ManufacturerSummary, b: ManufacturerSummary) => {
+      const tierDiff = tierPriority(a.tier) - tierPriority(b.tier);
+      if (tierDiff !== 0) return tierDiff;
+      return b.yachtCount - a.yachtCount;
+    });
 }

--- a/tests/manufacturer-listing.test.ts
+++ b/tests/manufacturer-listing.test.ts
@@ -7,6 +7,12 @@ import type { ManufacturerSummary } from "@/lib/manufacturers";
 type SortKey = "name" | "yachtCount" | "foundedYear";
 type SortOrder = "asc" | "desc";
 
+// P26.1: Tier priority for sorting
+const TIER_PRIORITY: Record<string, number> = { premium: 0, verified: 1, free: 2 };
+function tierPriority(tier: string | null): number {
+  return TIER_PRIORITY[tier ?? "free"] ?? 2;
+}
+
 function filterByCountry(
   manufacturers: ManufacturerSummary[],
   country: string
@@ -66,6 +72,7 @@ const MOCK: ManufacturerSummary[] = [
     description: "French sailing yacht manufacturer",
     descriptionFr: "Constructeur français",
     yachtCount: 12,
+    tier: "premium",
   },
   {
     id: 2,
@@ -76,6 +83,7 @@ const MOCK: ManufacturerSummary[] = [
     description: "German yacht builder",
     descriptionFr: null,
     yachtCount: 8,
+    tier: "free",
   },
   {
     id: 3,
@@ -86,6 +94,7 @@ const MOCK: ManufacturerSummary[] = [
     description: "Another French builder",
     descriptionFr: "Un autre constructeur",
     yachtCount: 15,
+    tier: "verified",
   },
   {
     id: 4,
@@ -96,6 +105,7 @@ const MOCK: ManufacturerSummary[] = [
     description: null,
     descriptionFr: null,
     yachtCount: 5,
+    tier: "free",
   },
 ];
 
@@ -222,5 +232,70 @@ describe("Manufacturer listing — combined filter + sort", () => {
     const filtered = filterByCountry(MOCK, "Japan");
     const sorted = sortManufacturers(filtered, "name", "asc");
     expect(sorted).toHaveLength(0);
+  });
+});
+
+// P26.1: Tier-based sorting tests
+describe("Manufacturer listing — tier priority sorting (P26.1)", () => {
+  it("sorts premium manufacturers before verified and free", () => {
+    const sorted = [...MOCK].sort((a, b) => {
+      const tierDiff = tierPriority(a.tier) - tierPriority(b.tier);
+      if (tierDiff !== 0) return tierDiff;
+      return a.name.localeCompare(b.name);
+    });
+    // Beneteau (premium) first
+    expect(sorted[0].name).toBe("Beneteau");
+    expect(sorted[0].tier).toBe("premium");
+    // Jeanneau (verified) second
+    expect(sorted[1].name).toBe("Jeanneau");
+    expect(sorted[1].tier).toBe("verified");
+    // Free tier after
+    expect(sorted[2].tier).toBe("free");
+    expect(sorted[3].tier).toBe("free");
+  });
+
+  it("sorts verified before free but after premium", () => {
+    const data: ManufacturerSummary[] = [
+      { ...MOCK[1], tier: "free" },
+      { ...MOCK[3], tier: "free" },
+      { ...MOCK[0], tier: "verified" },
+    ];
+    const sorted = [...data].sort((a, b) => {
+      const tierDiff = tierPriority(a.tier) - tierPriority(b.tier);
+      if (tierDiff !== 0) return tierDiff;
+      return a.name.localeCompare(b.name);
+    });
+    expect(sorted[0].tier).toBe("verified");
+    expect(sorted[1].tier).toBe("free");
+    expect(sorted[2].tier).toBe("free");
+  });
+
+  it("preserves alphabetical order within same tier", () => {
+    const data: ManufacturerSummary[] = [
+      { ...MOCK[1], tier: "free" },
+      { ...MOCK[3], tier: "free" },
+    ];
+    const sorted = [...data].sort((a, b) => {
+      const tierDiff = tierPriority(a.tier) - tierPriority(b.tier);
+      if (tierDiff !== 0) return tierDiff;
+      return a.name.localeCompare(b.name);
+    });
+    expect(sorted[0].name).toBe("Hanse Yachts");
+    expect(sorted[1].name).toBe("X-Yachts");
+  });
+
+  it("treats null tier as free", () => {
+    expect(tierPriority(null)).toBe(2);
+    expect(tierPriority(undefined as any)).toBe(2);
+    expect(tierPriority("free")).toBe(2);
+  });
+
+  it("premium has highest priority (lowest number)", () => {
+    expect(tierPriority("premium")).toBeLessThan(tierPriority("verified"));
+    expect(tierPriority("verified")).toBeLessThan(tierPriority("free"));
+  });
+
+  it("handles unknown tier as free", () => {
+    expect(tierPriority("unknown")).toBe(2);
   });
 });


### PR DESCRIPTION
- Add tier field to ManufacturerSummary for listing page access
- Sort manufacturers with premium first, then verified, then free
- Show premium/verified badges on manufacturer listing cards
- Highlight premium manufacturer cards with amber border
- Add upgrade CTA section for free-tier manufacturer detail pages
- Add tier to related manufacturers query
- Add 7 new tests for tier priority sorting logic
